### PR TITLE
fix(ci): 修复 Windows 官方包中文乱码并加产物编码自检（issue #26）

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -12,6 +12,11 @@ permissions:
 jobs:
   build-linux:
     runs-on: ubuntu-latest  # x86_64；PyInstaller 不支持交叉编译，必须在 Linux 上构建
+    # 编码隔离（issue #26）：强制 UTF-8 模式，避免任何环节按 legacy 编码
+    # 二次解码中文源码/资源（PYTHONIOENCODING 只解决控制台输出）。
+    env:
+      PYTHONUTF8: '1'
+      PYTHONIOENCODING: utf-8
 
     steps:
       - name: Checkout
@@ -77,6 +82,17 @@ jobs:
               $EXCLUDES \
               "$ENTRY"
             if [ $? -ne 0 ]; then echo "::error::$VARIANT 构建失败"; exit 1; fi
+          done
+
+      # 中文编码自检（issue #26）：字节码字面量/文本资源/中文文件名被
+      # 编码污染即失败，绝不发布乱码包（与 Windows build_onedir.ps1 一致）。
+      - name: Chinese-encoding self-check on bundles
+        run: |
+          for VARIANT in webm-chat webm; do
+            APP="dist/dsh-pet-standalone-$VARIANT"
+            echo "==> checking $APP"
+            python scripts/check_bundle_encoding.py --dir "$APP"
+            if [ $? -ne 0 ]; then echo "::error::$APP 中文编码自检失败（issue #26）"; exit 1; fi
           done
 
       - name: Verify pet module collected

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -12,6 +12,11 @@ permissions:
 jobs:
   build-macos:
     runs-on: macos-latest   # Apple Silicon（arm64）；Intel 用户请用源码运行
+    # 编码隔离（issue #26）：强制 UTF-8 模式，避免任何环节按 legacy 编码
+    # 二次解码中文源码/资源（PYTHONIOENCODING 只解决控制台输出）。
+    env:
+      PYTHONUTF8: '1'
+      PYTHONIOENCODING: utf-8
 
     steps:
       - name: Checkout
@@ -75,6 +80,17 @@ jobs:
               $EXCLUDES \
               "$ENTRY"
             if [ $? -ne 0 ]; then echo "::error::$VARIANT 构建失败"; exit 1; fi
+          done
+
+      # 中文编码自检（issue #26）：字节码字面量/文本资源/中文文件名被
+      # 编码污染即失败，绝不发布乱码包（与 Windows build_onedir.ps1 一致）。
+      - name: Chinese-encoding self-check on bundles
+        run: |
+          for VARIANT in webm-chat webm; do
+            APP="dist/dsh-pet-standalone-$VARIANT.app"
+            echo "==> checking $APP"
+            python scripts/check_bundle_encoding.py --dir "$APP"
+            if [ $? -ne 0 ]; then echo "::error::$APP 中文编码自检失败（issue #26）"; exit 1; fi
           done
 
       - name: Verify pet module collected

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,4 +1,4 @@
-﻿name: Build Windows App
+name: Build Windows App
 
 on:
   workflow_dispatch:        # 手动触发（Actions 页面 → Run workflow）
@@ -12,9 +12,11 @@ permissions:
 jobs:
   build-windows:
     runs-on: windows-latest
-    # PYTHONIOENCODING：Windows 英文 runner 控制台为 cp1252，make_icon.py 等
-    # 脚本的中文 print 会 UnicodeEncodeError，统一按 UTF-8 输出。
+    # 编码隔离（issue #26）：PYTHONIOENCODING 只解决控制台输出，
+    # PYTHONUTF8=1 让 locale.getpreferredencoding() 恒为 utf-8，杜绝
+    # PyInstaller/辅助脚本按 GBK/cp1252 二次解码中文源码或资源。
     env:
+      PYTHONUTF8: '1'
       PYTHONIOENCODING: utf-8
 
     steps:

--- a/scripts/build_onedir.ps1
+++ b/scripts/build_onedir.ps1
@@ -13,6 +13,13 @@
       gif-chat    - GIF assets + AI chat (run with -Gif to generate GIFs first)
       gif         - GIF assets, no chat
 
+    Encoding isolation (issue #26):
+      The whole build runs with PYTHONUTF8=1 + PYTHONIOENCODING=utf-8 so neither
+      PyInstaller nor the helper scripts can decode UTF-8 sources/resources with
+      a legacy codepage (GBK/cp1252). After PyInstaller, an encoding self-check
+      (scripts\check_bundle_encoding.py) scans the bundle's bytecode/resources/
+      filenames for known Chinese literals and fails the build if any are garbled.
+
     Examples:
       powershell -ExecutionPolicy Bypass -File scripts\build_onedir.ps1
       powershell -ExecutionPolicy Bypass -File scripts\build_onedir.ps1 -Variant webm -SkipZip
@@ -21,12 +28,20 @@ param(
     [string]$Variant = 'webm-chat',
     [switch]$SkipBuild,
     [switch]$SkipZip,
+    [switch]$SkipCheck,
     [switch]$Gif
 )
 
 $ErrorActionPreference = 'Stop'
 $root = Split-Path -Parent $PSScriptRoot
 Set-Location $root
+
+# 编码隔离（issue #26）：整个构建过程强制 UTF-8。
+# - PYTHONIOENCODING 只解决控制台 print 中文；PYTHONUTF8=1 让 Python 的
+#   locale.getpreferredencoding() 恒为 utf-8，杜绝 PyInstaller/辅助脚本按
+#   GBK/cp1252 二次解码源码或资源（乱码包根因）。
+$env:PYTHONUTF8 = '1'
+$env:PYTHONIOENCODING = 'utf-8'
 
 $variants = @{
     'webm-chat' = @{ Name = 'dsh-pet-standalone-webm-chat'; Entry = 'packaging\pet_entry.py' }
@@ -71,8 +86,15 @@ if (-not $SkipBuild) {
     if ($LASTEXITCODE -ne 0) { throw "make_icon failed: $LASTEXITCODE" }
 
     Write-Host "[1/3] PyInstaller --onedir building $name ..." -ForegroundColor Cyan
-    # 注入变体标识：配置目录/会话/开机自启按变体隔离（pet/config.py 读取）
-    Set-Content -Path 'packaging\build_variant.py' -Value "VARIANT = '$Variant'" -Encoding UTF8
+    # 注入变体标识：配置目录/会话/开机自启按变体隔离（pet/config.py 读取）。
+    # 必须写 BOM-free UTF-8：PowerShell 5.1 的 Set-Content -Encoding UTF8 会带
+    # BOM，且内容若含中文再被旧编辑器按 GBK 另存就会污染产物（issue #26）。
+    $variantPy = Join-Path $root 'packaging\build_variant.py'
+    [System.IO.File]::WriteAllText(
+        $variantPy,
+        "VARIANT = '$Variant'`n",
+        [System.Text.UTF8Encoding]::new($false)
+    )
     python -m PyInstaller --noconfirm --clean --onedir --windowed --noupx `
         --name $name `
         --distpath dist-onedir `
@@ -96,6 +118,16 @@ if (-not $SkipBuild) {
 
 $appDir = Join-Path $root "dist-onedir\$name"
 if (-not (Test-Path $appDir)) { throw "Build output missing: $appDir" }
+
+# 中文编码自检（issue #26）：字节码字面量/文本资源/中文文件名任一项被
+# 编码污染即中止，绝不把乱码包发出去。
+if (-not $SkipCheck) {
+    Write-Host "[1.5/3] Chinese-encoding self-check on bundle..." -ForegroundColor Cyan
+    python scripts\check_bundle_encoding.py --dir $appDir
+    if ($LASTEXITCODE -ne 0) {
+        throw "Bundle encoding check failed — refusing to package garbled output (issue #26)"
+    }
+}
 
 if (-not $SkipZip) {
     Write-Host "[2/3] Packing portable zip..." -ForegroundColor Cyan

--- a/scripts/check_bundle_encoding.py
+++ b/scripts/check_bundle_encoding.py
@@ -1,0 +1,310 @@
+# -*- coding: utf-8 -*-
+"""打包产物中文编码自检（issue #26：官方 Windows 包中文乱码）。
+
+在 PyInstaller 构建完成后扫描产物目录，验证中文字面量在包内保持原样，
+发现污染立即以非零退出码中止发布，防止再次发出乱码包：
+
+1. Python 字节码（<name>.pyz / base_library.zip / 散落 .pyc）：
+   反序列化 code 对象，收集全部字符串常量，断言已知中文字面量
+   （吃Token/写代码/深色玻璃 等）原样存在。若构建环节把 UTF-8 源码
+   按 GBK/cp1252 二次解码再编译，字面量会变成「合法但错误」的乱码，
+   此检查必然失败；marshal 解析失败时退化为字节级扫描兜底。
+2. 打包的文本资源（.json/.qss/.txt/.md）：严格按 UTF-8 解码（容忍 BOM），
+   解码失败说明资源已被二次转码。
+3. 中文素材文件名（如 吃Token.webm）在包内必须存在。
+
+用法：
+    python scripts/check_bundle_encoding.py --dir dist-onedir/dsh-pet-standalone-webm-chat
+
+退出码：0 = 通过；1 = 发现乱码（构建脚本应中止并拒绝出包）。
+无 Qt 依赖；优先使用 PyInstaller 自带的 reader 解析 onedir exe/.app 内嵌的
+PYZ 字节码，未安装 PyInstaller 时退化为 zip/pyc/字节级扫描兜底。
+"""
+from __future__ import annotations
+
+import argparse
+import marshal
+import sys
+import zipfile
+import zlib
+from pathlib import Path
+from typing import Iterable
+
+# 这些字面量以原始中文形式存在于打包进所有变体的 .py 源码中
+# （catalog/agent_link/proactive/speech_bubble），编译后必在字节码常量里。
+EXPECTED_CODE_LITERALS = (
+    "吃Token",
+    "写代码",
+    "原地敲击桌面互动",
+    "深色玻璃",
+    "让我看看……",
+    "DSH 桥接插件安装失败",
+)
+
+# 必须原样存在的包内中文文件名（webm 变体；gif 变体同名换扩展名）
+EXPECTED_FILENAME_NEEDLES = ("吃Token",)
+
+# 必须能按 UTF-8 严格解码的文本资源扩展名（webm/音频等二进制不在此列）
+TEXT_SUFFIXES = (".json", ".qss", ".txt", ".md")
+
+_PYC_HEADER = 16  # CPython 3.7+ pyc 文件头长度（magic + flags + mtime + size）
+
+
+def _iter_code_constants(code, acc: set[str]) -> None:
+    """递归收集 code 对象及其嵌套 code 的全部字符串常量。"""
+    for const in getattr(code, "co_consts", ()) or ():
+        if isinstance(const, str):
+            acc.add(const)
+        elif hasattr(const, "co_consts"):
+            _iter_code_constants(const, acc)
+
+
+def scan_code_constants(data: bytes) -> set[str]:
+    """尝试把字节流按 code 对象（pyc/marshal）反序列化并收集字符串常量。
+
+    失败返回空集——调用方应退化到字节级扫描（见 ``_byte_scan_literals``）。
+    """
+    constants: set[str] = set()
+    candidates = (data, data[_PYC_HEADER:])
+    for candidate in candidates:
+        try:
+            obj = marshal.loads(candidate)
+        except Exception:
+            continue
+        if hasattr(obj, "co_consts"):
+            _iter_code_constants(obj, constants)
+        elif isinstance(obj, tuple):  # 老格式 pyc 顶层是 (magic, code)
+            for item in obj:
+                if hasattr(item, "co_consts"):
+                    _iter_code_constants(item, constants)
+    return constants
+
+
+def _byte_scan_literals(data: bytes, literals: Iterable[str]) -> set[str]:
+    """字节级兜底：直接查找字面量的 UTF-8 字节序列。
+
+    marshal 失败时使用。乱码编译产物中原始 UTF-8 字节必然缺失，
+    因此命中即证明该字面量在字节码里原样存在。
+    """
+    found: set[str] = set()
+    for literal in literals:
+        if literal.encode("utf-8") in data:
+            found.add(literal)
+    return found
+
+
+def _decompress_member(data: bytes) -> bytes:
+    """PyInstaller PYZ 成员默认 zlib 压缩；存储模式直接返回原始字节。"""
+    try:
+        return zlib.decompress(data)
+    except zlib.error:
+        return data
+
+
+def scan_zip_code_constants(path: Path, literals: Iterable[str]) -> set[str]:
+    """扫描 zip（<name>.pyz / base_library.zip）内全部字节码常量。"""
+    constants: set[str] = set()
+    literal_list = list(literals)
+    try:
+        with zipfile.ZipFile(path) as archive:
+            for info in archive.infolist():
+                if not info.filename.endswith(".pyc"):
+                    continue
+                try:
+                    raw = _decompress_member(archive.read(info))
+                except Exception:
+                    continue
+                found = scan_code_constants(raw)
+                if found:
+                    constants |= found
+                else:
+                    constants |= _byte_scan_literals(raw, literal_list)
+    except (OSError, zipfile.BadZipFile):
+        pass
+    return constants
+
+
+def scan_pyc_file_constants(path: Path, literals: Iterable[str]) -> set[str]:
+    """扫描散落的单个 .pyc 文件。"""
+    try:
+        raw = path.read_bytes()
+    except OSError:
+        return set()
+    found = scan_code_constants(raw)
+    if found:
+        return found
+    return _byte_scan_literals(raw, literals)
+
+
+def _iter_pyinstaller_executables(root: Path):
+    """返回 PyInstaller onedir 产物中可能嵌入 CArchive 的主程序路径。
+
+    Windows 是根目录下的 .exe；macOS .app 是 Contents/MacOS 下的可执行文件；
+    Linux 是根目录下无扩展名的可执行文件（通常与目录同名）。
+    """
+    if root.name.endswith(".app"):
+        macos_dir = root / "Contents" / "MacOS"
+        if macos_dir.is_dir():
+            for path in macos_dir.iterdir():
+                if path.is_file():
+                    yield path
+            return
+    for path in root.iterdir():
+        if not path.is_file():
+            continue
+        if path.suffix.lower() == ".exe" or path.suffix == "":
+            yield path
+
+
+def scan_pyinstaller_executables(root: Path, literals: Iterable[str]) -> set[str]:
+    """扫描 onedir 可执行文件内嵌的 CArchive/PYZ 字节码常量。
+
+    PyInstaller onedir 的工程模块字节码位于主程序内嵌的 PYZ（ZlibArchive）里，
+    顶层入口脚本位于 CArchive 的 PYSOURCE 条目中——两者都不是磁盘上的 .pyz
+    文件，必须用 PyInstaller reader 解析。未安装 PyInstaller 时返回空集。
+    """
+    try:
+        from PyInstaller.archive.readers import CArchiveReader
+        from PyInstaller.archive.readers import PKG_ITEM_PYSOURCE, PKG_ITEM_PYZ
+    except Exception:
+        return set()
+
+    constants: set[str] = set()
+    literal_list = list(literals)
+    for exe in _iter_pyinstaller_executables(root):
+        try:
+            archive = CArchiveReader(str(exe))
+        except Exception:
+            continue
+        for name, entry in archive.toc.items():
+            typecode = entry[4]
+            try:
+                if typecode == PKG_ITEM_PYZ:
+                    pyz = archive.open_embedded_archive(name)
+                    for module_name in pyz.toc:
+                        try:
+                            obj = pyz.extract(module_name)
+                        except Exception:
+                            continue
+                        if hasattr(obj, "co_consts"):
+                            _iter_code_constants(obj, constants)
+                elif typecode == PKG_ITEM_PYSOURCE:
+                    data = archive.extract(name)
+                    if hasattr(data, "co_consts"):
+                        _iter_code_constants(data, constants)
+                    else:
+                        found = scan_code_constants(data)
+                        if found:
+                            constants |= found
+                        else:
+                            constants |= _byte_scan_literals(data, literal_list)
+            except Exception:
+                continue
+    return constants
+
+
+def collect_code_constants(root: Path, literals: Iterable[str]) -> set[str]:
+    """收集产物目录内全部字节码字符串常量。
+
+    优先扫描 onedir 主程序内嵌的 PYZ/PYSOURCE（真实发布形态），再补充扫描
+    zip/pyz/pyc 等散落字节码，覆盖非 onedir 或 build 目录场景。
+    """
+    constants: set[str] = set()
+    constants |= scan_pyinstaller_executables(root, literals)
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        if path.suffix == ".pyz" or path.name == "base_library.zip":
+            constants |= scan_zip_code_constants(path, literals)
+        elif path.suffix == ".pyc":
+            constants |= scan_pyc_file_constants(path, literals)
+    return constants
+
+
+def verify_text_resources(root: Path, suffixes: tuple[str, ...]) -> list[str]:
+    """严格 UTF-8 校验包内文本资源，返回解码失败的相对路径列表。"""
+    bad: list[str] = []
+    for path in root.rglob("*"):
+        if not path.is_file() or path.suffix.lower() not in suffixes:
+            continue
+        try:
+            path.read_text(encoding="utf-8-sig")  # 容忍 BOM，其余严格
+        except (OSError, UnicodeDecodeError):
+            bad.append(str(path.relative_to(root)))
+    return bad
+
+
+def verify_chinese_filenames(root: Path, needles: tuple[str, ...]) -> list[str]:
+    """校验包内存在包含指定中文串的文件名，返回缺失列表。"""
+    missing: list[str] = []
+    for needle in needles:
+        if not any(needle in path.name for path in root.rglob("*")):
+            missing.append(needle)
+    return missing
+
+
+def check_bundle(
+    root: Path,
+    code_literals: Iterable[str] = EXPECTED_CODE_LITERALS,
+    filename_needles: tuple[str, ...] = EXPECTED_FILENAME_NEEDLES,
+    text_suffixes: tuple[str, ...] = TEXT_SUFFIXES,
+) -> list[str]:
+    """对产物目录执行全部编码检查，返回错误信息列表（空 = 通过）。"""
+    errors: list[str] = []
+
+    constants = collect_code_constants(root, code_literals)
+    # 字节码常量可能包含完整句子（如 "深色玻璃 · 右上方"），因此按子串匹配：
+    # 只要某个常量里原样包含该中文片段，即认为该字面量未被编码污染。
+    found_literals = {
+        lit for lit in code_literals if any(lit in const for const in constants)
+    }
+    missing = [lit for lit in code_literals if lit not in found_literals]
+    if missing:
+        errors.append(
+            "字节码中缺少中文常量（疑似源码被按非 UTF-8 编码二次解码编译）: "
+            + ", ".join(missing)
+        )
+
+    bad_texts = verify_text_resources(root, text_suffixes)
+    if bad_texts:
+        errors.append(
+            "以下文本资源无法按 UTF-8 解码（疑似被二次转码）: "
+            + ", ".join(bad_texts)
+        )
+
+    missing_files = verify_chinese_filenames(root, filename_needles)
+    if missing_files:
+        errors.append("包内缺少中文名素材文件: " + ", ".join(missing_files))
+
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="PyInstaller 产物中文编码自检（issue #26）"
+    )
+    parser.add_argument(
+        "--dir",
+        required=True,
+        help="构建产物目录（如 dist-onedir/dsh-pet-standalone-webm-chat）",
+    )
+    args = parser.parse_args(argv)
+
+    root = Path(args.dir)
+    if not root.is_dir():
+        print(f"[encoding-check] 产物目录不存在: {root}", file=sys.stderr)
+        return 1
+
+    print(f"[encoding-check] 扫描产物目录: {root}")
+    errors = check_bundle(root)
+    if not errors:
+        print("[encoding-check] PASS: 中文编码检查全部通过（字面量/资源/文件名原样保持 UTF-8）")
+        return 0
+    print("[encoding-check] FAIL: 发现中文编码污染，拒绝出包：", file=sys.stderr)
+    for error in errors:
+        print(f"  - {error}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_bundle_encoding_check.py
+++ b/tests/test_bundle_encoding_check.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+"""打包产物中文编码自检脚本（scripts/check_bundle_encoding.py）单元测试。
+
+用合成目录模拟 PyInstaller 产物（pyz 压缩字节码 + 散落 pyc + 文本资源 +
+中文文件名），验证自检能：
+- 从字节码里找回中文字面量（marshal 路径与字节级兜底路径）；
+- 识别被乱码编译的字节码（字面量缺失 → FAIL）；
+- 识别被二次转码的文本资源（无法按 UTF-8 严格解码 → FAIL）；
+- 识别缺失的中文素材文件名。
+"""
+from __future__ import annotations
+
+import importlib.util
+import marshal
+import zipfile
+import zlib
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "check_bundle_encoding.py"
+
+
+def _load_checker():
+    spec = importlib.util.spec_from_file_location("check_bundle_encoding", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_CHECKER = _load_checker()
+
+
+@pytest.fixture(scope="module")
+def checker():
+    return _CHECKER
+
+
+def _make_pyc_bytes(code) -> bytes:
+    """模拟 PyInstaller pyz 内的成员：16 字节 pyc 头 + marshal 后的 code 对象。"""
+    return b"\x00" * 16 + marshal.dumps(code)
+
+
+def _make_module_code(literal: str):
+    """构造含中文字面量的模块级 code 对象（co_consts 里带该字符串）。"""
+    return compile(
+        f"VALUE = {literal!r}\ndef speak():\n    return VALUE\n",
+        "<synthetic>",
+        "exec",
+    )
+
+
+def _make_catalog_code(literals, garble: bool = False):
+    """构造含全部期望字面量的模块 code；garble 时把第一个字面量换成乱码。
+
+    字面量嵌在较长字符串常量里，模拟真实源码中「深色玻璃 · 右上方」这类
+    片段不是独立常量、但必须按子串命中的场景。
+    """
+    lines = "\n".join(
+        f"    L{i} = '前缀' + {lit!r} + '后缀'" for i, lit in enumerate(literals)
+    )
+    source = f"def catalog():\n{lines}\n    return [L0, L1, L2, L3, L4, L5]\n"
+    if garble:
+        source = source.replace(literals[0], "\u9d5a\ufffd" + literals[0][2:])
+    return compile(source, "<synthetic>", "exec")
+
+
+def _write_pyz(path: Path, members: dict[str, bytes]) -> None:
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as archive:
+        for name, data in members.items():
+            archive.writestr(name, zlib.compress(data))  # 模拟 PYZ 的 zlib 压缩
+
+
+class TestCodeConstantScan:
+    def test_finds_literals_in_marshalled_code(self, checker):
+        code = _make_module_code("吃Token")
+        found = checker.scan_code_constants(_make_pyc_bytes(code))
+        assert "吃Token" in found
+
+    def test_byte_scan_fallback_finds_utf8_literal(self, checker):
+        raw = "写代码".encode("utf-8") + b"\x00" * 64
+        assert checker._byte_scan_literals(raw, ["写代码"]) == {"写代码"}
+        assert checker._byte_scan_literals(raw, ["吃Token"]) == set()
+
+    def test_zip_scan_handles_compressed_members(self, checker, tmp_path):
+        pyz = tmp_path / "app.pyz"
+        _write_pyz(pyz, {"pet/catalog.pyc": _make_pyc_bytes(_make_module_code("原地敲击桌面互动"))})
+        found = checker.scan_zip_code_constants(pyz, ["原地敲击桌面互动", "写代码"])
+        assert "原地敲击桌面互动" in found
+        assert "写代码" not in found  # 不存在的字面量不会被误报为存在
+
+
+class TestBundleChecks:
+    def _build_bundle(self, tmp_path: Path, *, garble_code=False, garble_text=False) -> Path:
+        root = tmp_path / "app"
+        internal = root / "_internal"
+        internal.mkdir(parents=True)
+        literals = _CHECKER.EXPECTED_CODE_LITERALS
+        _write_pyz(
+            internal / "app.pyz",
+            {"pet/catalog.pyc": _make_pyc_bytes(_make_catalog_code(literals, garble_code))},
+        )
+        # 文本资源：正常 UTF-8 或 GBK 转码后的坏字节
+        menu = internal / "pet" / "menu_templates"
+        menu.mkdir(parents=True)
+        if garble_text:
+            (menu / "modern.json").write_bytes("新版菜单".encode("gbk"))
+        else:
+            (menu / "modern.json").write_text("新版菜单", encoding="utf-8")
+        # 中文素材文件名
+        videos = root / "assets" / "characters" / "shenshen" / "videos" / "random"
+        videos.mkdir(parents=True)
+        (videos / "吃Token.webm").write_bytes(b"fake")
+        return root
+
+    def test_clean_bundle_passes(self, checker, tmp_path):
+        root = self._build_bundle(tmp_path)
+        assert checker.check_bundle(root) == []
+
+    def test_garbled_bytecode_fails(self, checker, tmp_path):
+        root = self._build_bundle(tmp_path, garble_code=True)
+        errors = checker.check_bundle(root)
+        assert errors, "乱码字节码必须被检出"
+        assert "吃Token" in errors[0]
+
+    def test_garbled_text_resource_fails(self, checker, tmp_path):
+        root = self._build_bundle(tmp_path, garble_text=True)
+        errors = checker.check_bundle(root)
+        assert any("modern.json" in error for error in errors)
+
+    def test_missing_chinese_asset_fails(self, checker, tmp_path):
+        root = self._build_bundle(tmp_path)
+        (root / "assets" / "characters" / "shenshen" / "videos" / "random" / "吃Token.webm").unlink()
+        errors = checker.check_bundle(root)
+        assert any("吃Token" in error for error in errors)


### PR DESCRIPTION
Closes #26

## 改动
- 三平台 CI 统一设置 \PYTHONUTF8=1\，让 Python 的 \locale.getpreferredencoding()\ 恒为 utf-8，避免 PyInstaller/辅助脚本按 GBK/cp1252 二次解码 UTF-8 中文源码或资源（\PYTHONIOENCODING\ 只解决控制台输出）。
- \scripts/build_onedir.ps1\：整个本地构建强制 UTF-8；\packaging/build_variant.py\ 改为 BOM-free UTF-8 写入；打包 zip 前运行中文编码自检。
- 新增 \scripts/check_bundle_encoding.py\：解析 onedir 主程序内嵌 PYZ/PYSOURCE 字节码常量、严格校验文本资源 UTF-8、校验中文素材文件名；发现污染即失败，绝不发布乱码包。
- 新增 \	ests/test_bundle_encoding_check.py\ 单元测试。

## 验证
- \python -m pytest tests/test_bundle_encoding_check.py -q\：7 passed
- 用最小 PyInstaller onedir 构建验证过自检脚本能读取 exe 内嵌 PYZ 中的中文字面量。