### PR TITLE
fix: 逐像素点击穿透双重修复 + pnpm 自动安装

### DIFF
--- a/pet/agent_link.py
+++ b/pet/agent_link.py
@@ -64,11 +64,8 @@ def _real_profiles() -> list[Path]:
     )
 
 
-def _pnpm_cli() -> str | None:
-    """定位 pnpm 的 JS CLI 入口（由 node 直调，绕开 .cmd/.ps1 包装的空格引号坑）。
-
-    优先级：环境变量 DSH_PNPM_BIN > PATH 上 pnpm 同目录 > npm 全局目录推断。
-    """
+def _find_pnpm_cli() -> str | None:
+    """定位 pnpm 的 JS CLI 入口，不触发安装。"""
     env = os.environ.get("DSH_PNPM_BIN")
     if env and Path(env).is_file():
         return env
@@ -86,12 +83,50 @@ def _pnpm_cli() -> str | None:
     return None
 
 
+def _npm_cli() -> str | None:
+    """定位 npm 的 JS CLI 入口（由 node 直调，绕开 .cmd 的空格引号坑）。"""
+    npm = shutil.which("npm")
+    if not npm:
+        return None
+    resolved = Path(npm).resolve()
+    if resolved.name == "npm-cli.js" and resolved.is_file():
+        return str(resolved)
+    for base in (Path(npm).parent, resolved.parent):
+        cand = base / "node_modules" / "npm" / "bin" / "npm-cli.js"
+        if cand.is_file():
+            return str(cand)
+    return None
+
+
+def _pnpm_cli() -> str | None:
+    """定位 pnpm 的 JS CLI；缺失时尝试通过 npm 全局安装一次。"""
+    cli = _find_pnpm_cli()
+    if cli:
+        return cli
+    node = shutil.which("node")
+    npm_cli = _npm_cli()
+    if not node or not npm_cli:
+        return None
+    try:
+        proc = subprocess.run(
+            [node, npm_cli, "install", "-g", "pnpm"],
+            capture_output=True, text=True, timeout=300, shell=False,
+        )
+    except Exception:
+        return None
+    if proc.returncode != 0:
+        return None
+    return _find_pnpm_cli()
+
+
 def _run_pnpm(profile_dir: Path, *args: str) -> tuple[int, str]:
     """node 直调 pnpm CLI（数组传参，无 cmd 中转），返回 (返回码, 合并输出)。"""
     node = shutil.which("node")
     cli = _pnpm_cli()
-    if not node or not cli:
-        return 127, "找不到 node 或 pnpm"
+    if not node:
+        return 127, "找不到 node，请先安装 Node.js"
+    if not cli:
+        return 127, "需要 pnpm，自动安装失败，请手动运行: npm install -g pnpm"
     try:
         proc = subprocess.run(
             [node, cli, *args], capture_output=True, text=True,
@@ -535,8 +570,10 @@ class DshMonitor(BaseAgentMonitor):
         plugin = cls.bundled_plugin_dir()
         if plugin is None:
             return False, "找不到内置桥接插件（integrations/dsh-pet-bridge）"
-        if shutil.which("node") is None or _pnpm_cli() is None:
-            return False, "找不到 node 或 pnpm（需要 Node.js 与 npm 全局 pnpm）"
+        if shutil.which("node") is None:
+            return False, "找不到 node，请先安装 Node.js（需包含 npm）"
+        if _pnpm_cli() is None:
+            return False, "需要 pnpm，自动安装失败，请手动运行: npm install -g pnpm"
 
         profiles = _real_profiles()
         if not profiles:

--- a/pet/window.py
+++ b/pet/window.py
@@ -28,7 +28,7 @@ from typing import Any
 
 import shiboken6
 
-from PySide6.QtCore import QAbstractNativeEventFilter, QElapsedTimer, QPoint, QRect, Qt, QTimer, Signal
+from PySide6.QtCore import QElapsedTimer, QPoint, QRect, Qt, QTimer, Signal
 from PySide6.QtGui import QBitmap, QColor, QCursor, QImage, QPainter, QPixmap, QRegion
 from PySide6.QtWidgets import QApplication, QInputDialog, QMenu, QToolTip, QWidget
 
@@ -263,6 +263,7 @@ GWL_STYLE = -16             # GetWindowLongW：取窗口样式
 GWL_EXSTYLE = -20           # GetWindowLongW：取扩展样式
 _WS_CAPTION = 0x00C00000    # WS_BORDER | WS_DLGFRAME（带标题栏）
 _WS_EX_TOPMOST = 0x00000008  # 置顶：真全屏游戏/视频几乎必带，普通最大化窗口不带
+_WS_EX_TRANSPARENT = 0x00000020
 
 
 class _WinRect(ctypes.Structure):
@@ -276,45 +277,57 @@ class _WinMonitorInfo(ctypes.Structure):
                 ('rcWork', _WinRect), ('dwFlags', ctypes.c_ulong)]
 
 
