### PR TITLE
fix(autostart): Chat/无 Chat 变体开机自启互不影响

### DIFF
--- a/pet/autostart.py
+++ b/pet/autostart.py
@@ -32,18 +32,9 @@ PLIST_LABEL = (
     else f"{_APP_BASE_ID}.{APP_DIR_NAME}"
 )
 # Windows 自启注册表值名按变体隔离（如 dsh-pet-standalone-webm-chat）。
-# 旧版本/旧目录可能残留多个值名，若只清理当前值名会导致“关闭后仍自启”
-# 或“开机出现两个桌宠/两个终端”，因此统一维护一份已知值名清单。
+# 每个变体只管理自己的值，避免“关无 Chat 版把 Chat 版也关了”。
 VALUE_NAME = APP_DIR_NAME
 RUN_KEY = r"Software\Microsoft\Windows\CurrentVersion\Run"
-# 历史/各变体可能写入过的值名；enable 时只保留当前变体，disable 时全部清除。
-KNOWN_VALUE_NAMES = (
-    "dsh-pet-standalone",
-    "dsh-pet-standalone-webm",
-    "dsh-pet-standalone-webm-chat",
-    "dsh-pet-standalone-gif",
-    "dsh-pet-standalone-gif-chat",
-)
 
 _IS_WIN = sys.platform == "win32"
 _IS_MAC = sys.platform == "darwin"
@@ -103,40 +94,8 @@ def _win_command_is_current(command: str) -> bool:
     return "cmd /c start" in command.lower()
 
 
-def _iter_known_win_values() -> list[tuple[str, str]]:
-    """读取注册表里所有已知 dsh-pet 自启值名，返回 [(name, command), ...]。"""
-    try:
-        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, RUN_KEY) as key:
-            found = []
-            for name in KNOWN_VALUE_NAMES:
-                try:
-                    command, _ = winreg.QueryValueEx(key, name)
-                except FileNotFoundError:
-                    continue
-                found.append((name, str(command or "")))
-            return found
-    except OSError:
-        return []
-
-
-def _delete_known_win_values(exclude: set[str] | None = None) -> None:
-    """删除已知 dsh-pet 自启值；exclude 里的值名保留。"""
-    exclude = exclude or set()
-    try:
-        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, RUN_KEY, 0, winreg.KEY_SET_VALUE) as key:
-            for name in KNOWN_VALUE_NAMES:
-                if name in exclude:
-                    continue
-                try:
-                    winreg.DeleteValue(key, name)
-                except FileNotFoundError:
-                    pass
-    except OSError:
-        pass
-
-
 def is_enabled() -> bool:
-    """当前是否已注册开机自启（任一已知 dsh-pet 值存在即视为已启用）。"""
+    """当前变体是否已注册开机自启（只查当前变体自己的注册表值）。"""
     if _IS_WIN:
         try:
             with winreg.OpenKey(winreg.HKEY_CURRENT_USER, RUN_KEY) as key:
@@ -160,8 +119,8 @@ def is_enabled() -> bool:
                         pass
                 return True
         except FileNotFoundError:
-            # 当前值名不存在，但历史残留值仍可能开机启动
-            return bool(_iter_known_win_values())
+            # 只认当前变体自己的值；其他变体的自启状态互不影响。
+            return False
     if _IS_MAC:
         return _plist_path().exists()
     if _IS_LINUX:
@@ -193,8 +152,7 @@ def enable() -> bool:
     """开启自启；返回是否写入成功（Windows 回读注册表验证，macOS 验证 plist 存在，Linux 验证 .desktop 存在）。"""
     if _IS_WIN:
         try:
-            # 先清掉历史/其他变体残留，避免开机同时启动多只桌宠/多个终端
-            _delete_known_win_values(exclude={VALUE_NAME})
+            # 只写当前变体自己的值，不影响其他 Chat/无 Chat 变体的自启状态。
             with winreg.OpenKey(winreg.HKEY_CURRENT_USER, RUN_KEY, 0, winreg.KEY_SET_VALUE) as key:
                 winreg.SetValueEx(key, VALUE_NAME, 0, winreg.REG_SZ, _win_command())
             # 回读验证，防止写入被安全软件/策略静默拦截
@@ -235,7 +193,11 @@ def disable() -> bool:
     """关闭自启；返回是否已清除。"""
     if _IS_WIN:
         try:
-            _delete_known_win_values()
+            with winreg.OpenKey(winreg.HKEY_CURRENT_USER, RUN_KEY, 0, winreg.KEY_SET_VALUE) as key:
+                try:
+                    winreg.DeleteValue(key, VALUE_NAME)
+                except FileNotFoundError:
+                    pass
             return True
         except OSError:
             return False

