### PR TITLE
fix: Agent 联动——dsh 过程汇报工具名识别 + 动作轮换兜底

### DIFF
--- a/pet/agent_link.py
+++ b/pet/agent_link.py
@@ -969,14 +969,18 @@ class AgentLinkManager(QObject):
 
     # 联动气泡展示名
     AGENT_NAMES = {"dsh": "DSH", "claude": "Claude Code", "cursor": "Cursor", "opencode": "OpenCode"}
-    # 过程汇报：工具名 → 用户可读文案（白名单制，未知工具静默不弹，不泄露原始命令/路径）
+    # 过程汇报：工具名 → 用户可读文案（不展示原始命令/路径）
     TOOL_LABELS = {
         "read": "正在读文件", "write": "正在写文件", "edit": "正在改代码",
         "notebookedit": "正在改代码", "bash": "正在跑命令", "shell": "正在跑命令",
+        "pwsh": "正在跑命令", "powershell": "正在跑命令",
         "grep": "正在搜索", "glob": "正在搜索", "search": "正在搜索",
+        "memory_search": "正在翻记忆",
         "webfetch": "正在查网页", "websearch": "正在查网页",
+        "fetch": "正在查网页", "browser": "正在查网页", "web_fetch": "正在查网页",
         "task": "正在派活给子代理", "todowrite": "正在列计划",
     }
+    _UNKNOWN_TOOL_LABEL = "正在调用工具"
     _ACTIVITY_MIN_INTERVAL = 10.0    # 同 Agent 过程气泡最小间隔
     _ACTIVITY_GLOBAL_MIN = 8.0       # 全局最小间隔（多 Agent 并发防刷屏）
     _ACTIVITY_SAME_LABEL = 60.0      # 同一工具文案 60s 内不重复
@@ -1242,12 +1246,22 @@ class AgentLinkManager(QObject):
     # ------------------------------------------------------------------
     _LINK_MAIN = ("写代码", "吃Token")
     _LINK_BREAK = ("轻快记录", "原地漂浮踏步")
+    _LINK_MAIN_KEYWORDS = ("代码", "工作", "写", "打字", "敲")
+    _LINK_BREAK_KEYWORDS = ("记录", "踏步", "伸懒腰")
 
     def _next_link_anim_rotation(self) -> str | None:
         """下一个联动动作：主动作严格交替；每第 3 次插播摸鱼（独立节奏）。"""
-        acts = getattr(self.win, "cats", {}).get("acts", [])
+        acts = list(getattr(self.win, "cats", {}).get("acts", []) or [])
         main = [a for a in self._LINK_MAIN if a in acts]
         brk = [a for a in self._LINK_BREAK if a in acts]
+        # 不同角色包的动作名不统一：精确名缺失时按语义关键词回退。
+        if not main:
+            main = [a for a in acts if any(k in a for k in self._LINK_MAIN_KEYWORDS)]
+        if not brk:
+            brk = [a for a in acts if any(k in a for k in self._LINK_BREAK_KEYWORDS)]
+        # 角色包至少有一个动作时，确保 Agent 忙碌期间始终有可见反馈。
+        if not main and not brk:
+            main = acts
         if not main and not brk:
             return None
         self._link_seq += 1
@@ -1312,9 +1326,7 @@ class AgentLinkManager(QObject):
         agent_cfg = self.cfg.get("agent_link", {})
         if not agent_cfg.get("notify_activity", False):
             return
-        label = self.TOOL_LABELS.get(str(tool).strip().lower(), "")
-        if not label:
-            return
+        label = self.TOOL_LABELS.get(str(tool).strip().lower(), self._UNKNOWN_TOOL_LABEL)
         now = self._clock()
         last = self._last_activity.get(agent_key)
         if last is not None:

--- a/tests/test_agent_link.py
+++ b/tests/test_agent_link.py
@@ -940,6 +940,17 @@ class TestAgentLinkChainingAndActivity:
         expected = ["写代码", "吃Token", "轻快记录", "吃Token", "写代码", "原地漂浮踏步"]
         assert res == expected
 
+    def test_anim_rotation_falls_back_to_keywords_and_available_acts(self, tmp_path):
+        """精确动作名不存在时，按主/摸鱼关键词选择；完全不匹配时回退到任意动作。"""
+        mgr, win, bubbles, clock = self._make_mgr(
+            tmp_path, acts=["敲击键盘", "伸懒腰", "发呆"]
+        )
+        res = [mgr._next_link_anim_rotation() for _ in range(6)]
+        assert res == ["敲击键盘", "敲击键盘", "伸懒腰", "敲击键盘", "敲击键盘", "伸懒腰"]
+
+        mgr, win, bubbles, clock = self._make_mgr(tmp_path, acts=["跳舞"])
+        assert mgr._next_link_anim_rotation() == "跳舞"
+
 
     def test_empty_acts_returns_none(self, tmp_path):
         """2. 无可用动作时 _next_link_anim_rotation 返回 None（DummyWin cats.acts 为空列表）不抛异常。"""
