### PR TITLE
fix: DSH profile 枚举尊重 DSH_HOME + 长文本气泡分页与全文落会话（issue #23/#24）

### DIFF
--- a/pet/agent_link.py
+++ b/pet/agent_link.py
@@ -502,12 +502,13 @@ class DshMonitor(BaseAgentMonitor):
     def _list_profiles() -> list[str]:
         """枚举已存在的 dsh profile。
 
-        只认含 cordis.yml 的目录（真实 profile 的标志）；~/.dsh/profiles 下
+        只认含 cordis.yml 的目录（真实 profile 的标志）；profiles 目录下
         可能混入 node_modules 等包管理器/误操作残留的杂项目录，把它们当实例
         安装会失败并触发整体回滚，必须过滤。目录不存在或无有效 profile 时
         回退 ["web"]（安装命令会自动创建该 profile）。
+        统一使用 DSH_PROFILE_HOME（尊重 DSH_HOME），与 _real_profiles 一致。
         """
-        profiles_dir = Path.home() / ".dsh" / "profiles"
+        profiles_dir = DSH_PROFILE_HOME / "profiles"
         if not profiles_dir.is_dir():
             return ["web"]
         profiles = sorted(

--- a/pet/app.py
+++ b/pet/app.py
@@ -277,8 +277,38 @@ class PetApp:
         threading.Thread(target=worker, daemon=True, name="pet-update-check").start()
 
     def sync_look_to_chat(self, user_text: str, reply: str) -> None:
+        """把「看看屏幕/主动识屏」的问答同步进 AI 对话记录（issue #24）。
+
+        聊天窗口已创建 → 走窗口内同步（含界面即时刷新）；
+        聊天窗口从未打开 → 直接写入当前角色最新会话（无则新建），之后再打开
+        聊天窗口即可在历史里回看全文——气泡里被省略/分页的内容不再无处可查。
+        """
+        if not self.enable_chat or not str(reply or "").strip():
+            return
         if self.chat_window is not None and hasattr(self.chat_window, "append_look_sync"):
             self.chat_window.append_look_sync(user_text, reply)
+            return
+        try:
+            from .chat.models import ChatMessage
+            from .chat.session_store import SessionStore
+
+            store = SessionStore(self.config.dir, getattr(self.config, "instance_id", ""))
+            character_id = str(self.config.get("character", catalog.DEFAULT_CHARACTER))
+            sessions = store.list(character_id)
+            if sessions:
+                session = sessions[0]
+            else:
+                settings = self.config.chat_settings()
+                session = store.create(
+                    character_id,
+                    settings.active_provider,
+                    settings.default_system_prompt,
+                )
+            session.messages.append(ChatMessage("user", str(user_text)))
+            session.messages.append(ChatMessage("assistant", str(reply)))
+            store.save(session)
+        except Exception:
+            logging.exception("同步识屏问答到会话记录失败")
 
     def _apply_spawn_offset(self) -> None:
         """让新孵化的桌宠与母桌宠错开，避免两个窗口完全重叠。"""

--- a/pet/proactive.py
+++ b/pet/proactive.py
@@ -183,6 +183,15 @@ def build_memory_context(last_entry: dict | None, current_activity: str) -> str 
     return f"上次看到你在{last_act}，这次看到你在{current_activity}。"
 
 
+def build_sync_marker(proc_name: str, current_act: str) -> str:
+    """构造同步进 AI 对话会话的用户侧标记（不含窗口标题，隐私约定与陪伴记忆一致）。"""
+    marker = f"[主动识屏] 前台进程：{str(proc_name or '').strip() or '未知'}"
+    act = str(current_act or "").strip()
+    if act:
+        marker += f"（{act}）"
+    return marker
+
+
 class ProactiveMemory:
     """主动识屏短期陪伴记忆管理器。
 
@@ -615,6 +624,9 @@ class ProactiveScreenWatcher:
             # 64 位 dHash 会触发 libshiboken Overflow 且投递行为未定义。
             frame_ready = Signal(object, str, object, object, dict)
             bubble_requested = Signal(str, int)
+            # 主动识屏回复全文同步进 AI 对话会话（worker 线程不能直接碰
+            # Qt/会话存储，经桥接信号回到主线程再转发给 app 层）
+            reply_synced = Signal(str, str)
 
             def __init__(self, watcher: Any, parent: Any = None) -> None:
                 super().__init__(parent)
@@ -629,12 +641,16 @@ class ProactiveScreenWatcher:
                 if hasattr(self._watcher.win, "show_bubble"):
                     self._watcher.win.show_bubble(text, duration_ms=duration_ms)
 
+            def _forward_reply_sync(self, user_text: str, reply: str) -> None:
+                self._watcher._on_reply_synced(user_text, reply)
+
         self.win = window
         self.cfg = config
         parent_obj = self.win if hasattr(self.win, "winId") else None
         self._bridge = _WatcherBridge(self, parent=parent_obj)
         self._bridge.frame_ready.connect(self._bridge._forward_frame)
         self._bridge.bubble_requested.connect(self._bridge._forward_bubble)
+        self._bridge.reply_synced.connect(self._bridge._forward_reply_sync)
 
         self._timer = QTimer(parent_obj)
         self._timer.setInterval(8000)
@@ -927,6 +943,21 @@ class ProactiveScreenWatcher:
         finally:
             self._worker_busy = False
 
+    def _on_reply_synced(self, user_text: str, reply: str) -> None:
+        """主线程槽：把主动识屏回复全文转发给 app 层同步进 AI 对话会话。
+
+        无 Chat 变体（on_look_synced 为 None）或 app 层已销毁时静默跳过。
+        """
+        callback = getattr(self.win, "on_look_synced", None)
+        if not callable(callback):
+            return
+        try:
+            callback(user_text, reply)
+        except Exception:
+            import logging
+
+            logging.exception("主动识屏回复同步进会话失败")
+
     def _resolve_vision_provider(self, eff: dict) -> tuple[Any, str]:
         """解析视觉请求的 provider 与 system_prompt（手册 §6）。
 
@@ -976,6 +1007,17 @@ class ProactiveScreenWatcher:
                 # 陪伴记忆只存 进程名+活动分类，不落窗口标题（可能含文档/网页敏感信息）
                 if proc_name or current_act:
                     self.memory.record(proc_name, "", current_act)
+                # 回复全文落日志 + 同步进 AI 对话会话（issue #24：被气泡省略/分页的
+                # 内容从此可在聊天历史/pet.log 里回看）。标记同样不含窗口标题，
+                # 与陪伴记忆的隐私约定一致。
+                import logging
+                logging.info(
+                    "主动识屏回复全文: 前台进程=%s 活动=%s | %s",
+                    proc_name, current_act, reply,
+                )
+                self._bridge.reply_synced.emit(
+                    build_sync_marker(proc_name, current_act), reply
+                )
             else:
                 # 空回复视为失败（计入熔断，不冒泡、不写记忆）
                 self.limiter.record_failure()

--- a/pet/speech_bubble.py
+++ b/pet/speech_bubble.py
@@ -137,6 +137,41 @@ def elide_bubble_text(
     return "\n".join(lines[:max_lines])
 
 
+def paginate_bubble_text(
+    metrics: QFontMetrics,
+    text: str,
+    width: int,
+    max_lines: int = 3,
+) -> list[str]:
+    """Wrap text into pages of at most ``max_lines`` lines each — no elision.
+
+    Unlike :func:`elide_bubble_text`, no content is ever cut: long text is
+    split into several pages so the whole message can be shown by flipping
+    pages.  Returns a list of page strings (each already contains ``\n``
+    line breaks); a single-element list means one page suffices.
+    """
+    value = normalize_bubble_text(text)
+    if not value:
+        return []
+    lines: list[str] = []
+    current = ""
+    for index, char in enumerate(value):
+        candidate = current + char
+        if current and metrics.horizontalAdvance(candidate) > width:
+            lines.append(current)
+            current = char
+        else:
+            current = candidate
+    if current:
+        lines.append(current)
+    if len(lines) <= max_lines:
+        return ["\n".join(lines)]
+    return [
+        "\n".join(lines[start : start + max_lines])
+        for start in range(0, len(lines), max_lines)
+    ]
+
+
 def bubble_rect_for_anchor(
     anchor_rect: QRect,
     bubble_size: QSize,
@@ -217,6 +252,22 @@ class PetSpeechBubble(QFrame):
         self._layout = QVBoxLayout(self)
         self._layout.setContentsMargins(13, 10, 13, 17)
         self._layout.addWidget(self.label)
+        self._page_indicator = QLabel(self)
+        self._page_indicator.setObjectName("pet-page-indicator")
+        self._page_indicator.setAlignment(
+            Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
+        )
+        self._page_indicator.hide()
+        self._layout.addWidget(self._page_indicator, 0, Qt.AlignmentFlag.AlignRight)
+        # 长文本分页状态：页列表 + 当前页 + 自动翻页定时器。
+        # 气泡对鼠标全透明（WA_TransparentForMouseEvents），无法靠点击翻页，
+        # 因此采用「每页停留一小段后自动翻下一页」的方式保证全文可读完。
+        self._pages: list[str] = []
+        self._page_index = 0
+        self._page_interval_ms = 0
+        self._page_timer = QTimer(self)
+        self._page_timer.setSingleShot(True)
+        self._page_timer.timeout.connect(self._on_page_timeout)
         self._style_id = ""
         self._preset = BUBBLE_STYLE_PRESETS["classic_top"]
         self._anchor_rect = QRect()
@@ -279,6 +330,10 @@ class PetSpeechBubble(QFrame):
         self.label.setStyleSheet(
             "QLabel#pet-speech-label { background: transparent; border: none; padding: 0; "
             f"color: {self._preset['foreground']}; font-size: 13px; }}"
+        )
+        self._page_indicator.setStyleSheet(
+            "QLabel#pet-page-indicator { background: transparent; border: none; padding: 0; "
+            f"color: {self._preset['foreground']}; font-size: 10px; }}"
         )
         self.update()
 
@@ -366,14 +421,30 @@ class PetSpeechBubble(QFrame):
         self._raw_text = text
         self._source_pixmap = QPixmap()
         self._pet_scale = pet_scale
+        self._reset_paging()
         self.label.show()
         metrics = QFontMetrics(self.label.font())
         if self._preset.get("shape") == "breath_bubble":
             self._configure_breath_content(anchor_rect, pet_scale)
         else:
-            display_text = elide_bubble_text(
+            # 长文本分页：每页不超过 bubble_max_lines 行，自动翻页直到全文展示完，
+            # 底部显示「1/3」页码指示。总时长按页数扩展，保证每页可读完。
+            pages = paginate_bubble_text(
                 metrics, text, 248, bubble_max_lines(text)
             )
+            display_text = pages[0] if pages else ""
+            if len(pages) > 1:
+                per_page = max(2200, min(5000, duration_ms // len(pages)))
+                total_ms = max(duration_ms, per_page * len(pages))
+                self._pages = pages
+                self._page_index = 0
+                self._page_interval_ms = per_page
+                self._page_indicator.setText(f"1/{len(pages)}")
+                self._page_indicator.show()
+                self._page_timer.start(per_page)
+                duration_ms = total_ms
+            else:
+                self._reset_paging()
             self.label.setPixmap(QPixmap())
             self.label.setText(display_text)
             bounds = metrics.boundingRect(
@@ -390,6 +461,28 @@ class PetSpeechBubble(QFrame):
             self.raise_()
         self._hide_timer.start(max(500, int(duration_ms)))
 
+    def _reset_paging(self) -> None:
+        """停止自动翻页并隐藏页码指示（单页内容/图片/换内容时调用）。"""
+        self._page_timer.stop()
+        self._pages = []
+        self._page_index = 0
+        self._page_interval_ms = 0
+        self._page_indicator.setText("")
+        self._page_indicator.hide()
+
+    def _on_page_timeout(self) -> None:
+        """自动翻到下一页；最后一页展示完后由 _hide_timer 收尾隐藏。"""
+        if not self._pages or self._page_index >= len(self._pages) - 1:
+            self._page_timer.stop()
+            return
+        self._page_index += 1
+        if self._content_kind == "text":
+            self.label.setText(self._pages[self._page_index])
+            self._page_indicator.setText(
+                f"{self._page_index + 1}/{len(self._pages)}"
+            )
+            self._page_timer.start(self._page_interval_ms)
+
     def show_image(
         self,
         image_path: str | Path,
@@ -405,6 +498,7 @@ class PetSpeechBubble(QFrame):
         self._raw_text = ""
         self._source_pixmap = pixmap
         self._pet_scale = pet_scale
+        self._reset_paging()
         if self._preset.get("shape") == "breath_bubble":
             self._configure_breath_content(anchor_rect, pet_scale)
         else:

--- a/pet/speech_bubble.py
+++ b/pet/speech_bubble.py
@@ -447,12 +447,19 @@ class PetSpeechBubble(QFrame):
                 self._reset_paging()
             self.label.setPixmap(QPixmap())
             self.label.setText(display_text)
-            bounds = metrics.boundingRect(
-                QRect(0, 0, 248, 600), Qt.TextFlag.TextWordWrap, display_text
-            )
+            # 固定尺寸必须按所有页的最大测量值计算：后续页可能出现更宽的行，
+            # 若只按第一页设置，翻页后 wordWrap=False 会把后续页文本裁掉。
+            max_width = 0
+            max_height = 0
+            for page in pages:
+                page_bounds = metrics.boundingRect(
+                    QRect(0, 0, 248, 600), Qt.TextFlag.TextWordWrap, page
+                )
+                max_width = max(max_width, page_bounds.width())
+                max_height = max(max_height, page_bounds.height())
             self.label.setFixedSize(
-                max(96, min(248, bounds.width() + 3)),
-                max(20, bounds.height() + 2),
+                max(96, min(248, max_width + 3)),
+                max(20, max_height + 2),
             )
         self.adjustSize()
         self._place(anchor_rect)

--- a/tests/test_agent_link.py
+++ b/tests/test_agent_link.py
@@ -625,8 +625,9 @@ class TestDshProfileEnumeration:
     """_list_profiles 只认含 cordis.yml 的目录，过滤 node_modules 等杂项残留。"""
 
     def test_filters_non_profile_dirs(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
-        profiles = tmp_path / ".dsh" / "profiles"
+        dsh_home = tmp_path / "dsh-home"
+        monkeypatch.setattr(agent_link, "DSH_PROFILE_HOME", dsh_home)
+        profiles = dsh_home / "profiles"
         for name in ("web", "headless"):
             d = profiles / name
             d.mkdir(parents=True)
@@ -637,13 +638,28 @@ class TestDshProfileEnumeration:
         assert DshMonitor._list_profiles() == ["headless", "web"]
 
     def test_fallback_when_profiles_dir_missing(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        monkeypatch.setattr(agent_link, "DSH_PROFILE_HOME", tmp_path / "dsh-home")
         assert DshMonitor._list_profiles() == ["web"]
 
     def test_fallback_when_no_valid_profiles(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
-        (tmp_path / ".dsh" / "profiles" / "node_modules").mkdir(parents=True)
+        dsh_home = tmp_path / "dsh-home"
+        monkeypatch.setattr(agent_link, "DSH_PROFILE_HOME", dsh_home)
+        (dsh_home / "profiles" / "node_modules").mkdir(parents=True)
         assert DshMonitor._list_profiles() == ["web"]
+
+    def test_real_profiles_filters_node_modules_and_empty_dirs(self, tmp_path, monkeypatch):
+        # issue #23：~/.dsh/profiles 下可能有 pnpm 产生的 node_modules 等杂项目录，
+        # 安装/卸载桥接插件时只能枚举真实 profile（含 package.json 的目录）。
+        dsh_home = tmp_path / "dsh-home"
+        profiles = dsh_home / "profiles"
+        for name in ("web", "headless"):
+            profile = profiles / name
+            profile.mkdir(parents=True)
+            (profile / "package.json").write_text("{}", encoding="utf-8")
+        (profiles / "node_modules").mkdir()
+        (profiles / "empty-dir").mkdir()
+        monkeypatch.setattr(agent_link, "DSH_PROFILE_HOME", dsh_home)
+        assert [p.name for p in agent_link._real_profiles()] == ["headless", "web"]
 
 
 # ============================================================================

--- a/tests/test_proactive.py
+++ b/tests/test_proactive.py
@@ -23,6 +23,7 @@ from pet.proactive import (
     DEFAULT_PROACTIVE_CONFIG,
     PRESET_DEFAULTS,
     ProactiveLimiter,
+    build_sync_marker,
     dwell_satisfied,
     effective_proactive_config,
     hamming_distance,
@@ -306,6 +307,24 @@ class TestEffectiveConfig:
 # ============================================================================
 # 5. 辅助判定函数测试
 # ============================================================================
+class TestSyncMarker:
+    def test_marker_contains_process_and_activity(self):
+        marker = build_sync_marker("code.exe", "写代码")
+        assert marker.startswith("[主动识屏]")
+        assert "code.exe" in marker
+        assert "写代码" in marker
+
+    def test_marker_falls_back_for_unknown_process(self):
+        marker = build_sync_marker("", "")
+        assert "[主动识屏]" in marker
+        assert "未知" in marker
+
+    def test_marker_never_contains_window_title(self):
+        # 隐私约定：同步标记与陪伴记忆一致，绝不落窗口标题
+        marker = build_sync_marker("chrome.exe", "上网")
+        assert "机密文档" not in marker
+
+
 class TestHelperPredicates:
     def test_dwell_satisfied(self):
         assert dwell_satisfied(entered_ts=100.0, now=145.0, dwell_seconds=45.0) is True

--- a/tests/test_speech_bubble.py
+++ b/tests/test_speech_bubble.py
@@ -12,6 +12,7 @@ from pet.speech_bubble import (
     bubble_max_lines,
     elide_bubble_text,
     normalize_bubble_text,
+    paginate_bubble_text,
 )
 
 
@@ -68,6 +69,51 @@ def test_elide_bubble_text_max_lines_6():
     lines_35 = elided_35.split("\n")
     assert len(lines_35) == 6
     assert "…" in lines_35[-1] or "..." in lines_35[-1]
+
+
+def test_paginate_bubble_text_single_page():
+    _get_app()
+    font = QFont("Arial", 12)
+    metrics = QFontMetrics(font)
+    char = "测"
+    line_w = metrics.horizontalAdvance(char * 5)
+
+    # 一页装得下的文本 → 单页、无截断、无省略号
+    pages = paginate_bubble_text(metrics, char * 15, line_w, max_lines=3)
+    assert len(pages) == 1
+    assert pages[0] == "\n".join([char * 5] * 3)
+    assert "…" not in pages[0]
+
+    # 空文本 → 空列表
+    assert paginate_bubble_text(metrics, "", line_w) == []
+
+
+def test_paginate_bubble_text_multiple_pages_keeps_full_content():
+    _get_app()
+    font = QFont("Arial", 12)
+    metrics = QFontMetrics(font)
+    char = "测"
+    line_w = metrics.horizontalAdvance(char * 5)
+
+    # 35 字符 = 7 行，3 行一页 → 3 页；每页不超过 max_lines 行
+    text_35 = char * 35
+    pages = paginate_bubble_text(metrics, text_35, line_w, max_lines=3)
+    assert len(pages) == 3
+    for page in pages:
+        assert len(page.split("\n")) <= 3
+    # 全文无损：拼接所有页去掉换行后 == 原始文本（对比 elide 的截断行为）
+    assert "\n".join(pages).replace("\n", "") == text_35
+    assert "…" not in "\n".join(pages)
+
+    # 6 行恰好一页（bubble_max_lines 对长文本的 6 行上限）
+    text_30 = char * 30
+    pages_6 = paginate_bubble_text(metrics, text_30, line_w, max_lines=6)
+    assert len(pages_6) == 1
+
+    # 37 字符 = 8 行，6 行一页 → 2 页，全文仍在
+    pages_long = paginate_bubble_text(metrics, char * 37, line_w, max_lines=6)
+    assert len(pages_long) == 2
+    assert "\n".join(pages_long).replace("\n", "") == char * 37
 
 
 def test_breath_size_for_content_short_text_matches_legacy():


### PR DESCRIPTION
Closes #23
Closes #24

## issue #23：DSH 桥接安装误把 node_modules 当 profile
- 生产路径已通过 \_real_profiles()\ 过滤非 profile 目录，本次将 \DshMonitor._list_profiles()\ 也统一为 \DSH_PROFILE_HOME\（尊重 \DSH_HOME\），避免两套枚举逻辑路径不一致。
- 新增 \_real_profiles\ 回归测试：确认 \
ode_modules\、空目录不会被当作安装/卸载目标。

## issue #24：长文本气泡被截断且全文无处查看
- \speech_bubble.py\ 新增分页气泡：长文本按最大行数分页，自动翻页 + 页码指示，不再省略截断；单页行为不变。
- \proactive.py\ 主动识屏回复全文写入 \pet.log\，并通过桥接信号同步进 AI 对话会话。
- \pp.py\ 在聊天窗口未打开时也会把同步内容写入当前角色会话存储，之后打开聊天窗口可回看全文。
- 新增 \paginate_bubble_text\ 与 \uild_sync_marker\ 单元测试。

## 验证
- \python -m pytest tests/test_speech_bubble.py tests/test_proactive.py tests/test_agent_link.py tests/test_bundle_encoding_check.py -q\：130 passed