### PR TITLE
修复：开启 Windows「自动隐藏任务栏」后桌宠随任务栏一起隐藏

### DIFF
--- a/pet/window.py
+++ b/pet/window.py
@@ -671,11 +671,27 @@ class PetWindow(QWidget):
         'Windows.UI.Core.CoreWindow',  # 开始菜单/通知中心全屏层
     }
 
+    @staticmethod
+    def _fullscreen_geometry_hit(l: float, t: float, r: float, b: float,
+                                 geom, is_zoomed: bool) -> bool:
+        """覆盖整屏几何且非最大化 = 真全屏。
+
+        开启 Windows「自动隐藏任务栏」后，最大化窗口也会铺满整屏（任务栏
+        被盖住），与真全屏在几何上无法区分。真全屏窗口（游戏/视频/F11）
+        不会是最大化状态（IsZoomed 为假），最大化窗口则一定是 IsZoomed 为
+        真——据此把"自动隐藏任务栏下的最大化窗口"排除，避免误隐藏桌宠。
+        """
+        if is_zoomed:
+            return False
+        return (l <= geom.left() and t <= geom.top()
+                and r >= geom.right() and b >= geom.bottom())
+
     def _foreground_covers_fullscreen(self) -> bool:
         """前台窗口是否覆盖整个屏幕几何（含任务栏）= 真全屏。仅 Windows。
 
         只判定真全屏（全屏视频/游戏/浏览器 F11，窗口覆盖含任务栏的
-        全屏几何）；普通最大化窗口（任务栏未被覆盖）不触发隐藏。
+        全屏几何）；最大化窗口不触发隐藏——即使开启了 Windows「自动
+        隐藏任务栏」、最大化窗口铺满整屏，也按 IsZoomed 状态排除。
 
         注意：GetWindowRect 返回物理像素，而 Qt geometry 是逻辑坐标——
         高 DPI（125%/150%）下直接比较会把最大化窗口误判为"覆盖全屏"
@@ -718,10 +734,8 @@ class PetWindow(QWidget):
             # 物理像素 → 逻辑像素
             l, t = rect.left / dpr, rect.top / dpr
             r, b = rect.right / dpr, rect.bottom / dpr
-            g = scr.geometry()
-            # 覆盖全屏几何（含任务栏）= 真全屏
-            return (l <= g.left() and t <= g.top()
-                    and r >= g.right() and b >= g.bottom())
+            return self._fullscreen_geometry_hit(
+                l, t, r, b, scr.geometry(), bool(u32.IsZoomed(hwnd)))
         except Exception:
             return False
 

--- a/pet/window.py
+++ b/pet/window.py
@@ -190,6 +190,43 @@ def wander_target_y(
     return int(max(y_lo, min(y_hi, start_y + rnd.randint(-max_dy, max_dy))))
 
 
+# ---- Win32：任务栏状态查询（全屏自动隐藏判定用）----
+_ABM_GETSTATE = 4     # SHAppBarMessage：查询任务栏自动隐藏/置顶状态
+_ABS_AUTOHIDE = 0x1   # 返回状态含该位 = 任务栏处于自动隐藏模式
+
+
+class _WinRect(ctypes.Structure):
+    _fields_ = [('left', ctypes.c_long), ('top', ctypes.c_long),
+                ('right', ctypes.c_long), ('bottom', ctypes.c_long)]
+
+
+class _AppBarData(ctypes.Structure):
+    _fields_ = [('cbSize', ctypes.c_uint),
+                ('hWnd', ctypes.c_void_p),
+                ('uCallbackMessage', ctypes.c_uint),
+                ('uEdge', ctypes.c_uint),
+                ('rc', _WinRect),
+                ('lParam', ctypes.c_longlong)]
+
+
+def _taskbar_autohide_enabled() -> bool:
+    """Windows 任务栏是否处于「自动隐藏」模式。仅 Windows；异常按 False 处理。
+
+    注意：只能反映主任务栏；多屏副任务栏的自动隐藏状态不在查询范围。
+    """
+    if os.name != 'nt':
+        return False
+    try:
+        shell32 = ctypes.windll.shell32
+        shell32.SHAppBarMessage.restype = ctypes.c_uint
+        data = _AppBarData()
+        data.cbSize = ctypes.sizeof(_AppBarData)
+        state = shell32.SHAppBarMessage(_ABM_GETSTATE, ctypes.byref(data))
+        return bool(state & _ABS_AUTOHIDE)
+    except Exception:
+        return False
+
+
 class PetWindow(QWidget):
     """桌宠窗口本体。"""
 
@@ -673,15 +710,16 @@ class PetWindow(QWidget):
 
     @staticmethod
     def _fullscreen_geometry_hit(l: float, t: float, r: float, b: float,
-                                 geom, is_zoomed: bool) -> bool:
-        """覆盖整屏几何且非最大化 = 真全屏。
+                                 geom, is_zoomed: bool, autohide_taskbar: bool) -> bool:
+        """覆盖整屏几何 = 真全屏；任务栏自动隐藏时额外排除最大化窗口。
 
-        开启 Windows「自动隐藏任务栏」后，最大化窗口也会铺满整屏（任务栏
-        被盖住），与真全屏在几何上无法区分。真全屏窗口（游戏/视频/F11）
-        不会是最大化状态（IsZoomed 为假），最大化窗口则一定是 IsZoomed 为
-        真——据此把"自动隐藏任务栏下的最大化窗口"排除，避免误隐藏桌宠。
+        任务栏常驻可见时，最大化窗口只铺到工作区、盖不住任务栏区域，
+        几何判定本身就能排除它（无需看 IsZoomed），最大化式无边框全屏
+        游戏（最大化 + 覆盖整屏）仍按真全屏命中。任务栏自动隐藏时，最大
+        化窗口会铺满整屏（盖住任务栏），与真全屏几何无法区分——此时才用
+        IsZoomed 排除最大化窗口，避免误隐藏桌宠。
         """
