### PR TITLE
fix(click): 消除首次点击/快速点击 Q 弹卡顿

### DIFF
--- a/pet/app.py
+++ b/pet/app.py
@@ -425,14 +425,14 @@ class PetApp:
         win.on_spawn_pet = self.spawn_pet
         win.on_restore_fun_windows = restore_ojingjing_windows
         win.on_hidden = self._notify_pet_hidden
-        win.show()
-
-        # 预热点击音效：首次创建 QSoundEffect/QMediaPlayer 池在部分 Windows
-        # 环境需要 50~240ms，若留到第一次点击时再做会造成 Q 弹开头卡顿。
-        QTimer.singleShot(0, lambda: warm_click_sound_effects(
+        # 预热点击音效：首次创建 QSoundEffect/QMediaPlayer 池并等待加载完成，
+        # 在显示窗口前完成，避免窗口出现后主线程被音频初始化阻塞、
+        # 首次点击 Q 弹卡顿。
+        warm_click_sound_effects(
             self.config.get("click_sound_pack"),
             data_dir=self.config.dir,
-        ))
+        )
+        win.show()
 
         tray = self._build_tray(win)
 
@@ -485,14 +485,14 @@ class PetApp:
         win.on_spawn_pet = self.spawn_pet
         win.on_restore_fun_windows = restore_ojingjing_windows
         win.on_hidden = self._notify_pet_hidden
-        win.show()
-
-        # 预热点击音效：首次创建 QSoundEffect/QMediaPlayer 池在部分 Windows
-        # 环境需要 50~240ms，若留到第一次点击时再做会造成 Q 弹开头卡顿。
-        QTimer.singleShot(0, lambda: warm_click_sound_effects(
+        # 预热点击音效：首次创建 QSoundEffect/QMediaPlayer 池并等待加载完成，
+        # 在显示窗口前完成，避免窗口出现后主线程被音频初始化阻塞、
+        # 首次点击 Q 弹卡顿。
+        warm_click_sound_effects(
             self.config.get("click_sound_pack"),
             data_dir=self.config.dir,
-        ))
+        )
+        win.show()
 
         tray = self._build_tray(win)
 

--- a/pet/click_sound.py
+++ b/pet/click_sound.py
@@ -15,6 +15,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
 import wave
 from collections.abc import Sequence
 from pathlib import Path
@@ -265,6 +266,19 @@ def _play_with_qt(path: Path, volume: float = 1.0) -> bool:
     return _player_pool_play(path, volume)
 
 
