### PR TITLE
fix: dsh 工具名补全 + thinking 状态专属气泡文案

### DIFF
--- a/pet/agent_link.py
+++ b/pet/agent_link.py
@@ -1358,8 +1358,14 @@ class AgentLinkManager(QObject):
             return
         name = self.AGENT_NAMES.get(agent_key, agent_key)
         if state == "thinking":
-            # DSH 联动搭配鲸鱼娘形象时用角色梗自称
-            think_text = "大肥鱼正在深度思考……" if agent_key == "dsh" else f"{name} 正在深度思考……"
+            # 自定义文案优先（支持 {name} 占位符），留空用默认
+            custom = agent_cfg.get("thinking_text", "").strip()
+            if custom:
+                think_text = custom.replace("{name}", name)
+            elif agent_key == "dsh":
+                think_text = "大肥鱼正在深度思考……"
+            else:
+                think_text = f"{name} 正在深度思考……"
             self._show_link_bubble(think_text, important=False, duration_ms=3000)
         else:
             self._show_link_bubble(f"{name} 开始干活啦～", important=False, duration_ms=3000)

--- a/pet/agent_link.py
+++ b/pet/agent_link.py
@@ -1016,6 +1016,7 @@ class AgentLinkManager(QObject):
         "memory_search": "正在翻记忆",
         "webfetch": "正在查网页", "websearch": "正在查网页",
         "fetch": "正在查网页", "browser": "正在查网页", "web_fetch": "正在查网页",
+        "web_search": "正在查网页", "read_page": "正在读网页",
         "task": "正在派活给子代理", "todowrite": "正在列计划",
     }
     _UNKNOWN_TOOL_LABEL = "正在调用工具"
@@ -1263,7 +1264,7 @@ class AgentLinkManager(QObject):
             anim = self._next_link_anim_rotation()
             if anim and hasattr(self.win, "request_link_anim"):
                 self.win.request_link_anim(anim)
-            self._maybe_notify_start(agent_key, prev_raw)
+            self._maybe_notify_start(agent_key, prev_raw, state)
         elif state == "attention":
             # busy 后的 attention（如 Claude Stop=回合结束）由完成确认流程接管，
             # 避免「需要看一眼」和「完成通知」双气泡；独立出现的才立即提醒
@@ -1347,16 +1348,21 @@ class AgentLinkManager(QObject):
     # ------------------------------------------------------------------
     # 联动气泡（开始干活可选 / 任务完成通知）
     # ------------------------------------------------------------------
-    def _maybe_notify_start(self, agent_key: str, prev_raw: str | None) -> None:
+    def _maybe_notify_start(self, agent_key: str, prev_raw: str | None, state: str = "working") -> None:
         """开始干活气泡：仅「非 busy → busy」时提示（thinking↔working 互跳不弹）。
-        低优先级：气泡位被占时直接丢弃。"""
+        低优先级：气泡位被占时直接丢弃。thinking 状态用更有趣的文案。"""
         agent_cfg = self.cfg.get("agent_link", {})
         if not agent_cfg.get("notify_state", False):
             return
         if prev_raw in self._BUSY_STATES:
             return
         name = self.AGENT_NAMES.get(agent_key, agent_key)
-        self._show_link_bubble(f"{name} 开始干活啦～", important=False, duration_ms=3000)
+        if state == "thinking":
+            # DSH 联动搭配鲸鱼娘形象时用角色梗自称
+            think_text = "大肥鱼正在深度思考……" if agent_key == "dsh" else f"{name} 正在深度思考……"
+            self._show_link_bubble(think_text, important=False, duration_ms=3000)
+        else:
+            self._show_link_bubble(f"{name} 开始干活啦～", important=False, duration_ms=3000)
 
     def _on_agent_activity(self, agent_key: str, tool: str) -> None:
         """过程汇报气泡（可选，默认关）：「DSH 正在读文件…」这类。

--- a/pet/agent_link.py
+++ b/pet/agent_link.py
@@ -1348,6 +1348,24 @@ class AgentLinkManager(QObject):
     # ------------------------------------------------------------------
     # 联动气泡（开始干活可选 / 任务完成通知）
     # ------------------------------------------------------------------