-        if is_zoomed:
+        if autohide_taskbar and is_zoomed:
             return False
         return (l <= geom.left() and t <= geom.top()
                 and r >= geom.right() and b >= geom.bottom())
@@ -690,8 +728,9 @@ class PetWindow(QWidget):
         """前台窗口是否覆盖整个屏幕几何（含任务栏）= 真全屏。仅 Windows。
 
         只判定真全屏（全屏视频/游戏/浏览器 F11，窗口覆盖含任务栏的
-        全屏几何）；最大化窗口不触发隐藏——即使开启了 Windows「自动
-        隐藏任务栏」、最大化窗口铺满整屏，也按 IsZoomed 状态排除。
+        全屏几何）。任务栏常驻可见时最大化窗口只铺到工作区，几何判定
+        本身就能排除；仅当任务栏处于「自动隐藏」模式（最大化窗口会铺满
+        整屏、盖住任务栏）时才按 IsZoomed 排除最大化窗口。
 
         注意：GetWindowRect 返回物理像素，而 Qt geometry 是逻辑坐标——
         高 DPI（125%/150%）下直接比较会把最大化窗口误判为"覆盖全屏"
@@ -715,10 +754,7 @@ class PetWindow(QWidget):
             if buf.value in self._FS_SKIP_CLASSES:
                 return False
 
-            class RECT(ctypes.Structure):
-                _fields_ = [('left', ctypes.c_long), ('top', ctypes.c_long),
-                            ('right', ctypes.c_long), ('bottom', ctypes.c_long)]
-            rect = RECT()
+            rect = _WinRect()
             if not u32.GetWindowRect(hwnd, ctypes.byref(rect)):
                 return False
             # 窗口中心点（物理像素）→ 先定位屏幕，再用该屏 DPR 换算逻辑坐标
@@ -735,7 +771,8 @@ class PetWindow(QWidget):
             l, t = rect.left / dpr, rect.top / dpr
             r, b = rect.right / dpr, rect.bottom / dpr
             return self._fullscreen_geometry_hit(
-                l, t, r, b, scr.geometry(), bool(u32.IsZoomed(hwnd)))
+                l, t, r, b, scr.geometry(), bool(u32.IsZoomed(hwnd)),
+                _taskbar_autohide_enabled())
         except Exception:
             return False
 

--- a/pet/window.py
+++ b/pet/window.py
@@ -190,41 +190,14 @@ def wander_target_y(
     return int(max(y_lo, min(y_hi, start_y + rnd.randint(-max_dy, max_dy))))
 
 
-# ---- Win32：任务栏状态查询（全屏自动隐藏判定用）----
-_ABM_GETSTATE = 4     # SHAppBarMessage：查询任务栏自动隐藏/置顶状态
-_ABS_AUTOHIDE = 0x1   # 返回状态含该位 = 任务栏处于自动隐藏模式
+# ---- Win32：全屏判定用常量/结构 ----
+GWL_STYLE = -16             # GetWindowLongW：取窗口样式
+_WS_CAPTION = 0x00C00000    # WS_BORDER | WS_DLGFRAME（带标题栏）
 
 
 class _WinRect(ctypes.Structure):
     _fields_ = [('left', ctypes.c_long), ('top', ctypes.c_long),
                 ('right', ctypes.c_long), ('bottom', ctypes.c_long)]
-
-
-class _AppBarData(ctypes.Structure):
-    _fields_ = [('cbSize', ctypes.c_uint),
-                ('hWnd', ctypes.c_void_p),
-                ('uCallbackMessage', ctypes.c_uint),
-                ('uEdge', ctypes.c_uint),
-                ('rc', _WinRect),
-                ('lParam', ctypes.c_longlong)]
-
-
-def _taskbar_autohide_enabled() -> bool:
-    """Windows 任务栏是否处于「自动隐藏」模式。仅 Windows；异常按 False 处理。
-
-    注意：只能反映主任务栏；多屏副任务栏的自动隐藏状态不在查询范围。
-    """
-    if os.name != 'nt':
-        return False
-    try:
-        shell32 = ctypes.windll.shell32
-        shell32.SHAppBarMessage.restype = ctypes.c_uint
-        data = _AppBarData()
-        data.cbSize = ctypes.sizeof(_AppBarData)
-        state = shell32.SHAppBarMessage(_ABM_GETSTATE, ctypes.byref(data))
-        return bool(state & _ABS_AUTOHIDE)
-    except Exception:
-        return False
 
 
 class PetWindow(QWidget):
@@ -710,16 +683,15 @@ class PetWindow(QWidget):
 
     @staticmethod
     def _fullscreen_geometry_hit(l: float, t: float, r: float, b: float,
-                                 geom, is_zoomed: bool, autohide_taskbar: bool) -> bool:
-        """覆盖整屏几何 = 真全屏；任务栏自动隐藏时额外排除最大化窗口。
+                                 geom, has_caption: bool) -> bool:
+        """覆盖整屏几何且无标题栏 = 真全屏。
 
-        任务栏常驻可见时，最大化窗口只铺到工作区、盖不住任务栏区域，
-        几何判定本身就能排除它（无需看 IsZoomed），最大化式无边框全屏
-        游戏（最大化 + 覆盖整屏）仍按真全屏命中。任务栏自动隐藏时，最大
-        化窗口会铺满整屏（盖住任务栏），与真全屏几何无法区分——此时才用
-        IsZoomed 排除最大化窗口，避免误隐藏桌宠。
+        带标题栏（WS_CAPTION）的窗口只是普通/最大化窗口，不是全屏；真全屏
+        （游戏/视频/浏览器 F11）会去掉标题栏。这样 Windows「自动隐藏任务栏」
+        下最大化窗口即使铺满整屏也不误判为全屏；而已经最大化后按 F11 的窗口
+        （IsZoomed 仍为真、但标题栏被应用清掉）仍能正确命中为真全屏。
         """