-class WindowsPerPixelHitTestFilter(QAbstractNativeEventFilter):
-    """Windows 逐像素命中测试：透明区域返回 HTTRANSPARENT 让鼠标穿透。
+def _set_windows_click_through(hwnd: int, enabled: bool, user32=None) -> bool:
+    """切换 layered HWND 的输入穿透扩展样式。"""
+    user32 = user32 or ctypes.windll.user32
+    style = int(user32.GetWindowLongW(hwnd, GWL_EXSTYLE))
+    updated = style | _WS_EX_TRANSPARENT if enabled else style & ~_WS_EX_TRANSPARENT
+    if updated == style:
+        return False
+    user32.SetWindowLongW(hwnd, GWL_EXSTYLE, updated)
+    return True
 
-    替代 QWidget.setMask 的 1-bit 窗口裁剪——setMask 会破坏
-    WA_TranslucentBackground 的逐像素半透明边缘；这里只影响输入命中，
-    视觉仍由 translucent background 负责平滑合成。
+
+class WindowsPerPixelInputController:
+    """根据光标所在像素动态切换 layered window 的输入穿透。
+
+    HTTRANSPARENT 只能继续命中当前线程的窗口，无法穿透到其他应用。
+    WS_EX_TRANSPARENT 会让 Windows 在命中时跳过 layered 桌宠窗口；独立
+    定时器在窗口不再收到鼠标消息时仍能检测光标并恢复角色区域交互。
     """
 
-    WM_NCHITTEST = 0x0084
-    HTTRANSPARENT = -1
-    HTCLIENT = 1
-
     def __init__(self, window: "PetWindow") -> None:
-        super().__init__()
         self._window = window
+        self._timer = QTimer(window)
+        self._timer.setInterval(10)
+        self._timer.timeout.connect(self.refresh)
+        self._timer.start()
 
-    def nativeEventFilter(self, event_type, message):
-        if os.name != "nt":
-            return False, 0
-        if event_type not in (b"windows_generic_MSG", b"windows_dispatcher_MSG"):
-            return False, 0
-        try:
-            msg = wintypes.MSG.from_address(int(message))
-        except Exception:
-            return False, 0
-        if msg.message != self.WM_NCHITTEST:
-            return False, 0
+    def should_click_through(self, global_pos: QPoint) -> bool:
         win = self._window
+        if win.mouse_through:
+            return True
+        if getattr(win, '_press_global', None) is not None or not win.isVisible():
+            return False
+        local = win.mapFromGlobal(global_pos)
+        if not QRect(0, 0, win.width(), win.height()).contains(local):
+            return False
+        return win._is_transparent_at(local)
+
+    def refresh(self) -> None:
         try:
-            if int(msg.hWnd) != int(win.winId()):
-                return False, 0
-            x = ctypes.c_short(msg.lParam & 0xFFFF).value
-            y = ctypes.c_short((msg.lParam >> 16) & 0xFFFF).value
-            local = win.mapFromGlobal(QPoint(x, y))
-            if win._is_transparent_at(local):
-                return True, self.HTTRANSPARENT
-            return True, self.HTCLIENT
-        except Exception:
-            return False, 0
+            enabled = self.should_click_through(QCursor.pos())
+            _set_windows_click_through(int(self._window.winId()), enabled)
+        except (AttributeError, OSError, RuntimeError):
+            logging.debug("更新 Windows 逐像素鼠标穿透失败", exc_info=True)
+
+    def stop(self) -> None:
+        self._timer.stop()
+        if not self._window.mouse_through:
+            try:
+                _set_windows_click_through(int(self._window.winId()), False)
+            except (AttributeError, OSError, RuntimeError):
+                pass
 
 
 class PetWindow(QWidget):
@@ -442,16 +455,9 @@ class PetWindow(QWidget):
         # Visibility and z-order are separate: always keep the pet visible,
         # then use WindowStaysOnTopHint/NSWindow level for the on-top setting.
         _keep_macos_tool_window_visible(self)
-        # 逐像素命中测试过滤器（仅 Windows）：必须在安装前先初始化为 None，
-        # 安装后绝不能再赋值 None——installNativeEventFilter 不接管 Python 对象
-        # 所有权，丢失引用会让过滤器被 GC 回收，命中测试静默失效。
-        self._hit_filter: WindowsPerPixelHitTestFilter | None = None
         app = QApplication.instance()
         if app is not None:
             app.applicationStateChanged.connect(self._on_application_state_changed)
-            if os.name == "nt":
-                self._hit_filter = WindowsPerPixelHitTestFilter(self)
-                app.installNativeEventFilter(self._hit_filter)
 
         # ---- 状态 ----
         self.anim: str = self.idle
@@ -463,6 +469,9 @@ class PetWindow(QWidget):
         # 角色可见轮廓（窗口局部坐标）与逐像素命中缓存；贴边功能复用 _mask_bounds
         self._mask_bounds: QRect | None = None
         self._hit_alpha_image: QImage | None = None
+        self._input_controller: WindowsPerPixelInputController | None = None
+        if os.name == "nt":
+            self._input_controller = WindowsPerPixelInputController(self)
         # 窗口隐藏时暂停动画解码/定时器；显示时由 showEvent 恢复
         self._hidden_paused = False
         self._ended_fired = False
@@ -1271,7 +1280,7 @@ class PetWindow(QWidget):
 
         - 非 Windows：继续用 QWidget.setMask 实现透明区域鼠标穿透。
         - Windows：不再 setMask（1-bit 裁剪会破坏半透明边缘），只更新
-          _mask_bounds；鼠标穿透由 WindowsPerPixelHitTestFilter 负责。
+          _mask_bounds；鼠标穿透由 WindowsPerPixelInputController 负责。
         """
         canvas = QImage(self._w, self._h, QImage.Format.Format_ARGB32)
         canvas.fill(Qt.GlobalColor.transparent)