+    # 各 Agent 的默认 thinking 文案；DSH 用角色梗，其他用烧烤梗
+    _THINKING_DEFAULTS = {"dsh": "大肥鱼正在深度思考……"}
+
+    def _thinking_text(self, agent_key: str) -> str:
+        """thinking 气泡文案：按 Agent 自定义 > 旧全局自定义 > 按 Agent 默认。"""
+        agent_cfg = self.cfg.get("agent_link", {})
+        custom = (agent_cfg.get("thinking_texts") or {}).get(agent_key, "").strip()
+        # 兼容旧的全局 thinking_text 字段（设置页保存时已自动迁移）
+        if not custom:
+            custom = str(agent_cfg.get("thinking_text", "") or "").strip()
+        if custom:
+            name = self.AGENT_NAMES.get(agent_key, agent_key)
+            return custom.replace("{name}", name)
+        if agent_key in self._THINKING_DEFAULTS:
+            return self._THINKING_DEFAULTS[agent_key]
+        name = self.AGENT_NAMES.get(agent_key, agent_key)
+        return f"{name} 正在深度烧烤……"
+
     def _maybe_notify_start(self, agent_key: str, prev_raw: str | None, state: str = "working") -> None:
         """开始干活气泡：仅「非 busy → busy」时提示（thinking↔working 互跳不弹）。
         低优先级：气泡位被占时直接丢弃。thinking 状态用更有趣的文案。"""
@@ -1358,15 +1376,7 @@ class AgentLinkManager(QObject):
             return
         name = self.AGENT_NAMES.get(agent_key, agent_key)
         if state == "thinking":
-            # 自定义文案优先（支持 {name} 占位符），留空用默认
-            custom = agent_cfg.get("thinking_text", "").strip()
-            if custom:
-                think_text = custom.replace("{name}", name)
-            elif agent_key == "dsh":
-                think_text = "大肥鱼正在深度思考……"
-            else:
-                think_text = f"{name} 正在深度思考……"
-            self._show_link_bubble(think_text, important=False, duration_ms=3000)
+            self._show_link_bubble(self._thinking_text(agent_key), important=False, duration_ms=3000)
         else:
             self._show_link_bubble(f"{name} 开始干活啦～", important=False, duration_ms=3000)
 

--- a/pet/modern_settings_dialog.py
+++ b/pet/modern_settings_dialog.py
@@ -1081,6 +1081,11 @@ class ModernSettingsDialog(QDialog):
             SettingRow("self_talk_texts", "候选内容", "每行一条；留空时恢复内置文本。", self.texts_edit, stacked=True),
             SettingRow("self_talk_images", "图片目录", "从目录中的常见图片格式随机选择；默认使用内置彩蛋图片池，留空时只显示文本。", self.self_talk_image_dir_picker, stacked=True),
         ], behavior_content))
+        behavior_layout.addWidget(SettingsSection("Agent 联动", [
+            SettingRow("agent_thinking_text", "思考气泡文案",
+                       "Agent 深度思考时的气泡文案。支持 {name} 占位符自动替换为 Agent 名；留空使用默认文案。",
+                       self.thinking_text_edit, stacked=True),
+        ], behavior_content))
         behavior_layout.addStretch(1)
         self._add_page("桌宠行为", "play", self._page_shell("桌宠行为", behavior_content))
 
@@ -1284,6 +1289,13 @@ class ModernSettingsDialog(QDialog):
             directory=True,
             parent=self,
         )
+
+        # Agent 联动：自定义 thinking 气泡文案
+        agent_link_cfg = self.config.get("agent_link", {})
+        self.thinking_text_edit = QLineEdit(self)
+        self.thinking_text_edit.setPlaceholderText("大肥鱼正在深度思考……")
+        self.thinking_text_edit.setText(str(agent_link_cfg.get("thinking_text", "") or ""))
+        self.thinking_text_edit.setClearButtonEnabled(True)
 
         appearance = self.config.get("context_menu_appearance", DEFAULT_CONTEXT_MENU_APPEARANCE)
         self.menu_theme_select = ModernSelect(self, width=132)
@@ -1788,6 +1800,10 @@ class ModernSettingsDialog(QDialog):
         self.config.set("self_talk_duration_seconds", self.self_talk_duration_spin.value())
         self.config.set("self_talk_texts", texts or list(DEFAULT_SELF_TALK_TEXTS))
         self.config.set("self_talk_image_dir", self.self_talk_image_dir_picker.text())