-        if autohide_taskbar and is_zoomed:
+        if has_caption:
             return False
         return (l <= geom.left() and t <= geom.top()
                 and r >= geom.right() and b >= geom.bottom())
@@ -727,10 +699,10 @@ class PetWindow(QWidget):
     def _foreground_covers_fullscreen(self) -> bool:
         """前台窗口是否覆盖整个屏幕几何（含任务栏）= 真全屏。仅 Windows。
 
-        只判定真全屏（全屏视频/游戏/浏览器 F11，窗口覆盖含任务栏的
-        全屏几何）。任务栏常驻可见时最大化窗口只铺到工作区，几何判定
-        本身就能排除；仅当任务栏处于「自动隐藏」模式（最大化窗口会铺满
-        整屏、盖住任务栏）时才按 IsZoomed 排除最大化窗口。
+        只判定真全屏（全屏视频/游戏/浏览器 F11，窗口覆盖含任务栏的全屏几何
+        且无标题栏）。普通最大化窗口带标题栏，几何/样式判定都会排除它；即使
+        开启 Windows「自动隐藏任务栏」、最大化窗口铺满整屏，也因带标题栏而
+        不触发隐藏。
 
         注意：GetWindowRect 返回物理像素，而 Qt geometry 是逻辑坐标——
         高 DPI（125%/150%）下直接比较会把最大化窗口误判为"覆盖全屏"
@@ -754,6 +726,8 @@ class PetWindow(QWidget):
             if buf.value in self._FS_SKIP_CLASSES:
                 return False
 
+            style = u32.GetWindowLongW(hwnd, GWL_STYLE)
+            has_caption = bool(style & _WS_CAPTION)
             rect = _WinRect()
             if not u32.GetWindowRect(hwnd, ctypes.byref(rect)):
                 return False
@@ -771,8 +745,7 @@ class PetWindow(QWidget):
             l, t = rect.left / dpr, rect.top / dpr
             r, b = rect.right / dpr, rect.bottom / dpr
             return self._fullscreen_geometry_hit(
-                l, t, r, b, scr.geometry(), bool(u32.IsZoomed(hwnd)),
-                _taskbar_autohide_enabled())
+                l, t, r, b, scr.geometry(), has_caption)
         except Exception:
             return False
 

--- a/tests/test_window_pause.py
+++ b/tests/test_window_pause.py
@@ -189,28 +189,39 @@ def test_disable_auto_hide_restores_pet(app, tmp_path):
     app.processEvents()
 
 
-def test_fullscreen_geometry_hit_ignores_maximized_window(app, tmp_path):
-    """自动隐藏任务栏场景：最大化窗口即使铺满整屏也不判为真全屏（不误隐藏桌宠）。
+def test_fullscreen_geometry_hit_conditional_on_autohide_taskbar(app, tmp_path):
+    """全屏判定：IsZoomed 排除仅在任务栏自动隐藏时启用。
 
-    回归：开启 Windows「自动隐藏任务栏」后最大化窗口会铺满整屏（任务栏被
-    盖住），旧实现只看几何、把这类窗口误判成真全屏而隐藏桌宠。修复后叠加
-    IsZoomed（最大化）判定排除，同时保留真全屏（游戏/视频/F11）的隐藏能力。
+    回归一：开启 Windows「自动隐藏任务栏」后最大化窗口铺满整屏，旧实现只看
+    几何、把它误判成真全屏而隐藏桌宠 → 自动隐藏模式下必须排除最大化窗口。
+    回归二：最大化式无边框全屏游戏（任务栏常驻 + 最大化 + 覆盖整屏）在任务栏
+    常驻模式下应继续命中，保留真全屏自动隐藏能力——不能无条件排除最大化窗口。
     """
     lib = FakeLibrary()
     win = PetWindow(lib, Config(base=tmp_path))
     geom = QRect(0, 0, 1920, 1080)  # 含任务栏区域的整屏几何
 