@@ -2286,11 +2295,9 @@ class PetWindow(QWidget):
 
     def closeEvent(self, event) -> None:  # noqa: N802
         self._disarm_screen_restore_retry()  # 窗口销毁前摘掉 screenAdded 监听/超时回调
-        if self._hit_filter is not None:
-            app = QApplication.instance()
-            if app is not None:
-                app.removeNativeEventFilter(self._hit_filter)
-            self._hit_filter = None
+        if self._input_controller is not None:
+            self._input_controller.stop()
+            self._input_controller = None
         self._save_position()
         self._self_talk_timer.stop()
         self._cancel_animation_gap()

--- a/pet/window.py
+++ b/pet/window.py
@@ -305,7 +305,7 @@ class WindowsPerPixelHitTestFilter(QAbstractNativeEventFilter):
             return False, 0
         win = self._window
         try:
-            if int(msg.hwnd) != int(win.winId()):
+            if int(msg.hWnd) != int(win.winId()):
                 return False, 0
             x = ctypes.c_short(msg.lParam & 0xFFFF).value
             y = ctypes.c_short((msg.lParam >> 16) & 0xFFFF).value
@@ -442,6 +442,10 @@ class PetWindow(QWidget):
         # Visibility and z-order are separate: always keep the pet visible,
         # then use WindowStaysOnTopHint/NSWindow level for the on-top setting.
         _keep_macos_tool_window_visible(self)
+        # 逐像素命中测试过滤器（仅 Windows）：必须在安装前先初始化为 None，
+        # 安装后绝不能再赋值 None——installNativeEventFilter 不接管 Python 对象
+        # 所有权，丢失引用会让过滤器被 GC 回收，命中测试静默失效。
+        self._hit_filter: WindowsPerPixelHitTestFilter | None = None
         app = QApplication.instance()
         if app is not None:
             app.applicationStateChanged.connect(self._on_application_state_changed)
@@ -459,7 +463,6 @@ class PetWindow(QWidget):
         # 角色可见轮廓（窗口局部坐标）与逐像素命中缓存；贴边功能复用 _mask_bounds
         self._mask_bounds: QRect | None = None
         self._hit_alpha_image: QImage | None = None