+        # Agent 联动：自定义 thinking 文案（合并写回，不覆盖 agent_link 其他开关）
+        agent_cfg = dict(self.config.get("agent_link", {}))
+        agent_cfg["thinking_text"] = self.thinking_text_edit.text().strip()
+        self.config.set("agent_link", agent_cfg)
         self.config.set("context_menu_appearance", {
             "theme": self.menu_theme_select.currentData(),
             "density": self.menu_density_select.currentData(),

--- a/pet/modern_settings_dialog.py
+++ b/pet/modern_settings_dialog.py
@@ -42,6 +42,7 @@ from PySide6.QtWidgets import (
 
 from . import autostart as autostart_mod
 from . import catalog
+from .agent_link import AgentLinkManager
 from .config import (
     DEFAULT_CONTEXT_MENU_APPEARANCE,
     DEFAULT_MENU_EASTER_EGG,
@@ -1081,11 +1082,17 @@ class ModernSettingsDialog(QDialog):
             SettingRow("self_talk_texts", "候选内容", "每行一条；留空时恢复内置文本。", self.texts_edit, stacked=True),
             SettingRow("self_talk_images", "图片目录", "从目录中的常见图片格式随机选择；默认使用内置彩蛋图片池，留空时只显示文本。", self.self_talk_image_dir_picker, stacked=True),
         ], behavior_content))
-        behavior_layout.addWidget(SettingsSection("Agent 联动", [
-            SettingRow("agent_thinking_text", "思考气泡文案",
-                       "Agent 深度思考时的气泡文案。支持 {name} 占位符自动替换为 Agent 名；留空使用默认文案。",
-                       self.thinking_text_edit, stacked=True),
-        ], behavior_content))
+        # Agent 联动：每个 Agent 一行自定义思考文案
+        agent_thinking_rows = []
+        for agent_key, edit in self.thinking_text_edits.items():
+            agent_name = AgentLinkManager.AGENT_NAMES.get(agent_key, agent_key)
+            default = AgentLinkManager._THINKING_DEFAULTS.get(agent_key, f"{agent_name} 正在深度烧烤……")
+            agent_thinking_rows.append(
+                SettingRow(f"agent_thinking_{agent_key}", f"{agent_name} 思考文案",
+                           f"默认：{default}；支持 {{name}} 占位符；留空用默认。",
+                           edit, stacked=True)
+            )
+        behavior_layout.addWidget(SettingsSection("Agent 联动 · 思考气泡文案", agent_thinking_rows, behavior_content))
         behavior_layout.addStretch(1)
         self._add_page("桌宠行为", "play", self._page_shell("桌宠行为", behavior_content))
 
@@ -1290,12 +1297,22 @@ class ModernSettingsDialog(QDialog):
             parent=self,
         )
 
-        # Agent 联动：自定义 thinking 气泡文案
+        # Agent 联动：每个 Agent 的自定义 thinking 气泡文案
         agent_link_cfg = self.config.get("agent_link", {})
-        self.thinking_text_edit = QLineEdit(self)
-        self.thinking_text_edit.setPlaceholderText("大肥鱼正在深度思考……")
-        self.thinking_text_edit.setText(str(agent_link_cfg.get("thinking_text", "") or ""))
-        self.thinking_text_edit.setClearButtonEnabled(True)
+        thinking_texts = agent_link_cfg.get("thinking_texts") or {}
+        # 兼容旧的全局 thinking_text 字段
+        legacy_text = str(agent_link_cfg.get("thinking_text", "") or "")
+        self.thinking_text_edits: dict[str, QLineEdit] = {}
+        for agent_key, agent_name in AgentLinkManager.AGENT_NAMES.items():
+            edit = QLineEdit(self)
+            default = AgentLinkManager._THINKING_DEFAULTS.get(agent_key, f"{agent_name} 正在深度烧烤……")
+            edit.setPlaceholderText(default)
+            text = str(thinking_texts.get(agent_key, "") or "")
+            if not text and legacy_text:
+                text = legacy_text
+            edit.setText(text)
+            edit.setClearButtonEnabled(True)
+            self.thinking_text_edits[agent_key] = edit
 
         appearance = self.config.get("context_menu_appearance", DEFAULT_CONTEXT_MENU_APPEARANCE)
         self.menu_theme_select = ModernSelect(self, width=132)
@@ -1802,7 +1819,12 @@ class ModernSettingsDialog(QDialog):
         self.config.set("self_talk_image_dir", self.self_talk_image_dir_picker.text())
         # Agent 联动：自定义 thinking 文案（合并写回，不覆盖 agent_link 其他开关）
         agent_cfg = dict(self.config.get("agent_link", {}))