-    # 真全屏：窗口铺满整屏且非最大化（游戏/视频/F11）→ 命中，应隐藏桌宠
-    assert win._fullscreen_geometry_hit(0, 0, 1920, 1080, geom, is_zoomed=False) is True
+    # 真全屏（F11/原生全屏）：非最大化 + 覆盖整屏，任务栏是否自动隐藏都命中
+    assert win._fullscreen_geometry_hit(0, 0, 1920, 1080, geom,
+                                        is_zoomed=False, autohide_taskbar=False) is True
+    assert win._fullscreen_geometry_hit(0, 0, 1920, 1080, geom,
+                                        is_zoomed=False, autohide_taskbar=True) is True
 
-    # 自动隐藏任务栏 + 最大化窗口：几何上同样铺满整屏，但处于最大化 → 不命中（本次修复）
-    assert win._fullscreen_geometry_hit(0, 0, 1920, 1080, geom, is_zoomed=True) is False
+    # 最大化式无边框全屏游戏：任务栏常驻 + 最大化 + 覆盖整屏 → 仍按真全屏命中
+    assert win._fullscreen_geometry_hit(0, 0, 1920, 1080, geom,
+                                        is_zoomed=True, autohide_taskbar=False) is True
 
-    # 任务栏常驻可见 + 普通最大化窗口：只铺到工作区，未覆盖整屏 → 不命中
-    assert win._fullscreen_geometry_hit(0, 0, 1920, 1040, geom, is_zoomed=True) is False
+    # 自动隐藏任务栏 + 最大化窗口：几何铺满整屏但处于最大化 → 不命中（修复目标）
+    assert win._fullscreen_geometry_hit(0, 0, 1920, 1080, geom,
+                                        is_zoomed=True, autohide_taskbar=True) is False
+
+    # 任务栏常驻 + 普通最大化窗口：只铺到工作区，未覆盖整屏 → 几何判定排除
+    assert win._fullscreen_geometry_hit(0, 0, 1920, 1040, geom,
+                                        is_zoomed=True, autohide_taskbar=False) is False
 
     # 普通窗口：既不覆盖整屏也非全屏 → 不命中