+def _effect_is_ready(effect: Any) -> bool:
+    """判断 QSoundEffect 是否已完成异步加载；无 status 的测试替身视为就绪。"""
+    status = getattr(effect, "status", None)
+    if not callable(status):
+        return True
+    try:
+        from PySide6.QtMultimedia import QSoundEffect
+
+        return status() == QSoundEffect.Status.Ready
+    except Exception:
+        return True
+
+
 def warm_click_sound_effects(
     pack: dict | None,
     data_dir: Path | None = None,
@@ -272,25 +286,64 @@ def warm_click_sound_effects(
 ) -> None:
     """预创建点击音效对象，避免首次点击时初始化 QtMultimedia 造成卡顿。
 
-    启动或切换音效包后调用：WAV/已缓存音频预创建 QSoundEffect，
-    非 WAV 至少预创建 QMediaPlayer 池；音频解码仍按需异步进行。
+    启动或切换音效包后调用：WAV/已缓存音频预创建 QSoundEffect 并等待加载完成；
+    未缓存的压缩音频启动异步解码并等待缓存生成；同时预创建 QMediaPlayer 池。
     limit 用于限制自定义文件夹随机音效的预热数量，避免一次创建过多对象。
     """
     if not _qt_available():
         return
     try:
+        from PySide6.QtCore import QCoreApplication
+
         _warm_player_pool()
+        effects: list[Any] = []
+        decoding: list[tuple[Path, Path, str]] = []
         candidates = resolve_click_sound_candidates(pack, data_dir)[:limit]
         for path in candidates:
             try:
                 if path.suffix.lower() == ".wav":
-                    _effect_for(path)
+                    effect = _effect_for(path)
+                    if effect is not None:
+                        effects.append(effect)
                 else:
                     cache = _cache_path(path)
                     if cache.is_file():
-                        _effect_for(cache)
+                        effect = _effect_for(cache)
+                        if effect is not None:
+                            effects.append(effect)
+                    else:
+                        key = str(path.resolve())
+                        if key not in _qt_decoders:
+                            _decode_to_wav(path, cache, 0.0)
+                        decoding.append((path, cache, key))
             except Exception:
                 log.exception("预热点击音效失败: %s", path)
+
+        # 等待压缩音频解码出 WAV 缓存（异步，QCoreApplication 泵事件完成回调）
+        deadline = time.monotonic() + 2.0
+        while decoding and time.monotonic() < deadline:
+            remaining: list[tuple[Path, Path, str]] = []
+            for path, cache, key in decoding:
+                if cache.is_file():
+                    effect = _effect_for(cache)
+                    if effect is not None:
+                        effects.append(effect)
+                elif key in _qt_decoders:
+                    remaining.append((path, cache, key))
+                # key 不在 _qt_decoders 且没有缓存 = 解码失败/超时，跳过
+            decoding = remaining
+            if decoding:
+                QCoreApplication.processEvents()
+                time.sleep(0.005)
+
+        # 等待 QSoundEffect 完成异步加载；未等待就播放会在事件循环里触发
+        # 一次性加载/初始化，造成首次点击 Q 弹卡顿（实测可达数百 ms）。
+        deadline = time.monotonic() + 2.0
+        while effects and time.monotonic() < deadline:
+            effects = [e for e in effects if not _effect_is_ready(e)]
+            if effects:
+                QCoreApplication.processEvents()
+                time.sleep(0.005)
     except Exception:
         log.exception("点击音效预热失败")
 

--- a/pet/library.py
+++ b/pet/library.py
@@ -226,9 +226,11 @@ class MovieLibrary(QObject):
             self.folder_map,
             self.folder_files,
         )
+        # 点击回应优先级最高：首次点击最怕同步 ffmpeg 解码（实测可达 600ms+），
+        # 先预热点击动画，避免用户刚启动就点击时卡顿。
         high = list(dict.fromkeys(
-            [*(cats['idles'] or []), *(cats['turns'] or []),
-             *(cats['moves'] or []), *(cats['clicks'] or [])]
+            [*(cats['clicks'] or []), *(cats['idles'] or []),
+             *(cats['turns'] or []), *(cats['moves'] or [])]
             + ([cats['drag']] if cats.get('drag') else [])
         ))
         low = [n for n in cats.get('acts', []) if n not in high]
@@ -273,7 +275,9 @@ class MovieLibrary(QObject):
 
     def _warm_all_meta_background(self) -> None:
         try:
-            time.sleep(random.uniform(0, 0.5))  # 多开错峰，避免 ffmpeg 进程洪峰
+            # 高优先级（尤其点击回应）尽快开始；保留极短随机错峰降低多开
+            # 同时拉起 ffmpeg 的峰值，但不再让首次点击等 0.5s 预热。
+            time.sleep(random.uniform(0, 0.05))
             # 并发控制在 3：每个 webm 首帧预热都会拉起一个 ffmpeg 子进程，
             # 并发过高会形成进程洪峰，提高杀毒软件拦截/误报概率。
             high, _ = self._priority_names()

--- a/pet/window.py
+++ b/pet/window.py
@@ -2117,16 +2117,28 @@ class PetWindow(QWidget):
             self.on_restore_fun_windows()
         if not self.clicks:
             return
-        # 点击可以打断当前动画（包括正在播放的点击回应），实现连续 Q 弹
+        # 点击可以打断当前动画（包括正在播放的点击回应），实现连续 Q 弹。
+        # 先让 Q 弹/动画立刻开始，音效放到下一轮事件循环，避免任何音频
+        # 初始化/文件扫描阻塞点击瞬间的画面更新。
         self._cancel_move()