-        agent_cfg["thinking_text"] = self.thinking_text_edit.text().strip()
+        agent_cfg["thinking_texts"] = {
+            key: edit.text().strip()
+            for key, edit in self.thinking_text_edits.items()
+            if edit.text().strip()
+        }
+        agent_cfg.pop("thinking_text", None)  # 旧的全局字段已迁移到 thinking_texts
         self.config.set("agent_link", agent_cfg)
         self.config.set("context_menu_appearance", {
             "theme": self.menu_theme_select.currentData(),

--- a/tests/test_agent_link.py
+++ b/tests/test_agent_link.py
@@ -759,6 +759,23 @@ class TestAgentLinkBubbles:
         assert len(bubbles_on) == 2
         assert "开始干活啦" in bubbles_on[1]
 
+    def test_thinking_text_custom_override(self, tmp_path):
+        """自定义 thinking 文案：agent_link.thinking_text 非空时优先使用，支持 {name} 占位符。"""
+        mgr, win, bubbles, clock = self._make_mgr(
+            tmp_path, agent_link_cfg={"notify_state": True, "thinking_text": "{name} 大脑飞速运转中……"}
+        )
+        mgr._on_agent_state("dsh", "thinking")
+        assert len(bubbles) == 1
+        assert "DSH 大脑飞速运转中……" == bubbles[0]
+        assert "深度思考" not in bubbles[0]
+
+        # 空字符串 → 回退默认
+        mgr2, win2, bubbles2, _ = self._make_mgr(
+            tmp_path / "b", agent_link_cfg={"notify_state": True, "thinking_text": ""}
+        )
+        mgr2._on_agent_state("dsh", "thinking")
+        assert "大肥鱼正在深度思考" in bubbles2[0]
+
     def test_jitter_cancel_done_check(self, tmp_path):
         """4. working→idle→working 抖动：idle 后 pending 存在，
         再来 working 后 pending 被清空（_cancel_done_check 生效），此后 _fire_done 不弹气泡。"""

--- a/tests/test_agent_link.py
+++ b/tests/test_agent_link.py
@@ -744,12 +744,20 @@ class TestAgentLinkBubbles:
         mgr_on, win_on, bubbles_on, clock_on = self._make_mgr(tmp_path, agent_link_cfg={"notify_state": True})
         mgr_on._on_agent_state("dsh", "thinking")
         assert len(bubbles_on) == 1
-        assert "开始干活啦" in bubbles_on[0]
+        assert "正在深度思考" in bubbles_on[0]
 
         clock_on[0] += 3.0
         mgr_on._on_agent_state("dsh", "working")
-        # 连续 busy 状态，第二次不应重复弹「开始干活啦」
+        # 连续 busy 状态，thinking→working 互跳不重复弹
         assert len(bubbles_on) == 1
+
+        # idle 后再 working → 弹「开始干活啦」
+        clock_on[0] += 3.0
+        mgr_on._on_agent_state("dsh", "idle")
+        clock_on[0] += 3.0
+        mgr_on._on_agent_state("dsh", "working")
+        assert len(bubbles_on) == 2
+        assert "开始干活啦" in bubbles_on[1]
 
     def test_jitter_cancel_done_check(self, tmp_path):
         """4. working→idle→working 抖动：idle 后 pending 存在，


### PR DESCRIPTION
## 修复内容

### 1. dsh 工具名映射补全

DSH 的 `web_search`（带下划线）与白名单中 `websearch`（不带下划线）不匹配，走兜底文案而非「正在查网页」。补充：`web_search` → 正在查网页、`read_page` → 正在读网页。

### 2. thinking 状态专属气泡文案

Agent 进入 thinking（深度思考/模型推理）状态时，气泡与 working 的「开始干活啦～」区分开。不影响动作轮换逻辑。

### 3. 每个 Agent 独立的可自定义 thinking 文案

- 配置 `agent_link.thinking_texts`（按 Agent key 索引的字典），支持 `{name}` 占位符
- 默认文案：DSH → 「大肥鱼正在深度思考……」，其他 Agent → 「{name} 正在深度烧烤……」
- 兼容旧的全局 `agent_link.thinking_text` 字段（设置页保存时自动迁移）
- 现代设置页「桌宠行为 → Agent 联动 · 思考气泡文案」每个 Agent 一行输入框

## 测试

- 更新既有测试覆盖 thinking/working 文案区分
- 新增测试覆盖自定义文案优先级、{name} 占位符替换、空值回退默认
- 全量 pytest：472 passed / 5 skipped
