### PR TITLE
fix(packaging): macOS/Linux 构建补上 integrations 资源，修复 DSH 桥接一键安装

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -66,6 +66,7 @@ jobs:
               --add-data "assets/chat:assets/chat" \
               --add-data "assets/big_blue_fat_fish:assets/big_blue_fat_fish" \
               --add-data "pet/menu_templates:pet/menu_templates" \
+              --add-data "integrations:integrations" \
               "${CHAT_DATA[@]}" \
               --name "dsh-pet-standalone-$VARIANT" \
               --add-data "$DATAS:$DATAS" \
@@ -83,6 +84,10 @@ jobs:
               echo "::error::$APP pet 模块未被 PyInstaller 收集"; cat "$WARN"; exit 1
             fi
             echo "$APP pet 模块已收集"
+            if ! find dist -path "*integrations/dsh-pet-bridge/package.json" | grep -q .; then
+              echo "::error::$APP 未打包 integrations/dsh-pet-bridge，DSH 桥接一键安装必然失败"; exit 1
+            fi
+            echo "$APP 桥接插件资源已打包"
           done
 
       - name: Package as zip

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -66,6 +66,7 @@ jobs:
               --add-data "$DATAS:$DATAS" \
               --add-data "assets/big_blue_fat_fish:assets/big_blue_fat_fish" \
               --add-data "pet/menu_templates:pet/menu_templates" \
+              --add-data "integrations:integrations" \
               "${CHAT_DATA[@]}" \
               $EXCLUDES \
               "$ENTRY"
@@ -81,6 +82,10 @@ jobs:
               echo "::error::$APP pet 模块未被 PyInstaller 收集"; cat "$WARN"; exit 1
             fi
             echo "$APP pet 模块已收集"
+            if ! find dist -path "*integrations/dsh-pet-bridge/package.json" | grep -q .; then
+              echo "::error::$APP 未打包 integrations/dsh-pet-bridge，DSH 桥接一键安装必然失败"; exit 1
+            fi
+            echo "$APP 桥接插件资源已打包"
           done
 
       - name: Ad-hoc codesign

--- a/scripts/build_macos.sh
+++ b/scripts/build_macos.sh
@@ -53,6 +53,7 @@ for spec in "${variants[@]}"; do
         --add-data "assets/chat:assets/chat"
         --add-data "assets/sounds:assets/sounds"
         --add-data "pet/menu_templates:pet/menu_templates"
+        --add-data "integrations:integrations"
     )
     if [[ "$name" == *-chat ]]; then
         args+=(--add-data "pet/chat/legacy_styles.qss:pet/chat")


### PR DESCRIPTION
Closes #21

## 问题

`DshMonitor.bundled_plugin_dir()` 在打包版里找的是 `sys._MEIPASS/integrations/dsh-pet-bridge/package.json`（macOS 上即 `X.app/Contents/Resources/...`），但 macOS / Linux 的三条构建路径都没有把 `integrations` 传给 PyInstaller，所以官方产物里没有这个目录。结果：非 Windows 平台右键菜单「DSH 桥接插件一键安装」必然返回「找不到内置桥接插件（integrations/dsh-pet-bridge）」，且因为 `_on_install_finished()` 只在成功时才落配置，`agent_link.dsh` 永远保持 `false`，用户侧没有自救入口。

Windows 不受影响 —— `scripts/build_onedir.ps1:87` 早就有 `--add-data "integrations;integrations"`。本 PR 就是把这条参数补齐到另外三处，消除平台漂移。

与 PR #16 的 profile 枚举加固不冲突，也不被它覆盖：那次修的是安装器后半段的误判，而本问题在前半段取插件目录时就短路返回 `None` 了。

## 改动

`.github/workflows/build-macos.yml`、`.github/workflows/build-linux.yml`、`scripts/build_macos.sh` 各补一行：

```
--add-data "integrations:integrations"
```

按 Windows 的写法带整目录而不是只带 `integrations/dsh-pet-bridge`，今后往 `integrations/` 里加别的 Agent 桥接插件就不必再改 CI；`bundled_plugin_dir()` 的查找路径不受影响。

并在既有的「Verify pet module collected」步骤里追加一道资源存在性校验，让「资源没进包」在构建阶段就红，而不是等用户点菜单才发现：

```bash
if ! find dist -path "*integrations/dsh-pet-bridge/package.json" | grep -q .; then
  echo "::error::$APP 未打包 integrations/dsh-pet-bridge，DSH 桥接一键安装必然失败"; exit 1
fi
```

用 `find` 而不是写死路径，是因为两种 onedir 布局不同：macOS 落在 `X.app/Contents/Resources/`，Linux 落在 `dist/<name>/_internal/`。

## 验证

`build-macos.yml` / `build-linux.yml` 只在 `workflow_dispatch` 和 `v*` tag 下触发，PR 不会跑到这两条流水线，所以改动在本地做了等价校验：

1. `git apply --check` 通过，实际 apply 为 3 个文件 +11 行（相对 `main` HEAD `2a18abe`）；
2. 改后的两个 workflow 文件 YAML 解析通过，`scripts/build_macos.sh` 通过 `bash -n`；
3. 新增的 find 校验按三种目录布局做过行为测试：macOS `.app/Contents/Resources/integrations/...` → 通过；Linux `_internal/integrations/...` → 通过；空 `dist` → 正确判失败并 `exit 1`；
4. 缺陷本身在真机复现并验证了根因：已安装的官方 macOS arm64 构建 `Contents/Resources/` 下确无 `integrations`；把插件手动装进 DSH profile（`dsh plugin --profile web install ~/.dsh/local-plugins/dsh-pet-bridge`）并把 `agent_link.dsh` 置 `true` 后，桌宠 `DshMonitor` 正常启动并响应事件（动画实际切到「原地敲击桌面互动」/「写代码」），说明缺的只是打包资源，插件与监视器两侧逻辑都是好的。

## 顺带建议（未包含在本 PR）

`install_bridge()` 里 `plugin is None` 这条分支的提示可以说得更可操作些，例如「当前构建未包含桥接插件资源，请改用源码运行或反馈打包问题」，便于用户区分环境问题和构建问题。需要的话我另开一个小 PR。

---

定位、复现与补丁由千问办公（QwenWork）桌面助手完成 · 2026-08-29。