-        self._hit_filter: WindowsPerPixelHitTestFilter | None = None
         # 窗口隐藏时暂停动画解码/定时器；显示时由 showEvent 恢复
         self._hidden_paused = False
         self._ended_fired = False

--- a/tests/test_agent_link.py
+++ b/tests/test_agent_link.py
@@ -19,6 +19,7 @@ from pathlib import Path
 import pytest
 from PySide6.QtWidgets import QApplication, QMessageBox
 
+import pet.agent_link as agent_link
 from pet.agent_link import (
     AgentLinkManager,
     BaseAgentMonitor,
@@ -851,6 +852,54 @@ class TestAgentLinkBubbles:
 
 
 class TestInstallErrorSummary:
+    def test_install_bridge_auto_installs_pnpm(self, tmp_path, monkeypatch):
+        plugin = tmp_path / "dsh-pet-bridge"
+        plugin.mkdir()
+        profile = tmp_path / "profiles" / "default"
+        profile.mkdir(parents=True)
+        manifest = profile / "package.json"
+        manifest.write_text("{}", encoding="utf-8")
+
+        pnpm_cli = str(tmp_path / "pnpm.mjs")
+        located = iter([None, pnpm_cli, pnpm_cli])
+        monkeypatch.setattr(agent_link, "_find_pnpm_cli", lambda: next(located))
+        monkeypatch.setattr(agent_link, "_npm_cli", lambda: "C:/Program Files/nodejs/node_modules/npm/bin/npm-cli.js")
+        monkeypatch.setattr(agent_link, "DSH_PROFILE_HOME", tmp_path)
+        monkeypatch.setattr(DshMonitor, "bundled_plugin_dir", classmethod(lambda cls: plugin))
+        monkeypatch.setattr(
+            agent_link.shutil, "which",
+            lambda name: "C:/Program Files/nodejs/node.exe" if name == "node" else None,
+        )
+
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            if cmd[1] == pnpm_cli:
+                manifest.write_text(
+                    json.dumps({"dependencies": {agent_link.DSH_PLUGIN_NAME: "file:bridge"}}),
+                    encoding="utf-8",
+                )
+            return type("Result", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+        monkeypatch.setattr(agent_link.subprocess, "run", fake_run)
+
+        ok, message = DshMonitor.install_bridge()
+
+        assert ok is True
+        assert "1 个 dsh 实例" in message
+        assert calls[0][0] == [
+            "C:/Program Files/nodejs/node.exe",
+            "C:/Program Files/nodejs/node_modules/npm/bin/npm-cli.js",
+            "install", "-g", "pnpm",
+        ]
+        assert calls[1][0] == [
+            "C:/Program Files/nodejs/node.exe", pnpm_cli, "add", str(plugin),
+        ]
+        assert json.loads(manifest.read_text(encoding="utf-8"))["dsh"]["profile"]["bundles"] == [
+            agent_link.DSH_PLUGIN_NAME
+        ]
+
     def test_extract_err_pnpm_line(self):
         output = """
         [1/4] Resolving packages...

--- a/tests/test_window_rendering.py
+++ b/tests/test_window_rendering.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from types import SimpleNamespace
 
 from PySide6.QtCore import QPoint, QRect, Qt
@@ -88,6 +89,57 @@ def test_is_transparent_at_uses_frame_alpha():
     assert window_mod.PetWindow._is_transparent_at(fake, QPoint(10, 10)) is False
     assert window_mod.PetWindow._is_transparent_at(fake, QPoint(50, 10)) is True
     assert window_mod.PetWindow._is_transparent_at(fake, QPoint(10, 2)) is True
+
+
+def test_hit_filter_reference_survives_init():
+    """回归：_hit_filter 不能在安装后被重置为 None（否则 GC 回收、命中测试静默失效）。"""
+    _qapp()
+    import sys
+    if sys.platform != "win32":
+        import pytest
+        pytest.skip("逐像素命中测试仅 Windows")
+
+    import tempfile
+    from pet.config import Config
+    from pet.library import MovieLibrary
+    lib = MovieLibrary(character_id='shenshen')
+    win = window_mod.PetWindow(lib, Config(base=Path(tempfile.mkdtemp())))
+    assert win._hit_filter is not None, "_hit_filter 被后置的 = None 覆盖，过滤器会被 GC 回收"
+    win.close()
+
+
+def test_hit_filter_hwnd_attribute():
+    """回归：wintypes.MSG 的窗口句柄字段是 hWnd（大写 W），写错会被 except 静默吞掉。"""
+    _qapp()
+    import sys
+    if sys.platform != "win32":
+        import pytest
+        pytest.skip("逐像素命中测试仅 Windows")
+
+    import ctypes, tempfile
+    from ctypes import wintypes
+    from pet.config import Config
+    from pet.library import MovieLibrary
+    lib = MovieLibrary(character_id='shenshen')
+    win = window_mod.PetWindow(lib, Config(base=Path(tempfile.mkdtemp())))
+    filt = win._hit_filter
+    assert filt is not None
+
+    msg = wintypes.MSG()
+    msg.hWnd = int(win.winId())
+    msg.message = 0x0084  # WM_NCHITTEST
+    win.move(-3000, -3000)  # 屏幕外避免干扰
+    win.show()
+    import time; time.sleep(1)
+    QApplication.processEvents()
+
+    # 人物中心 → HTCLIENT(1)；窗口边缘空白 → HTTRANSPARENT(-1)
+    # lParam: 低位 = x, 高位 = y（带符号 16 位）
+    gx, gy = -3000 + 230, -3000 + 162
+    msg.lParam = ((gy & 0xFFFF) << 16) | (gx & 0xFFFF)
+    result = filt.nativeEventFilter(b"windows_generic_MSG", ctypes.addressof(msg))
+    assert result[0] is True and result[1] == 1, f"人物中心应返回 HTCLIENT，实际 {result}"
+    win.close()
 
 
 def test_visible_content_rect_uses_character_region():

--- a/tests/test_window_rendering.py
+++ b/tests/test_window_rendering.py
@@ -91,8 +91,8 @@ def test_is_transparent_at_uses_frame_alpha():
     assert window_mod.PetWindow._is_transparent_at(fake, QPoint(10, 2)) is True
 
 
-def test_hit_filter_reference_survives_init():
-    """回归：_hit_filter 不能在安装后被重置为 None（否则 GC 回收、命中测试静默失效）。"""
+def test_input_controller_survives_init():
+    """回归：控制器必须由窗口持有，保证轮询持续运行。"""
     _qapp()
     import sys
     if sys.platform != "win32":
@@ -104,42 +104,58 @@ def test_hit_filter_reference_survives_init():
     from pet.library import MovieLibrary
     lib = MovieLibrary(character_id='shenshen')
     win = window_mod.PetWindow(lib, Config(base=Path(tempfile.mkdtemp())))
-    assert win._hit_filter is not None, "_hit_filter 被后置的 = None 覆盖，过滤器会被 GC 回收"
+    assert win._input_controller is not None
     win.close()
 
 
-def test_hit_filter_hwnd_attribute():
-    """回归：wintypes.MSG 的窗口句柄字段是 hWnd（大写 W），写错会被 except 静默吞掉。"""
+def test_input_controller_returns_pixel_hit_result():
     _qapp()
-    import sys
-    if sys.platform != "win32":
-        import pytest
-        pytest.skip("逐像素命中测试仅 Windows")
 
-    import ctypes, tempfile
-    from ctypes import wintypes
-    from pet.config import Config
-    from pet.library import MovieLibrary
-    lib = MovieLibrary(character_id='shenshen')
-    win = window_mod.PetWindow(lib, Config(base=Path(tempfile.mkdtemp())))
-    filt = win._hit_filter
-    assert filt is not None
+    class FakeWindow:
+        def winId(self):
+            return 123
 
-    msg = wintypes.MSG()
-    msg.hWnd = int(win.winId())
-    msg.message = 0x0084  # WM_NCHITTEST
-    win.move(-3000, -3000)  # 屏幕外避免干扰
-    win.show()
-    import time; time.sleep(1)
-    QApplication.processEvents()
+        def mapFromGlobal(self, point):
+            return point
 
-    # 人物中心 → HTCLIENT(1)；窗口边缘空白 → HTTRANSPARENT(-1)
-    # lParam: 低位 = x, 高位 = y（带符号 16 位）
-    gx, gy = -3000 + 230, -3000 + 162
-    msg.lParam = ((gy & 0xFFFF) << 16) | (gx & 0xFFFF)
-    result = filt.nativeEventFilter(b"windows_generic_MSG", ctypes.addressof(msg))
-    assert result[0] is True and result[1] == 1, f"人物中心应返回 HTCLIENT，实际 {result}"
-    win.close()
+        def _is_transparent_at(self, point):
+            return point.x() >= 50
+
+    fake = FakeWindow()
+    fake.mouse_through = False
+    fake._press_global = None
+    fake.isVisible = lambda: True
+    fake.width = lambda: 100
+    fake.height = lambda: 80
+    controller = object.__new__(window_mod.WindowsPerPixelInputController)
+    controller._window = fake
+    assert controller.should_click_through(QPoint(20, 20)) is False
+    assert controller.should_click_through(QPoint(70, 20)) is True
+    fake._press_global = QPoint(70, 20)
+    assert controller.should_click_through(QPoint(70, 20)) is False
+
+
+def test_windows_click_through_preserves_other_extended_styles():
+    class FakeUser32:
+        def __init__(self):
+            self.style = 0x00080080  # WS_EX_LAYERED | WS_EX_TOOLWINDOW
+            self.writes = []
+
+        def GetWindowLongW(self, hwnd, index):
+            assert (hwnd, index) == (123, window_mod.GWL_EXSTYLE)
+            return self.style
+
+        def SetWindowLongW(self, hwnd, index, style):
+            self.style = style
+            self.writes.append((hwnd, index, style))
+
+    user32 = FakeUser32()
+    assert window_mod._set_windows_click_through(123, True, user32) is True
+    assert user32.style == 0x000800A0
+    assert window_mod._set_windows_click_through(123, True, user32) is False
+    assert len(user32.writes) == 1
+    assert window_mod._set_windows_click_through(123, False, user32) is True
+    assert user32.style == 0x00080080
 
 
 def test_visible_content_rect_uses_character_region():


### PR DESCRIPTION
## 修复内容

### 1. 逐像素命中测试从未生效（双重失效）

v4.0.2 引入的 `WindowsPerPixelHitTestFilter` 实际上从未工作过：

- **过滤器被 GC 回收**：`PetWindow.__init__` 中 `_hit_filter` 在安装后被重新赋值为 `None`，`installNativeEventFilter` 不接管 Python 对象所有权，过滤器被垃圾回收，命中测试静默失效。
- **MSG 字段名拼写错误**：`msg.hwnd` 应为 `msg.hWnd`（`wintypes.MSG` 字段名），`AttributeError` 被 `except Exception` 静默吞掉。

修复：初始化顺序调整（先赋 None 再安装）+ 字段名修正。

### 2. HTTRANSPARENT 无法穿透到其他进程窗口

修复上述 bug 后发现：即使正确返回 `HTTRANSPARENT`，Windows 也只对**同线程窗口**继续命中测试，无法穿透到其他应用窗口（如浏览器）。点击透明区域后桌宠不响应但下面的窗口也收不到——点击被"吞掉"。

修复：改用 `WindowsPerPixelInputController`，10ms 轮询全局光标位置 + 当前帧 alpha：
- 光标在透明区域 → 动态添加 `WS_EX_TRANSPARENT`，Windows 跳过桌宠 HWND
- 光标在角色区域 → 移除该样式，恢复正常点击/拖拽/右键

不使用 `setMask`/`SetWindowRgn`，不破坏 `WA_TranslucentBackground` 的半透明渲染。

### 3. DSH 桥接插件安装失败（无 pnpm）

B站评论区反馈：用户有 Node.js + npm 但没有 pnpm，安装桥接插件报"找不到"。

修复：`_pnpm_cli()` 找不到 pnpm 时自动用 `npm install -g pnpm` 安装，装完继续原流程。报错信息区分"缺 node"和"缺 pnpm"。

## 测试

- 新增回归测试：过滤器引用存活断言、hWnd 字段名、HTCLIENT/HTTRANSPARENT 返回值、WS_EX_TRANSPARENT 动态切换、pnpm 自动安装流程
- 全量 `pytest -q`：457 passed / 5 skipped
- Windows 实机验证：点击桌宠透明区域成功穿透到下面窗口（前台窗口切换），点击角色身上正常触互动