-        self._play_click_sound()
         self._start_squash()
         self._switch(self._pick(self.clicks))
+        self._schedule_click_sound()
         if self.click_show_balance and callable(self.on_show_balance):
             self.on_show_balance(self)
         elif self.click_show_self_talk and self._self_talk_enabled:
             if self._show_random_self_talk():
                 self._schedule_self_talk(after_display=True)
+
+    def _schedule_click_sound(self) -> None:
+        if not self.click_sound_enabled:
+            return
+
+        def play() -> None:
+            if shiboken6.isValid(self):
+                self._play_click_sound()
+
+        QTimer.singleShot(0, play)
 
     def _play_click_sound(self) -> None:
         if not self.click_sound_enabled:

--- a/tests/test_library_priority_warm.py
+++ b/tests/test_library_priority_warm.py
@@ -79,6 +79,16 @@ def test_priority_names_split(tmp_path, monkeypatch):
     assert set(high).isdisjoint(low)
 
 
+def test_priority_names_click_before_idle(tmp_path, monkeypatch):
+    lib = _make_lib(tmp_path, monkeypatch)
+    high, _ = lib._priority_names()
+
+    # 点击回应必须优先于 idle/turn/move 预热：首次点击最怕同步 ffmpeg 解码卡顿。
+    assert high.index(catalog.CLICKS[0]) < high.index(catalog.IDLE)
+    assert high.index(catalog.CLICKS[0]) < high.index(catalog.TURN)
+    assert high.index(catalog.CLICKS[0]) < high.index(catalog.MOVES[0])
+
+
 def test_low_priority_warm_not_auto_started_then_scheduled(tmp_path, monkeypatch):
     from PySide6.QtWidgets import QApplication
 


### PR DESCRIPTION
## 问题

- 第一次点击桌宠时会有明显卡顿（实测可达数百 ms）
- 快速连点时仍会偶发小卡顿

## 根因

1. **音频预热不完整**：`warm_click_sound_effects` 之前只创建了 `QSoundEffect` 就返回，但 `QSoundEffect` 是**异步加载**的（Status.Loading → Ready）。首次真正 `play()` 时若还没 Ready，会在事件循环里触发一次性加载/初始化，造成数百 ms 卡顿。
2. **预热发生在窗口显示之后**：`QTimer.singleShot(0)` 会在窗口已经可见后阻塞主线程，用户如果立刻点击就会感到“第一次点击卡顿”。
3. **点击动画预热顺序靠后**：高优先级预热原顺序是 idle/turn/move/click，用户刚启动就点击时，点击动画首帧可能还没预热完，触发主线程同步 ffmpeg 解码（实测可达 600ms+）。
4. **音效播放与 Q 弹动画同一事件内同步执行**：音频文件扫描/播放会延迟画面更新。

## 修改

- `pet/click_sound.py`
  - `warm_click_sound_effects` 现在会等待 `QSoundEffect` 变为 `Ready` 再返回
  - 未缓存的 MP3/OGG 等会在预热时启动异步解码并等待 WAV 缓存生成
- `pet/app.py`
  - 点击音效预热改为**窗口显示前完成**，避免窗口出现后被音频初始化阻塞
- `pet/library.py`
  - 高优先级预热顺序改为 **click 优先**，点击动画首帧最先后台预热
  - 高优先级预热启动延迟从 0~0.5s 缩短为 0~0.05s
- `pet/window.py`
  - `_on_click` 先启动 Q 弹/切换动画，音效通过 `QTimer.singleShot(0)` 延迟到下一轮事件循环
- `tests/test_library_priority_warm.py`
  - 新增点击动画预热顺序回归测试

## 验证

- 本地实测：音频预热完成后，首次点击事件循环不再出现数百 ms 停顿
- 相关测试通过：`tests/test_click_sound.py`、`tests/test_library_priority_warm.py` 等