-    assert win._fullscreen_geometry_hit(100, 100, 1500, 900, geom, is_zoomed=False) is False
+    assert win._fullscreen_geometry_hit(100, 100, 1500, 900, geom,
+                                        is_zoomed=False, autohide_taskbar=False) is False
 
     win.close()
     app.processEvents()

--- a/tests/test_window_pause.py
+++ b/tests/test_window_pause.py
@@ -7,7 +7,7 @@ mask，多开时属于纯白烧。此测试锁定 hideEvent 暂停、showEvent �
 from __future__ import annotations
 
 import pytest
-from PySide6.QtCore import QObject, Signal
+from PySide6.QtCore import QObject, QRect, Signal
 from PySide6.QtGui import QPixmap
 from PySide6.QtWidgets import QApplication
 
@@ -184,6 +184,33 @@ def test_disable_auto_hide_restores_pet(app, tmp_path):
     assert win._hidden_paused is False
     assert win.isVisible()
     assert win.cfg.get('auto_hide_fullscreen') is False
+
+    win.close()
+    app.processEvents()
+
+
+def test_fullscreen_geometry_hit_ignores_maximized_window(app, tmp_path):
+    """自动隐藏任务栏场景：最大化窗口即使铺满整屏也不判为真全屏（不误隐藏桌宠）。
+
+    回归：开启 Windows「自动隐藏任务栏」后最大化窗口会铺满整屏（任务栏被
+    盖住），旧实现只看几何、把这类窗口误判成真全屏而隐藏桌宠。修复后叠加
+    IsZoomed（最大化）判定排除，同时保留真全屏（游戏/视频/F11）的隐藏能力。
+    """
+    lib = FakeLibrary()
+    win = PetWindow(lib, Config(base=tmp_path))
+    geom = QRect(0, 0, 1920, 1080)  # 含任务栏区域的整屏几何
+
+    # 真全屏：窗口铺满整屏且非最大化（游戏/视频/F11）→ 命中，应隐藏桌宠
+    assert win._fullscreen_geometry_hit(0, 0, 1920, 1080, geom, is_zoomed=False) is True
+
+    # 自动隐藏任务栏 + 最大化窗口：几何上同样铺满整屏，但处于最大化 → 不命中（本次修复）
+    assert win._fullscreen_geometry_hit(0, 0, 1920, 1080, geom, is_zoomed=True) is False
+
+    # 任务栏常驻可见 + 普通最大化窗口：只铺到工作区，未覆盖整屏 → 不命中
+    assert win._fullscreen_geometry_hit(0, 0, 1920, 1040, geom, is_zoomed=True) is False
+
+    # 普通窗口：既不覆盖整屏也非全屏 → 不命中
+    assert win._fullscreen_geometry_hit(100, 100, 1500, 900, geom, is_zoomed=False) is False
 
     win.close()
     app.processEvents()

--- a/tests/test_window_pause.py
+++ b/tests/test_window_pause.py
@@ -189,39 +189,33 @@ def test_disable_auto_hide_restores_pet(app, tmp_path):
     app.processEvents()
 
 
-def test_fullscreen_geometry_hit_conditional_on_autohide_taskbar(app, tmp_path):
-    """全屏判定：IsZoomed 排除仅在任务栏自动隐藏时启用。
+def test_fullscreen_geometry_hit_requires_borderless(app, tmp_path):
+    """全屏判定：覆盖整屏几何且无标题栏（WS_CAPTION）= 真全屏。
 