@@ -952,7 +963,7 @@ class TestAgentLinkChainingAndActivity:
     def test_activity_reporting(self, tmp_path):
         """3. 过程汇报：cfg agent_link.notify_activity=True 时 mgr._on_agent_activity('dsh','bash') → 气泡含「正在跑命令」；
         10 秒内第二次任何工具不弹；同工具 60 秒内不重复（clock 前进 15s 再发 bash 仍不弹；换成 read 则弹「正在读文件」）；
-        全局限流 8s（另一 agent 在 8s 内也不弹）。notify_activity 默认 False 时不弹。未知工具（如 'frobnicate'）不弹。"""
+        全局限流 8s（另一 agent 在 8s 内也不弹）。notify_activity 默认 False 时不弹。未知工具（如 'frobnicate'）弹安全兜底文案。"""
         # notify_activity 默认 False 时不弹
         mgr_off, win_off, bubbles_off, clock_off = self._make_mgr(tmp_path)
         mgr_off._on_agent_activity("dsh", "bash")
@@ -961,33 +972,43 @@ class TestAgentLinkChainingAndActivity:
         # notify_activity = True
         mgr, win, bubbles, clock = self._make_mgr(tmp_path, agent_link_cfg={"notify_activity": True})
 
-        # 未知工具不弹
+        # 未知工具弹安全兜底文案，不泄露原始参数
         mgr._on_agent_activity("dsh", "frobnicate")
-        assert bubbles == []
+        assert len(bubbles) == 1
+        assert "正在调用工具" in bubbles[-1]
+        assert "frobnicate" not in bubbles[-1]
 
         # dsh bash → 弹「正在跑命令」
+        clock[0] += 10.0
         mgr._on_agent_activity("dsh", "bash")
-        assert len(bubbles) == 1
+        assert len(bubbles) == 2
         assert "正在跑命令" in bubbles[-1]
 
         # 10 秒内第二次任何工具不弹
         clock[0] += 5.0
         mgr._on_agent_activity("dsh", "read")
-        assert len(bubbles) == 1
+        assert len(bubbles) == 2
 
         # 全局限流 8s（另一 agent 在 8s 内也不弹，从 1000.0 起算此时 1005.0 < 1008.0）
         mgr._on_agent_activity("claude", "read")
-        assert len(bubbles) == 1
+        assert len(bubbles) == 2
 
         # 同工具 60 秒内不重复：前进 15s（总共 +20s > 10s，但 < 60s），再发 bash 仍不弹
         clock[0] += 15.0
         mgr._on_agent_activity("dsh", "bash")
-        assert len(bubbles) == 1
+        assert len(bubbles) == 2
 
         # 换成 read 则弹「正在读文件」
         mgr._on_agent_activity("dsh", "read")
-        assert len(bubbles) == 2
+        assert len(bubbles) == 3
         assert "正在读文件" in bubbles[-1]
+
+        clock[0] += 10.0
+        mgr._on_agent_activity("dsh", "pwsh")
+        assert "正在跑命令" in bubbles[-1]
+        clock[0] += 10.0
+        mgr._on_agent_activity("dsh", "memory_search")
+        assert "正在翻记忆" in bubbles[-1]
 
     def test_window_smooth_chaining(self, tmp_path):
         """4. window 侧平滑衔接（用真实 PetWindow + MovieLibrary，offscreen，参考 TestAgentMenuRebound 的构造）：


### PR DESCRIPTION
## 修复内容

使用 DeepSeek Harness（dsh）联动时发现两个问题：

### 1. dsh 的过程汇报气泡几乎不弹

`TOOL_LABELS` 白名单按 Claude Code 的工具名编写，dsh 在 Windows 上常用的 `pwsh`、`memory_search` 等不在名单内，按"未知工具静默不弹"的设计全部被丢弃，导致 dsh 工作期间过程汇报几乎只剩 grep/glob 能触发。

修复：

- 补充 dsh 常用工具名映射（`pwsh`/`powershell` → 正在跑命令、`memory_search` → 正在翻记忆、`fetch`/`browser`/`web_fetch` → 正在查网页）；
- 未知工具名改为弹安全兜底文案「正在调用工具」——保持不泄露原始命令/路径的设计意图，但不再无声丢弃。

### 2. 联动动作对动作名不精确匹配的角色包完全不触发

`_next_link_anim_rotation` 只在角色动作池精确包含「写代码/吃Token/轻快记录/原地漂浮踏步」时才返回动作，否则返回 None——没有这些动作名的角色包在 Agent 忙碌期间全程无任何联动反馈。

修复：精确名缺失时按语义关键词模糊匹配（主池：代码/工作/写/打字/敲；摸鱼池：记录/踏步/伸懒腰），仍无匹配则从角色现有动作中轮换，保证任何角色包都有可见反馈。精确名存在时行为与现状完全一致。

## 测试

- 新增测试覆盖：dsh 工具名映射命中、未知工具兜底文案（且不泄露原始工具名）、动作池精确名缺失时的关键词回退与任意动作兜底、精确名存在时行为不变。
- 全量 `pytest -q`：453 passed / 5 skipped。
- Windows 实机验证：注入 dsh AgentStatus(working) 事件，桌宠正确切换到工作类动作并弹出开始/完成气泡。