--- a/tests/test_autostart.py
+++ b/tests/test_autostart.py
@@ -1,12 +1,76 @@
 # -*- coding: utf-8 -*-
-"""开机自启模块测试（Linux XDG autostart 分支）。
-
-Windows 上通过 monkeypatch 平台标志 + XDG_CONFIG_HOME 模拟 Linux 行为。
-"""
+"""开机自启模块测试（Linux XDG autostart 分支 + Windows 变体隔离）。"""
 
 from pathlib import Path
 
 from pet import autostart as autostart_mod
+
+
+class FakeWinreg:
+    """极简 winreg 替身：用 dict 模拟 HKCU Run 值，验证变体互不影响。"""
+
+    HKEY_CURRENT_USER = object()
+    KEY_SET_VALUE = 1
+    REG_SZ = 1
+
+    def __init__(self):
+        self.values = {}
+
+    def OpenKey(self, root, subkey, reserved=0, access=0):
+        return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def QueryValueEx(self, key, name):
+        if name not in self.values:
+            raise FileNotFoundError(name)
+        return self.values[name], 1
+
+    def SetValueEx(self, key, name, reserved, value_type, value):
+        self.values[name] = value
+
+    def DeleteValue(self, key, name):
+        if name not in self.values:
+            raise FileNotFoundError(name)
+        del self.values[name]
+
+
+def _force_win(monkeypatch):
+    monkeypatch.setattr(autostart_mod, "_IS_WIN", True)
+    monkeypatch.setattr(autostart_mod, "_IS_MAC", False)
+    monkeypatch.setattr(autostart_mod, "_IS_LINUX", False)
+    fake = FakeWinreg()
+    monkeypatch.setattr(autostart_mod, "winreg", fake)
+    return fake
+
+
+def test_windows_autostart_variants_do_not_affect_each_other(monkeypatch):
+    fake = _force_win(monkeypatch)
+    monkeypatch.setattr(autostart_mod, "VALUE_NAME", "dsh-pet-standalone-webm")
+
+    assert autostart_mod.enable() is True
+    assert "dsh-pet-standalone-webm" in fake.values
+    assert autostart_mod.is_enabled() is True
+
+    # 切到 Chat 变体再开启：不应清掉无 Chat 版的自启
+    monkeypatch.setattr(autostart_mod, "VALUE_NAME", "dsh-pet-standalone-webm-chat")
+    assert autostart_mod.enable() is True
+    assert "dsh-pet-standalone-webm" in fake.values
+    assert "dsh-pet-standalone-webm-chat" in fake.values
+
+    # 关闭 Chat 版：无 Chat 版必须保留
+    assert autostart_mod.disable() is True
+    assert "dsh-pet-standalone-webm-chat" not in fake.values
+    assert "dsh-pet-standalone-webm" in fake.values
+
+    # is_enabled 只认当前变体自己的值
+    assert autostart_mod.is_enabled() is False
+    monkeypatch.setattr(autostart_mod, "VALUE_NAME", "dsh-pet-standalone-webm")
+    assert autostart_mod.is_enabled() is True
 
 
 def _force_linux(monkeypatch, tmp_path: Path):


### PR DESCRIPTION
## 问题

Chat 版和无 Chat 版的开机自启会互相影响：

- 关闭无 Chat 版的开机自启，Chat 版的自启也会被一起关掉
- 开启其中一个，另一个也会被清掉
- `is_enabled()` 会因其他变体的注册表值而误判为已开启

## 原因

`pet/autostart.py` 里 Windows 分支把所有 dsh-pet 变体的注册表值名当作一个整体管理：

- `disable()` 会删除 `KNOWN_VALUE_NAMES` 里的**全部**值
- `enable()` 会先删除其他变体的值
- `is_enabled()` 在当前值不存在时会回退检查其他已知值

## 修改

- `pet/autostart.py`
  - 每个变体只读写**自己的** HKCU Run 值名
  - `enable()` 不再删除其他变体
  - `disable()` 只删除当前变体
  - `is_enabled()` 只查询当前变体自己的值
  - 移除不再需要的全局 `KNOWN_VALUE_NAMES` / 批量删除逻辑
- `tests/test_autostart.py`
  - 新增 Windows 变体隔离回归测试：开启/关闭 Chat 不影响无 Chat，反之亦然

## 验证

- 全量测试：**523 passed / 5 skipped**