-    回归一：开启 Windows「自动隐藏任务栏」后最大化窗口铺满整屏，旧实现只看
-    几何、把它误判成真全屏而隐藏桌宠 → 自动隐藏模式下必须排除最大化窗口。
-    回归二：最大化式无边框全屏游戏（任务栏常驻 + 最大化 + 覆盖整屏）在任务栏
-    常驻模式下应继续命中，保留真全屏自动隐藏能力——不能无条件排除最大化窗口。
+    回归一：Windows「自动隐藏任务栏」下最大化窗口铺满整屏，旧实现只看几何把它
+    误判成真全屏而隐藏桌宠 → 带标题栏的窗口不命中。
+    回归二：已最大化后按 F11（IsZoomed 仍为真、但应用清掉标题栏）应命中——
+    几何 + IsZoomed 都无法区分该场景与普通最大化窗口，标题栏才是可靠信号。
     """
     lib = FakeLibrary()
     win = PetWindow(lib, Config(base=tmp_path))
     geom = QRect(0, 0, 1920, 1080)  # 含任务栏区域的整屏几何
 
-    # 真全屏（F11/原生全屏）：非最大化 + 覆盖整屏，任务栏是否自动隐藏都命中
-    assert win._fullscreen_geometry_hit(0, 0, 1920, 1080, geom,
-                                        is_zoomed=False, autohide_taskbar=False) is True
-    assert win._fullscreen_geometry_hit(0, 0, 1920, 1080, geom,
-                                        is_zoomed=False, autohide_taskbar=True) is True
+    # 真全屏（游戏/视频/浏览器 F11、最大化后按 F11、无边框全屏游戏）：
+    # 无标题栏 + 覆盖整屏 → 命中，应隐藏桌宠
+    assert win._fullscreen_geometry_hit(0, 0, 1920, 1080, geom, has_caption=False) is True
 
-    # 最大化式无边框全屏游戏：任务栏常驻 + 最大化 + 覆盖整屏 → 仍按真全屏命中
-    assert win._fullscreen_geometry_hit(0, 0, 1920, 1080, geom,
-                                        is_zoomed=True, autohide_taskbar=False) is True
+    # 自动隐藏任务栏 + 普通最大化窗口：铺满整屏但带标题栏 → 不命中（修复目标）
+    assert win._fullscreen_geometry_hit(0, 0, 1920, 1080, geom, has_caption=True) is False
 
-    # 自动隐藏任务栏 + 最大化窗口：几何铺满整屏但处于最大化 → 不命中（修复目标）
-    assert win._fullscreen_geometry_hit(0, 0, 1920, 1080, geom,
-                                        is_zoomed=True, autohide_taskbar=True) is False
+    # 任务栏常驻 + 普通最大化窗口：带标题栏且只到工作区 → 不命中
+    assert win._fullscreen_geometry_hit(0, 0, 1920, 1040, geom, has_caption=True) is False
 
-    # 任务栏常驻 + 普通最大化窗口：只铺到工作区，未覆盖整屏 → 几何判定排除
-    assert win._fullscreen_geometry_hit(0, 0, 1920, 1040, geom,
-                                        is_zoomed=True, autohide_taskbar=False) is False
+    # 无标题栏但未覆盖整屏（普通无边框窗口）→ 不命中，几何仍是必要条件
+    assert win._fullscreen_geometry_hit(100, 100, 1500, 900, geom, has_caption=False) is False
 
-    # 普通窗口：既不覆盖整屏也非全屏 → 不命中
-    assert win._fullscreen_geometry_hit(100, 100, 1500, 900, geom,
-                                        is_zoomed=False, autohide_taskbar=False) is False
+    # 带标题栏的普通窗口 → 不命中
+    assert win._fullscreen_geometry_hit(100, 100, 1500, 900, geom, has_caption=True) is False
 
     win.close()
     app.processEvents()


### PR DESCRIPTION
Closes #17 

## 摘要

修复 Windows「自动隐藏任务栏」模式下，普通最大化窗口被误判为真全屏、导致桌宠随任务栏一起自动隐藏的问题，并将真全屏判定改为不依赖任务栏显示状态。

## 问题根因

全屏自动隐藏 watcher 原本以「前台窗口矩形覆盖整屏几何（含任务栏区域）」作为真全屏判定依据（`pet/window.py` 的 `_foreground_covers_fullscreen`）。该判定隐含假设「任务栏常驻时始终占位，普通最大化窗口不会覆盖任务栏区域」：

1. 任务栏常驻可见时，最大化窗口只铺到工作区，判定正确；
2. 开启「自动隐藏任务栏」后，任务栏收起不再占位，最大化窗口铺满整屏（含任务栏区域），与真全屏在几何上无法区分，被误判为全屏 → 桌宠被隐藏。

进一步诊断（前台窗口状态实机采样）确认：真全屏应用（游戏、视频、浏览器 F11）与普通最大化窗口的真正区别不在最大化状态——已最大化后按 F11 的窗口 `IsZoomed` 仍为真，但应用会清除 `WS_CAPTION`（标题栏）。因此标题栏存在与否才是「真全屏」与「普通/最大化窗口」的可靠信号。

## 改动内容

### `pet/window.py`

- 新增模块级常量与结构：`GWL_STYLE`、`_WS_CAPTION`（`WS_BORDER | WS_DLGFRAME`）、`_WinRect`。
- `_fullscreen_geometry_hit` 判定式改为：**覆盖整屏几何 且 无标题栏（`WS_CAPTION`）= 真全屏**：
  - 带标题栏的窗口（普通窗口、最大化窗口）→ 直接返回 `False`，不触发隐藏；
  - 无标题栏且覆盖整屏（游戏、视频、浏览器 F11、已最大化后按 F11）→ 命中，触发隐藏。
- `_foreground_covers_fullscreen` 通过 `GetWindowLongW(hwnd, GWL_STYLE)` 读取窗口样式计算 `has_caption` 后传入判定函数。
- 移除上一版为规避误判引入的「任务栏自动隐藏状态检测」（`SHAppBarMessage` 相关代码），全屏判定不再依赖任务栏开关，行为在两种任务栏形态下一致。

### `tests/test_window_pause.py`

- 新增回归测试 `test_fullscreen_geometry_hit_requires_borderless`，覆盖：
  - 无标题栏 + 覆盖整屏 → 命中（真全屏、无边框全屏游戏、最大化后按 F11）；
  - 带标题栏 + 覆盖整屏 → 不命中（自动隐藏任务栏下的普通最大化窗口，本次修复目标）；
  - 带标题栏 + 仅覆盖工作区 → 不命中（任务栏常驻下的普通最大化窗口）；
  - 无标题栏 + 未覆盖整屏 → 不命中（普通无边框窗口，几何仍是必要条件）。

## 修复后行为对照

| 场景 | 修复前 | 修复后 |
|---|---|---|
| 任务栏常驻 + 普通最大化窗口 | 不隐藏 ✓ | 不隐藏 ✓ |
| 任务栏常驻 + F11 真全屏 | 隐藏 ✓ | 隐藏 ✓ |
| 自动隐藏任务栏 + 普通最大化窗口 | 隐藏 ✗（本 bug） | 不隐藏 ✓ |
| 自动隐藏任务栏 + 最大化后按 F11 | 不隐藏 ✗ | 隐藏 ✓ |
| 无边框全屏游戏（两种任务栏形态） | 隐藏 ✓ | 隐藏 ✓ |

## 测试验证

- 全量测试套件：`355 passed, 5 skipped`，无回归。
- Windows 实机验证：`auto_hide_fullscreen` 开启时，最大化窗口不再隐藏桌宠；已最大化窗口按 F11 可正确隐藏；任务栏常驻模式下行为不变。

## 说明

- 无边框全屏游戏有两种实现方式：一种直接铺满屏（无最大化状态、无标题栏），一种以 `WS_MAXIMIZE` 最大化铺满屏（`IsZoomed` 为真但同样去掉标题栏）。两种在本判定下均能正确命中为真全屏。
- 已最大化后按 F11 属于「应用清除标题栏、`IsZoomed` 保持为真」的实现，旧的「几何 + IsZoomed」判定无法区分它与普通最大化窗口，本改动通过标题栏信号解决。