### PR TITLE
feat: 第一批——灵动岛/聊天窗置顶/点击动画台词绑定

### DIFF
--- a/pet/app.py
+++ b/pet/app.py
@@ -43,9 +43,10 @@ class _BackgroundResult(QObject):
 
 
 class _BalanceBridge(_BackgroundResult):
-    def __init__(self, win):
+    def __init__(self, win, owner=None):
         super().__init__()
         self.win = win
+        self.owner = owner
         self.done.connect(self._show)
 
     def _show(self, ok: bool, payload) -> None:
@@ -56,6 +57,8 @@ class _BalanceBridge(_BackgroundResult):
             self.win.show_bubble(str(payload), duration_ms=6000)
             return
         _show_balance_payload(self.win, payload)
+        if self.owner is not None and hasattr(self.owner, "_update_island_balance"):
+            self.owner._update_island_balance(payload)
 
 
 def _show_balance_payload(win, payload) -> None:
@@ -218,6 +221,7 @@ class PetApp:
             self.island = DynamicIsland(self.config)
             self.island.clicked.connect(self._toggle_pet_from_island)
         self.island.refresh_from_config()
+        self.island.set_pet_visible(self.win.isVisible() if self.win is not None else True)
         self.island.show()
 
     def _toggle_pet_from_island(self) -> None:
@@ -228,6 +232,8 @@ class PetApp:
             win.hide(notify=False)
         else:
             win.show()
+        if getattr(self, "island", None) is not None:
+            self.island.set_pet_visible(win.isVisible())
 
     def _on_about_to_quit(self) -> None:
         """退出前保存当前有效窗口的位置。
@@ -309,7 +315,7 @@ class PetApp:
         # AppKit 抑制（与设置对话框首次点击无反应同源），singleShot 在 macOS
         # 上要等菜单关闭后才派发，Windows 上立即派发也无害。
         QTimer.singleShot(0, lambda: win.show_bubble('让我看看余额…', duration_ms=6000))
-        bridge = _BalanceBridge(win)
+        bridge = _BalanceBridge(win, owner=self)
         self._balance_bridge = bridge
         threading.Thread(
             target=self._balance_worker,
@@ -324,7 +330,6 @@ class PetApp:
             payload = {"text": text, "info": info}
             self._balance_cache = (time.monotonic(), payload, provider_key)
             self._write_balance_file_cache(payload, provider_key)
-            self._update_island_balance(payload)
             bridge.done.emit(True, payload)
         except Exception as exc:  # noqa: BLE001 - 任何失败走气泡提示
             bridge.done.emit(False, f'余额查询失败：{exc}')
@@ -728,6 +733,8 @@ class PetApp:
 
     def _notify_pet_hidden(self) -> None:
         """用户主动隐藏桌宠后弹托盘提示，指明恢复入口。"""
+        if getattr(self, "island", None) is not None:
+            self.island.set_pet_visible(False)
         if self.tray is None:
             return
         self.tray.showMessage(
@@ -745,6 +752,8 @@ class PetApp:
                 win.hide()
             else:
                 win.show()
+            if getattr(self, "island", None) is not None:
+                self.island.set_pet_visible(win.isVisible())
 
         menu = QMenu()
         # 气泡是置顶 Tool 窗口（层级高于原生菜单 popup），托盘菜单弹出前

--- a/pet/app.py
+++ b/pet/app.py
@@ -176,6 +176,7 @@ class PetApp:
         self.modern_chat_window = None
         self.chat_settings_dialog = None
         self.modern_settings_dialog = None
+        self.island = None
         self._spawned_pet_count = 0
         self._pending_dialog_opens: set[str] = set()
         self._balance_busy = False
@@ -198,9 +199,35 @@ class PetApp:
         character_id = str(self.config.get('character', catalog.DEFAULT_CHARACTER))
         logging.info('当前形象: %s', character_id)
         self._create_ui(character_id)
+        self._sync_dynamic_island()
         self._apply_spawn_offset()
         self._apply_balance_timer()
         QTimer.singleShot(3500, self._check_autostart_wanted)
+
+    def _sync_dynamic_island(self) -> None:
+        """按配置创建/隐藏灵动岛；桌宠隐藏后灵动岛仍可常驻。"""
+        island_cfg = self.config.get("dynamic_island", {})
+        enabled = bool(island_cfg.get("enabled", False)) if isinstance(island_cfg, dict) else False
+        if not enabled:
+            if getattr(self, "island", None) is not None:
+                self.island.hide()
+            return
+        if getattr(self, "island", None) is None:
+            from .dynamic_island import DynamicIsland
+
+            self.island = DynamicIsland(self.config)
+            self.island.clicked.connect(self._toggle_pet_from_island)
+        self.island.refresh_from_config()
+        self.island.show()
+
+    def _toggle_pet_from_island(self) -> None:
+        win = self.win
+        if win is None:
+            return
+        if win.isVisible():
+            win.hide(notify=False)
+        else:
+            win.show()
 
     def _on_about_to_quit(self) -> None:
         """退出前保存当前有效窗口的位置。
@@ -230,6 +257,25 @@ class PetApp:
         if minutes:
             self._balance_timer.start(minutes * 60000)
 
+    def _update_island_balance(self, payload) -> None:
+        """把余额文本/峰谷提示同步给灵动岛（若有）。"""
+        if getattr(self, "island", None) is None:
+            return
+        text = "余额 --"
+        info = {}
+        if isinstance(payload, dict):
+            text = str(payload.get("text") or "余额 --")
+            info = payload.get("info") or {}
+        peak_label, idle_label = balance_mod.resolve_tier_labels(
+            str(self.config.get("balance_tier_labels_mode", "default") or "default"),
+            str(self.config.get("balance_tier_label_peak", "") or ""),
+            str(self.config.get("balance_tier_label_idle", "") or ""),
+        )
+        hint = balance_mod.deepseek_pricing_hint(
+            peak_label=peak_label, idle_label=idle_label,
+        )
+        self.island.set_balance_info(hint, text)
+
     def show_balance(self, parent=None) -> None:
         win = parent or self.win
         if win is None or self._balance_busy or not win.isVisible():
@@ -249,11 +295,13 @@ class PetApp:
         ])
         if self._balance_cache is not None and now - self._balance_cache[0] < 30.0 \
                 and self._balance_cache[2] == provider_key:
+            self._update_island_balance(self._balance_cache[1])
             _show_balance_payload(win, self._balance_cache[1])
             return
         file_payload = self._read_balance_file_cache(provider_key)
         if file_payload is not None:
             self._balance_cache = (now, file_payload, provider_key)
+            self._update_island_balance(file_payload)
             _show_balance_payload(win, file_payload)
             return
         self._balance_busy = True
@@ -276,6 +324,7 @@ class PetApp:
             payload = {"text": text, "info": info}
             self._balance_cache = (time.monotonic(), payload, provider_key)
             self._write_balance_file_cache(payload, provider_key)
+            self._update_island_balance(payload)
             bridge.done.emit(True, payload)
         except Exception as exc:  # noqa: BLE001 - 任何失败走气泡提示
             bridge.done.emit(False, f'余额查询失败：{exc}')
@@ -512,6 +561,8 @@ class PetApp:
                 if chat_window is not None:
                     chat_window.set_pet_window(self.win)
                     chat_window.switch_character(character_id)
+        if getattr(self, "island", None) is not None:
+            self.island.refresh_from_config()
 
     def open_chat(self) -> None:
         """Open the configured chat UI; menus only need this stable dispatcher."""
@@ -670,6 +721,7 @@ class PetApp:
         # 此前只有 Accepted 才刷新：直接 X 关闭时保存生效但桌宠不更新。
         if self.win is not None:
             self.win.refresh_pet_settings()
+        self._sync_dynamic_island()
         self._apply_balance_timer()
         self._refresh_chat_windows()
         _mac_set_dock_icon_visible(bool(self.config.get("show_dock_icon", True)))

--- a/pet/app.py
+++ b/pet/app.py
@@ -221,7 +221,11 @@ class PetApp:
             self.island = DynamicIsland(self.config)
             self.island.clicked.connect(self._toggle_pet_from_island)
         self.island.refresh_from_config()
-        self.island.set_pet_visible(self.win.isVisible() if self.win is not None else True)
+        pet_visible = True
+        if self.win is not None:
+            is_visible = getattr(self.win, "isVisible", None)
+            pet_visible = bool(is_visible()) if callable(is_visible) else True
+        self.island.set_pet_visible(pet_visible)
         self.island.show()
 
     def _toggle_pet_from_island(self) -> None:
@@ -760,6 +764,22 @@ class PetApp:
         # 先隐藏气泡，避免气泡盖住菜单
         menu.aboutToShow.connect(lambda: win._speech_bubble.hide())
         menu.addAction('显示 / 隐藏', toggle_visible)
+
+        island_action = menu.addAction('灵动岛')
+        island_action.setCheckable(True)
+        island_action.setChecked(bool(
+            self.config.get("dynamic_island", {}).get("enabled", True)
+        ))
+
+        def toggle_island(enabled: bool) -> None:
+            island_cfg = dict(self.config.get("dynamic_island", {}) or {})
+            island_cfg["enabled"] = bool(enabled)
+            self.config.set("dynamic_island", island_cfg)
+            self.config.save()
+            self._sync_dynamic_island()
+
+        island_action.toggled.connect(toggle_island)
+
         if self.enable_chat:
             menu.addAction('AI 对话', self.open_chat)
             menu.addAction('AI 设置', self.open_chat_settings)
@@ -790,6 +810,9 @@ class PetApp:
             #（托盘菜单在 _build_tray 时一次性构建，不复用则不刷新会过期）
             mouse_through.setChecked(bool(self.config.get('mouse_through', False)))
             auto.setChecked(autostart_mod.is_enabled())
+            island_action.setChecked(bool(
+                self.config.get("dynamic_island", {}).get("enabled", True)
+            ))
 
         menu.aboutToShow.connect(sync_tray_checks)
 

--- a/pet/chat/legacy_styles.qss
+++ b/pet/chat/legacy_styles.qss
@@ -32,7 +32,8 @@ QLabel#subtitle-label {
     font-size: 10px;
 }
 QToolButton#window-minimize-button,
-QToolButton#window-close-button {
+QToolButton#window-close-button,
+QToolButton#window-pin-button {
     min-width: 32px;
     max-width: 32px;
     min-height: 32px;
@@ -49,6 +50,14 @@ QToolButton#window-minimize-button:hover {
 }
 QToolButton#window-close-button:hover {
     background: #ef6b73;
+    color: #ffffff;
+}
+QToolButton#window-pin-button:hover {
+    background: #334155;
+    color: #ffffff;
+}
+QToolButton#window-pin-button:checked {
+    background: #3994ff;
     color: #ffffff;
 }
 QFrame#chat-context-bar {

--- a/pet/chat/legacy_widgets.py
+++ b/pet/chat/legacy_widgets.py
@@ -343,6 +343,27 @@ class ChatWindow(QDialog):
         if self.follow_pet and self.isVisible():
             self.position_near_pet()
 
+    def toggle_always_on_top(self) -> None:
+        on = self.pin_button.isChecked()
+        self.config.set("chat_always_on_top", on)
+        self.config.save()
+        self.set_chat_always_on_top(on)
+
+    def set_chat_always_on_top(self, on: bool) -> None:
+        """切换聊天窗置顶；保留位置、尺寸与可见/激活状态。"""
+        was_visible = self.isVisible()
+        was_active = self.isActiveWindow()
+        geometry = self.geometry()
+        self.setWindowFlag(Qt.WindowType.WindowStaysOnTopHint, bool(on))
+        self.setGeometry(geometry)
+        if was_visible:
+            self.show()
+            if was_active:
+                self.activateWindow()
+        self.pin_button.blockSignals(True)
+        self.pin_button.setChecked(bool(on))
+        self.pin_button.blockSignals(False)
+
     def position_near_pet(self, pet_window=None, gap: int = 14) -> None:
         """Place the phone chat window beside the visible pet bounds."""
         pet = pet_window or self.pet_link.pet_window
@@ -448,6 +469,14 @@ class ChatWindow(QDialog):
         title_text.addWidget(self.subtitle_label)
         title_layout.addLayout(title_text)
         title_layout.addStretch(1)
+        self.pin_button = QToolButton()
+        self.pin_button.setObjectName("window-pin-button")
+        self.pin_button.setIcon(vector_widget_icon(self.pin_button, "pin", 16))
+        self.pin_button.setToolTip("窗口置顶")
+        self.pin_button.setAccessibleName("切换聊天窗口置顶")
+        self.pin_button.setCheckable(True)
+        self.pin_button.setChecked(bool(self.config.get("chat_always_on_top", False)))
+        title_layout.addWidget(self.pin_button)
         self.minimize_button = QToolButton()
         self.minimize_button.setObjectName("window-minimize-button")
         self.minimize_button.setIcon(self.style().standardIcon(QStyle.StandardPixmap.SP_TitleBarMinButton))
@@ -573,6 +602,7 @@ class ChatWindow(QDialog):
     def _connect(self) -> None:
         self.minimize_button.clicked.connect(self.showMinimized)
         self.close_button.clicked.connect(self.close)
+        self.pin_button.clicked.connect(self.toggle_always_on_top)
         self.new_session_button.clicked.connect(self.new_session)
         self.rename_session_button.clicked.connect(self.rename_current_session)
         self.delete_session_button.clicked.connect(self.delete_current_session)
@@ -873,6 +903,11 @@ class ChatWindow(QDialog):
         self._apply_character_theme()
         self._style()
         self._refresh_sessions()
+        desired_pin = bool(self.config.get("chat_always_on_top", False))
+        if desired_pin != bool(self.windowFlags() & Qt.WindowType.WindowStaysOnTopHint):
+            self.set_chat_always_on_top(desired_pin)
+        else:
+            self.pin_button.setChecked(desired_pin)
 
     def switch_character(self, character_id: str) -> None:
         if not character_id or character_id == self.character_id:

--- a/pet/chat/modern_styles.qss
+++ b/pet/chat/modern_styles.qss
@@ -64,13 +64,16 @@ QFrame#chat-main { background: #ffffff; border: none; border-top-right-radius: 1
 QFrame#chat-main-header { min-height: 55px; background: #ffffff; border: none; border-bottom: 1px solid #f0f1f4; border-top-right-radius: 13px; }
 QLabel#title-label { color: #252a32; font-size: 14px; font-weight: 600; }
 QLabel#subtitle-label { color: #7189c7; font-size: 10px; }
-QToolButton#sidebar-toggle-button, QToolButton#window-minimize-button, QToolButton#window-close-button {
+QToolButton#sidebar-toggle-button, QToolButton#window-minimize-button, QToolButton#window-close-button,
+QToolButton#window-pin-button {
     width: 29px; height: 29px; border: none; border-radius: 8px; background: transparent;
     color: #252a32; /* 深色系统下无 QSS color 会落到 palette 白字，白底上看不清 */
 }
 QToolButton#sidebar-toggle-button:hover { background: #f0f2f5; }
 QToolButton#window-minimize-button:hover { background: #f0f2f5; }
 QToolButton#window-close-button:hover { background: #fbe8e8; }
+QToolButton#window-pin-button:hover { background: #f0f2f5; }
+QToolButton#window-pin-button:checked { color: #ffffff; background: @ACCENT@; }
 QScrollArea#message-scroll, QScrollArea#message-scroll QWidget#qt_scrollarea_viewport,
 QWidget#message-view, QWidget#message-timeline { background: #ffffff; border: none; }
 QLabel#empty-state { color: #969da8; font-size: 14px; }

--- a/pet/chat/widgets.py
+++ b/pet/chat/widgets.py
@@ -894,6 +894,27 @@ class ChatWindow(QDialog):
         if self.follow_pet and self.isVisible():
             self.position_near_pet()
 
+    def toggle_always_on_top(self) -> None:
+        on = self.pin_button.isChecked()
+        self.config.set("chat_always_on_top", on)
+        self.config.save()
+        self.set_chat_always_on_top(on)
+
+    def set_chat_always_on_top(self, on: bool) -> None:
+        """切换聊天窗置顶；保留位置、尺寸与可见/激活状态。"""
+        was_visible = self.isVisible()
+        was_active = self.isActiveWindow()
+        geometry = self.geometry()
+        self.setWindowFlag(Qt.WindowType.WindowStaysOnTopHint, bool(on))
+        self.setGeometry(geometry)
+        if was_visible:
+            self.show()
+            if was_active:
+                self.activateWindow()
+        self.pin_button.blockSignals(True)
+        self.pin_button.setChecked(bool(on))
+        self.pin_button.blockSignals(False)
+
     def position_near_pet(self, pet_window=None, gap: int = 14) -> None:
         """Place the phone chat window beside the visible pet bounds."""
         pet = pet_window or self.pet_link.pet_window
@@ -1141,6 +1162,14 @@ class ChatWindow(QDialog):
         self.sidebar_toggle_button.setToolTip("显示或隐藏会话侧栏")
         self.sidebar_toggle_button.setAccessibleName("显示或隐藏会话侧栏")
         title_layout.addWidget(self.sidebar_toggle_button)
+        self.pin_button = QToolButton(self.title_bar)
+        self.pin_button.setObjectName("window-pin-button")
+        self.pin_button.setIcon(vector_widget_icon(self.pin_button, "pin", 16))
+        self.pin_button.setToolTip("窗口置顶")
+        self.pin_button.setAccessibleName("切换聊天窗口置顶")
+        self.pin_button.setCheckable(True)
+        self.pin_button.setChecked(bool(self.config.get("chat_always_on_top", False)))
+        title_layout.addWidget(self.pin_button)
         self.minimize_button = QToolButton(self.title_bar)
         self.minimize_button.setObjectName("window-minimize-button")
         self.minimize_button.setIcon(vector_widget_icon(self.minimize_button, "minimize", 16))
@@ -1232,6 +1261,7 @@ class ChatWindow(QDialog):
     def _connect(self) -> None:
         self.minimize_button.clicked.connect(self.showMinimized)
         self.close_button.clicked.connect(self.close)
+        self.pin_button.clicked.connect(self.toggle_always_on_top)
         self.new_session_button.clicked.connect(self.new_session)
         self.delete_session_button.clicked.connect(self.delete_current_session)
         self.clear_button.clicked.connect(self.clear_session)
@@ -1783,6 +1813,11 @@ class ChatWindow(QDialog):
         self._apply_character_theme()
         self._style()
         self._refresh_sessions()
+        desired_pin = bool(self.config.get("chat_always_on_top", False))
+        if desired_pin != bool(self.windowFlags() & Qt.WindowType.WindowStaysOnTopHint):
+            self.set_chat_always_on_top(desired_pin)
+        else:
+            self.pin_button.setChecked(desired_pin)
 
     def switch_character(self, character_id: str) -> None:
         if not character_id or character_id == self.character_id:

--- a/pet/click_talk_dialog.py
+++ b/pet/click_talk_dialog.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+"""点击动画台词绑定编辑对话框。
+
+每个点击动画可绑定多条专属自言自语台词；点击角色时优先播放当前动画
+绑定的台词，未绑定时回退全局随机自言自语。
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QPlainTextEdit,
+    QPushButton,
+    QVBoxLayout,
+)
+
+from . import catalog
+
+
+def _discover_click_names(character_id: str) -> list[str]:
+    """从素材目录发现当前角色的点击动画名；目录缺失时回退 catalog 常量。"""
+    base = Path(__file__).resolve().parent.parent / "assets" / "characters"
+    click_dir = base / str(character_id) / "videos" / "click"
+    if click_dir.is_dir():
+        names = sorted(p.stem for p in click_dir.glob("*.webm"))
+        if names:
+            return names
+    return list(catalog.CLICKS)
+
+
+class ClickTalkBindingsDialog(QDialog):
+    """维护当前角色的 动画id → [台词...] 绑定。"""
+
+    def __init__(self, config, click_names: list[str] | None = None, parent=None):
+        super().__init__(parent)
+        self.config = config
+        self.character_id = str(config.get("character", catalog.DEFAULT_CHARACTER))
+        self.click_names = list(click_names) if click_names else _discover_click_names(self.character_id)
+        self.bindings = {
+            str(action_id): list(texts)
+            for action_id, texts in config.click_talk_bindings(self.character_id).items()
+        }
+        self._dirty = False
+
+        self.setWindowTitle("点击动画台词绑定")
+        self.resize(560, 420)
+        self.setMinimumSize(480, 360)
+
+        layout = QVBoxLayout(self)
+        hint = QLabel(
+            "每个点击动画可绑定多条专属自言自语台词，每行一条。\n"
+            "点击桌宠时会优先播放当前动画绑定的台词；未绑定时回退全局随机自言自语。"
+        )
+        hint.setWordWrap(True)
+        layout.addWidget(hint)
+
+        body = QHBoxLayout()
+        self.list = QListWidget()
+        self.list.addItems(self.click_names)
+        self.list.setFixedWidth(200)
+        body.addWidget(self.list)
+
+        right = QVBoxLayout()
+        right.addWidget(QLabel("绑定台词（每行一条）："))
+        self.text_edit = QPlainTextEdit()
+        right.addWidget(self.text_edit)
+        body.addLayout(right)
+        layout.addLayout(body)
+
+        buttons = QHBoxLayout()
+        buttons.addStretch(1)
+        save = QPushButton("保存")
+        cancel = QPushButton("取消")
+        save.clicked.connect(self._save)
+        cancel.clicked.connect(self.reject)
+        buttons.addWidget(cancel)
+        buttons.addWidget(save)
+        layout.addLayout(buttons)
+
+        self.list.currentRowChanged.connect(self._load_selected)
+        if self.click_names:
+            self.list.setCurrentRow(0)
+
+    def _load_selected(self, row: int) -> None:
+        if row < 0 or row >= len(self.click_names):
+            self.text_edit.setPlainText("")
+            return
+        action_id = self.click_names[row]
+        self.text_edit.setPlainText("\n".join(self.bindings.get(action_id, [])))
+
+    def _save(self) -> None:
+        row = self.list.currentRow()
+        if 0 <= row < len(self.click_names):
+            action_id = self.click_names[row]
+            texts = [line.strip() for line in self.text_edit.toPlainText().splitlines() if line.strip()]
+            if texts:
+                self.bindings[action_id] = texts[:50]
+            else:
+                self.bindings.pop(action_id, None)
+        self.config.set_click_talk_bindings(self.character_id, self.bindings)
+        self._dirty = True
+        self.accept()
+
+    def bindings_dict(self) -> dict:
+        return self.bindings

--- a/pet/config.py
+++ b/pet/config.py
@@ -367,9 +367,9 @@ def _clean_self_talk_texts(value):
 
 
 def _default_dynamic_island_data() -> dict:
-    """灵动岛默认配置：默认关闭，位置留空由首次显示时自动定位。"""
+    """灵动岛默认配置：默认开启常驻，位置留空由首次显示时自动定位。"""
     return {
-        "enabled": False,
+        "enabled": True,
         "show_icon": True,
         "show_name": True,
         "show_info": True,

--- a/pet/config.py
+++ b/pet/config.py
@@ -376,6 +376,7 @@ def _default_dynamic_island_data() -> dict:
         "info_mode": "time",       # time / balance_tier / balance / custom
         "custom_text": "",
         "show_status": True,
+        "style": "dark",           # dark / light / glass
         "x": None,
         "y": None,
     }
@@ -395,6 +396,8 @@ def _clean_dynamic_island_data(value) -> dict:
     mode = str(result.get("info_mode") or "time").strip()
     result["info_mode"] = mode if mode in {"time", "balance_tier", "balance", "custom"} else "time"
     result["custom_text"] = str(result.get("custom_text") or "")[:80]
+    style = str(result.get("style") or "dark").strip()
+    result["style"] = style if style in {"dark", "light", "glass"} else "dark"
     # 至少保留一个组件：全部关闭时强制显示信息槽，避免空胶囊。
     if not (result["show_icon"] or result["show_name"] or result["show_info"] or result["show_status"]):
         result["show_info"] = True

--- a/pet/config.py
+++ b/pet/config.py
@@ -377,6 +377,7 @@ def _default_dynamic_island_data() -> dict:
         "custom_text": "",
         "show_status": True,
         "style": "dark",           # dark / light / glass
+        "icon": "🐳",
         "x": None,
         "y": None,
     }
@@ -398,6 +399,7 @@ def _clean_dynamic_island_data(value) -> dict:
     result["custom_text"] = str(result.get("custom_text") or "")[:80]
     style = str(result.get("style") or "dark").strip()
     result["style"] = style if style in {"dark", "light", "glass"} else "dark"
+    result["icon"] = str(result.get("icon") or "🐳").strip()[:8] or "🐳"
     # 至少保留一个组件：全部关闭时强制显示信息槽，避免空胶囊。
     if not (result["show_icon"] or result["show_name"] or result["show_info"] or result["show_status"]):
         result["show_info"] = True

--- a/pet/config.py
+++ b/pet/config.py
@@ -366,6 +366,68 @@ def _clean_self_talk_texts(value):
     return texts or list(DEFAULT_SELF_TALK_TEXTS)
 
 
+def _default_dynamic_island_data() -> dict:
+    """灵动岛默认配置：默认关闭，位置留空由首次显示时自动定位。"""
+    return {
+        "enabled": False,
+        "show_icon": True,
+        "show_name": True,
+        "show_info": True,
+        "info_mode": "time",       # time / balance_tier / balance / custom
+        "custom_text": "",
+        "show_status": True,
+        "x": None,
+        "y": None,
+    }
+
+
+def _clean_dynamic_island_data(value) -> dict:
+    defaults = _default_dynamic_island_data()
+    if not isinstance(value, dict):
+        return defaults
+    result = dict(defaults)
+    result.update({k: v for k, v in value.items() if k in defaults})
+    result["enabled"] = bool(result["enabled"])
+    result["show_icon"] = bool(result["show_icon"])
+    result["show_name"] = bool(result["show_name"])
+    result["show_info"] = bool(result["show_info"])
+    result["show_status"] = bool(result["show_status"])
+    mode = str(result.get("info_mode") or "time").strip()
+    result["info_mode"] = mode if mode in {"time", "balance_tier", "balance", "custom"} else "time"
+    result["custom_text"] = str(result.get("custom_text") or "")[:80]
+    # 至少保留一个组件：全部关闭时强制显示信息槽，避免空胶囊。
+    if not (result["show_icon"] or result["show_name"] or result["show_info"] or result["show_status"]):
+        result["show_info"] = True
+    return result
+
+
+def _clean_character_profiles(value) -> dict:
+    """角色档案：当前先承载 click_talk_bindings，后续可扩展头像/人设字段。"""
+    if not isinstance(value, dict):
+        return {}
+    cleaned = {}
+    for character_id, profile in value.items():
+        if not isinstance(profile, dict):
+            continue
+        bindings_raw = profile.get("click_talk_bindings")
+        bindings = {}
+        if isinstance(bindings_raw, dict):
+            for action_id, texts in bindings_raw.items():
+                if not isinstance(texts, list):
+                    continue
+                items = []
+                for item in texts:
+                    text = str(item).strip()
+                    if text and text not in items:
+                        items.append(text[:120])
+                if items:
+                    bindings[str(action_id)] = items
+        entry = dict(profile)
+        entry["click_talk_bindings"] = bindings
+        cleaned[str(character_id)] = entry
+    return cleaned
+
+
 class Config:
     def __init__(self, base=None, instance_id: str | None = None):
         base = Path(base) if isinstance(base, str) else (base or _default_base())
@@ -436,6 +498,9 @@ class Config:
             "modern_chat_card_opacity": 84,
             "chat_bg_crops": {},    # 每个背景的用户自定义取景框 {背景标识: [x,y,w,h] 归一化}
             "character_aliases": {},  # 角色显示名别名 {角色id: 自定义名}，空名=恢复默认
+            "character_profiles": {},  # 角色档案：{角色id: {click_talk_bindings: {动画id: [台词]}}}
+            "chat_always_on_top": False,  # 聊天窗置顶
+            "dynamic_island": _default_dynamic_island_data(),
             "proactive_screen": _default_proactive_screen_data(),
             "agent_link": _default_agent_link_data(),
             "chat_ui_style": "modern",  # modern / classic（仅聊天窗口保留双实现）
@@ -549,6 +614,9 @@ class Config:
             "chat_bg_crops",
             "chat_ui_style",
             "character_aliases",
+            "character_profiles",
+            "chat_always_on_top",
+            "dynamic_island",
         ):
             if key in raw and raw[key] is not None:
                 self.data[key] = raw[key]
@@ -624,6 +692,13 @@ class Config:
         )
         if self.data.get("chat_ui_style") not in {"modern", "classic"}:
             self.data["chat_ui_style"] = "modern"
+        self.data["character_profiles"] = _clean_character_profiles(
+            self.data.get("character_profiles")
+        )
+        self.data["chat_always_on_top"] = bool(self.data.get("chat_always_on_top", False))
+        self.data["dynamic_island"] = _clean_dynamic_island_data(
+            self.data.get("dynamic_island")
+        )
         for prefix in ("chat_background", "modern_chat_background"):
             opacity_key = f"{prefix}_opacity"
             fill_key = f"{prefix}_fill"
@@ -673,6 +748,41 @@ class Config:
             aliases.pop(character_id, None)
         self.save()
 
+    def character_profile(self, character_id: str) -> dict:
+        """返回角色档案；不存在时返回空档案。"""
+        profiles = self.data.get("character_profiles")
+        if isinstance(profiles, dict):
+            profile = profiles.get(str(character_id))
+            if isinstance(profile, dict):
+                return profile
+        return {}
+
+    def click_talk_bindings(self, character_id: str) -> dict:
+        """返回某角色的点击动画台词绑定：{动画id: [台词, ...]}。"""
+        profile = self.character_profile(character_id)
+        bindings = profile.get("click_talk_bindings")
+        return bindings if isinstance(bindings, dict) else {}
+
+    def click_talk_texts_for(self, character_id: str, action_id: str) -> list[str]:
+        """返回某点击动画绑定的台词；未绑定返回空列表。"""
+        bindings = self.click_talk_bindings(character_id)
+        texts = bindings.get(str(action_id))
+        return texts if isinstance(texts, list) else []
+
+    def set_click_talk_bindings(self, character_id: str, bindings: dict) -> None:
+        """保存某角色的点击动画台词绑定并立即落盘。"""
+        profiles = self.data.setdefault("character_profiles", {})
+        if not isinstance(profiles, dict):
+            profiles = {}
+            self.data["character_profiles"] = profiles
+        profile = profiles.setdefault(str(character_id), {})
+        if not isinstance(profile, dict):
+            profile = {}
+            profiles[str(character_id)] = profile
+        profile["click_talk_bindings"] = bindings
+        self.data["character_profiles"] = _clean_character_profiles(profiles)
+        self.save()
+
     def set(self, key, value):
         self.data[key] = value
         if key in {
@@ -684,6 +794,7 @@ class Config:
             "menu_easter_egg",
             "click_sound_enabled", "click_sound_pack", "click_sound_volume",
             "slingshot_enabled", "throw_strength", "agent_link",
+            "character_profiles", "chat_always_on_top", "dynamic_island",
         }:
             self._normalize_pet_settings()
 

--- a/pet/dynamic_island.py
+++ b/pet/dynamic_island.py
@@ -1,0 +1,235 @@
+# -*- coding: utf-8 -*-
+"""独立灵动岛胶囊窗口。
+
+- 常驻顶层小窗，可显示图标、名称、信息槽、状态灯；
+- 支持拖拽、屏幕顶部吸附、位置持久化；
+- 单击胶囊切换桌宠显示/隐藏（由应用层连接 clicked 信号）。
+"""
+from __future__ import annotations
+
+from PySide6.QtCore import QPoint, QRectF, Qt, QTimer, Signal
+from PySide6.QtGui import QColor, QGuiApplication, QPainter
+from PySide6.QtWidgets import QApplication, QWidget
+
+from . import catalog
+
+_CAPSULE_HEIGHT = 44
+_EDGE_MARGIN = 16
+_SNAP_TOP_THRESHOLD = 24
+
+
+def _cfg_dict(config) -> dict:
+    value = config.get("dynamic_island", {})
+    return value if isinstance(value, dict) else {}
+
+
+class DynamicIsland(QWidget):
+    """胶囊形态的独立灵动岛窗口。"""
+
+    clicked = Signal()
+
+    def __init__(self, config, parent=None):
+        super().__init__(parent)
+        self.config = config
+        self._cfg = _cfg_dict(config)
+        self.setObjectName("dynamic-island")
+        flags = (
+            Qt.WindowType.Tool
+            | Qt.WindowType.FramelessWindowHint
+            | Qt.WindowType.WindowStaysOnTopHint
+            | Qt.WindowType.WindowDoesNotAcceptFocus
+        )
+        self.setWindowFlags(flags)
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+        self.setAttribute(Qt.WidgetAttribute.WA_ShowWithoutActivating, True)
+        if hasattr(Qt.WidgetAttribute, "WA_MacAlwaysShowToolWindow"):
+            self.setAttribute(Qt.WidgetAttribute.WA_MacAlwaysShowToolWindow, True)
+
+        self._drag_offset: QPoint | None = None
+        self._dragging = False
+        self._press_global: QPoint | None = None
+        self._balance_tier_text = "余额峰谷 --"
+        self._balance_text = "余额 --"
+
+        self._info_timer = QTimer(self)
+        self._info_timer.setInterval(30_000)
+        self._info_timer.timeout.connect(self.update)
+        self._info_timer.start()
+
+        self._apply_position()
+
+    # ------------------------------------------------------------ 对外
+    def set_balance_info(self, tier_text: str, balance_text: str) -> None:
+        self._balance_tier_text = str(tier_text or "余额峰谷 --")
+        self._balance_text = str(balance_text or "余额 --")
+        self.update()
+
+    def refresh_from_config(self) -> None:
+        self._cfg = _cfg_dict(self.config)
+        self._apply_position()
+        self.update()
+
+    # ------------------------------------------------------------ 内部
+    def _visible_parts(self) -> tuple[bool, bool, bool, bool]:
+        c = self._cfg
+        icon = bool(c.get("show_icon", True))
+        name = bool(c.get("show_name", True))
+        info = bool(c.get("show_info", True))
+        status = bool(c.get("show_status", True))
+        if not (icon or name or info or status):
+            info = True
+        return icon, name, info, status
+
+    def _info_text(self) -> str:
+        mode = str(self._cfg.get("info_mode") or "time")
+        if mode == "custom":
+            return str(self._cfg.get("custom_text") or "").strip() or "自定义"
+        if mode == "balance_tier":
+            return self._balance_tier_text
+        if mode == "balance":
+            return self._balance_text
+        from PySide6.QtCore import QTime
+
+        return QTime.currentTime().toString("HH:mm")
+
+    def _character_name(self) -> str:
+        character_id = str(self.config.get("character", catalog.DEFAULT_CHARACTER))
+        return self.config.character_alias(character_id) or character_id
+
+    def _update_size(self) -> None:
+        icon, name, info, status = self._visible_parts()
+        fm = self.fontMetrics()
+        width = 28  # 左右内边距
+        if icon:
+            width += 28 + 8
+        if name:
+            width += fm.horizontalAdvance(self._character_name()) + 8
+        if info:
+            width += fm.horizontalAdvance(self._info_text()) + 8
+        if status:
+            width += 8 + 6
+        width += 12
+        self.setFixedSize(max(120, width), _CAPSULE_HEIGHT)
+
+    def _apply_position(self) -> None:
+        self._update_size()
+        x = self._cfg.get("x")
+        y = self._cfg.get("y")
+        screen = QGuiApplication.primaryScreen()
+        available = screen.availableGeometry() if screen is not None else None
+        if isinstance(x, (int, float)) and isinstance(y, (int, float)):
+            pos = QPoint(int(x), int(y))
+        else:
+            pos = QPoint(available.right() - self.width() - _EDGE_MARGIN, available.top() + _EDGE_MARGIN) if available else QPoint(100, 100)
+        if available is not None:
+            pos.setX(max(available.left(), min(pos.x(), available.right() - self.width() + 1)))
+            pos.setY(max(available.top(), min(pos.y(), available.bottom() - self.height() + 1)))
+        self.move(pos)
+
+    def _save_position(self) -> None:
+        island = dict(self._cfg)
+        island["x"] = self.x()
+        island["y"] = self.y()
+        self._cfg = island
+        self.config.set("dynamic_island", island)
+        self.config.save()
+
+    # ------------------------------------------------------------ 绘制
+    def paintEvent(self, event) -> None:  # noqa: N802
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        rect = QRectF(0, 0, self.width(), self.height())
+        radius = rect.height() / 2.0
+
+        # 柔和阴影：底层半透明圆角矩形
+        shadow = rect.translated(0, 2)
+        painter.setPen(Qt.PenStyle.NoPen)
+        painter.setBrush(QColor(0, 0, 0, 46))
+        painter.drawRoundedRect(shadow, radius, radius)
+
+        # 胶囊主体
+        painter.setBrush(QColor(28, 30, 38, 235))
+        painter.drawRoundedRect(rect, radius, radius)
+
+        icon, name, info, status = self._visible_parts()
+        x = 16.0
+        painter.setPen(Qt.PenStyle.NoPen)
+        if icon:
+            painter.setBrush(QColor(64, 184, 255, 255))
+            painter.drawEllipse(QRectF(x, (self.height() - 26) / 2, 26, 26))
+            painter.setPen(QColor(255, 255, 255))
+            fm = self.fontMetrics()
+            icon_text = "🐟"
+            painter.drawText(
+                QRectF(x, (self.height() - fm.height()) / 2 - 1, 26, fm.height()),
+                Qt.AlignmentFlag.AlignCenter,
+                icon_text,
+            )
+            painter.setPen(Qt.PenStyle.NoPen)
+            x += 26 + 8
+
+        painter.setPen(QColor(235, 238, 245))
+        if name:
+            text = self._character_name()
+            painter.drawText(
+                QRectF(x, 0, self.fontMetrics().horizontalAdvance(text), self.height()),
+                Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignLeft,
+                text,
+            )
+            x += self.fontMetrics().horizontalAdvance(text) + 8
+
+        if info:
+            info_text = self._info_text()
+            painter.setPen(QColor(160, 170, 190))
+            painter.drawText(
+                QRectF(x, 0, self.fontMetrics().horizontalAdvance(info_text), self.height()),
+                Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignLeft,
+                info_text,
+            )
+            x += self.fontMetrics().horizontalAdvance(info_text) + 8
+
+        if status:
+            painter.setPen(Qt.PenStyle.NoPen)
+            painter.setBrush(QColor(80, 220, 120))
+            painter.drawEllipse(QRectF(x, (self.height() - 6) / 2, 6, 6))
+
+        painter.end()
+
+    # ------------------------------------------------------------ 鼠标
+    def mousePressEvent(self, event) -> None:  # noqa: N802
+        if event.button() == Qt.MouseButton.LeftButton:
+            self._press_global = event.globalPosition().toPoint()
+            self._drag_offset = self._press_global - self.pos()
+            self._dragging = False
+            event.accept()
+            return
+        super().mousePressEvent(event)
+
+    def mouseMoveEvent(self, event) -> None:  # noqa: N802
+        if self._press_global is None or event.buttons() & Qt.MouseButton.LeftButton == 0:
+            return
+        global_pos = event.globalPosition().toPoint()
+        if not self._dragging and (global_pos - self._press_global).manhattanLength() >= QApplication.startDragDistance():
+            self._dragging = True
+        if self._dragging and self._drag_offset is not None:
+            self.move(global_pos - self._drag_offset)
+            event.accept()
+
+    def mouseReleaseEvent(self, event) -> None:  # noqa: N802
+        if event.button() != Qt.MouseButton.LeftButton:
+            return
+        if not self._dragging:
+            self.clicked.emit()
+        else:
+            available = QGuiApplication.primaryScreen().availableGeometry() if QGuiApplication.primaryScreen() else None
+            if available is not None:
+                x = max(available.left(), min(self.x(), available.right() - self.width() + 1))
+                y = max(available.top(), min(self.y(), available.bottom() - self.height() + 1))
+                if y <= available.top() + _SNAP_TOP_THRESHOLD:
+                    y = available.top()
+                self.move(x, y)
+            self._save_position()
+        self._press_global = None
+        self._drag_offset = None
+        self._dragging = False
+        event.accept()

--- a/pet/dynamic_island.py
+++ b/pet/dynamic_island.py
@@ -112,7 +112,8 @@ class DynamicIsland(QWidget):
     def _update_size(self) -> None:
         icon, name, info, status = self._visible_parts()
         fm = self.fontMetrics()
-        width = 28  # 左右内边距
+        # 左右边距各 16px，让状态灯到右边界的距离与图标到左边界的距离一致。
+        width = 32
         if icon:
             width += 28 + 8
         if name:
@@ -120,8 +121,7 @@ class DynamicIsland(QWidget):
         if info:
             width += fm.horizontalAdvance(self._info_text()) + 8
         if status:
-            width += 12 + 10
-        width += 12
+            width += 10
         self.setFixedSize(max(120, width), _CAPSULE_HEIGHT)
 
     def _apply_position(self) -> None:

--- a/pet/dynamic_island.py
+++ b/pet/dynamic_island.py
@@ -8,7 +8,7 @@
 from __future__ import annotations
 
 from PySide6.QtCore import QPoint, QRectF, Qt, QTimer, Signal
-from PySide6.QtGui import QColor, QGuiApplication, QPainter
+from PySide6.QtGui import QColor, QGuiApplication, QLinearGradient, QPainter, QPen
 from PySide6.QtWidgets import QApplication, QWidget
 
 from . import catalog
@@ -53,7 +53,7 @@ class DynamicIsland(QWidget):
 
         self._info_timer = QTimer(self)
         self._info_timer.setInterval(30_000)
-        self._info_timer.timeout.connect(self.update)
+        self._info_timer.timeout.connect(self._refresh)
         self._info_timer.start()
 
         self._apply_position()
@@ -62,11 +62,16 @@ class DynamicIsland(QWidget):
     def set_balance_info(self, tier_text: str, balance_text: str) -> None:
         self._balance_tier_text = str(tier_text or "余额峰谷 --")
         self._balance_text = str(balance_text or "余额 --")
-        self.update()
+        self._refresh()
 
     def refresh_from_config(self) -> None:
         self._cfg = _cfg_dict(self.config)
-        self._apply_position()
+        self._refresh()
+
+    def _refresh(self) -> None:
+        """内容变化后立即重算尺寸、夹回屏幕并重绘。"""
+        self._update_size()
+        self._clamp_to_screen()
         self.update()
 
     # ------------------------------------------------------------ 内部
@@ -126,6 +131,16 @@ class DynamicIsland(QWidget):
             pos.setY(max(available.top(), min(pos.y(), available.bottom() - self.height() + 1)))
         self.move(pos)
 
+    def _clamp_to_screen(self) -> None:
+        screen = QGuiApplication.primaryScreen()
+        if screen is None:
+            return
+        available = screen.availableGeometry()
+        x = max(available.left(), min(self.x(), available.right() - self.width() + 1))
+        y = max(available.top(), min(self.y(), available.bottom() - self.height() + 1))
+        if (x, y) != (self.x(), self.y()):
+            self.move(x, y)
+
     def _save_position(self) -> None:
         island = dict(self._cfg)
         island["x"] = self.x()
@@ -135,6 +150,19 @@ class DynamicIsland(QWidget):
         self.config.save()
 
     # ------------------------------------------------------------ 绘制
+    def _style_palette(self):
+        """返回 (背景, 主文字色, 次文字色)。背景可为 QColor 或 QLinearGradient。"""
+        style = str(self._cfg.get("style") or "dark")
+        if style == "light":
+            return QColor(255, 255, 255, 242), QColor(31, 35, 40), QColor(107, 114, 128)
+        if style == "glass":
+            gradient = QLinearGradient(0, 0, 0, self.height())
+            gradient.setColorAt(0.0, QColor(255, 255, 255, 196))
+            gradient.setColorAt(0.5, QColor(230, 242, 255, 150))
+            gradient.setColorAt(1.0, QColor(255, 255, 255, 210))
+            return gradient, QColor(35, 45, 60), QColor(90, 105, 125)
+        return QColor(28, 30, 38, 235), QColor(235, 238, 245), QColor(160, 170, 190)
+
     def paintEvent(self, event) -> None:  # noqa: N802
         painter = QPainter(self)
         painter.setRenderHint(QPainter.RenderHint.Antialiasing)
@@ -147,9 +175,16 @@ class DynamicIsland(QWidget):
         painter.setBrush(QColor(0, 0, 0, 46))
         painter.drawRoundedRect(shadow, radius, radius)
 
-        # 胶囊主体
-        painter.setBrush(QColor(28, 30, 38, 235))
+        # 胶囊主体（白色 / 黑色 / 玻璃质感）
+        background, primary_color, secondary_color = self._style_palette()
+        painter.setBrush(background)
+        painter.setPen(Qt.PenStyle.NoPen)
         painter.drawRoundedRect(rect, radius, radius)
+        if str(self._cfg.get("style") or "dark") == "glass":
+            # 玻璃高光描边，强化“液化玻璃”边缘
+            painter.setPen(QPen(QColor(255, 255, 255, 130), 1))
+            painter.setBrush(Qt.BrushStyle.NoBrush)
+            painter.drawRoundedRect(rect.adjusted(0.5, 0.5, -0.5, -0.5), radius - 0.5, radius - 0.5)
 
         icon, name, info, status = self._visible_parts()
         x = 16.0
@@ -168,7 +203,7 @@ class DynamicIsland(QWidget):
             painter.setPen(Qt.PenStyle.NoPen)
             x += 26 + 8
 
-        painter.setPen(QColor(235, 238, 245))
+        painter.setPen(primary_color)
         if name:
             text = self._character_name()
             painter.drawText(
@@ -180,7 +215,7 @@ class DynamicIsland(QWidget):
 
         if info:
             info_text = self._info_text()
-            painter.setPen(QColor(160, 170, 190))
+            painter.setPen(secondary_color)
             painter.drawText(
                 QRectF(x, 0, self.fontMetrics().horizontalAdvance(info_text), self.height()),
                 Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignLeft,

--- a/pet/dynamic_island.py
+++ b/pet/dynamic_island.py
@@ -50,6 +50,7 @@ class DynamicIsland(QWidget):
         self._press_global: QPoint | None = None
         self._balance_tier_text = "余额峰谷 --"
         self._balance_text = "余额 --"
+        self._pet_visible = True
 
         self._info_timer = QTimer(self)
         self._info_timer.setInterval(30_000)
@@ -63,6 +64,10 @@ class DynamicIsland(QWidget):
         self._balance_tier_text = str(tier_text or "余额峰谷 --")
         self._balance_text = str(balance_text or "余额 --")
         self._refresh()
+
+    def set_pet_visible(self, visible: bool) -> None:
+        self._pet_visible = bool(visible)
+        self.update()
 
     def refresh_from_config(self) -> None:
         self._cfg = _cfg_dict(self.config)
@@ -101,6 +106,9 @@ class DynamicIsland(QWidget):
         character_id = str(self.config.get("character", catalog.DEFAULT_CHARACTER))
         return self.config.character_alias(character_id) or character_id
 
+    def _icon_text(self) -> str:
+        return str(self._cfg.get("icon") or "🐳").strip()[:8] or "🐳"
+
     def _update_size(self) -> None:
         icon, name, info, status = self._visible_parts()
         fm = self.fontMetrics()
@@ -112,7 +120,7 @@ class DynamicIsland(QWidget):
         if info:
             width += fm.horizontalAdvance(self._info_text()) + 8
         if status:
-            width += 8 + 6
+            width += 12 + 10
         width += 12
         self.setFixedSize(max(120, width), _CAPSULE_HEIGHT)
 
@@ -194,7 +202,7 @@ class DynamicIsland(QWidget):
             painter.drawEllipse(QRectF(x, (self.height() - 26) / 2, 26, 26))
             painter.setPen(QColor(255, 255, 255))
             fm = self.fontMetrics()
-            icon_text = "🐟"
+            icon_text = self._icon_text()
             painter.drawText(
                 QRectF(x, (self.height() - fm.height()) / 2 - 1, 26, fm.height()),
                 Qt.AlignmentFlag.AlignCenter,
@@ -224,9 +232,12 @@ class DynamicIsland(QWidget):
             x += self.fontMetrics().horizontalAdvance(info_text) + 8
 
         if status:
+            dot_size = 10
+            dot_color = QColor(80, 220, 120) if self._pet_visible else QColor(130, 140, 155)
             painter.setPen(Qt.PenStyle.NoPen)
-            painter.setBrush(QColor(80, 220, 120))
-            painter.drawEllipse(QRectF(x, (self.height() - 6) / 2, 6, 6))
+            painter.setBrush(dot_color)
+            painter.drawEllipse(QRectF(x, (self.height() - dot_size) / 2, dot_size, dot_size))
+            x += dot_size + 12
 
         painter.end()
 

--- a/pet/modern_settings_dialog.py
+++ b/pet/modern_settings_dialog.py
@@ -1152,6 +1152,7 @@ class ModernSettingsDialog(QDialog):
             SettingRow("dynamic_island_info", "显示信息槽", "显示时间/余额/自定义短文本等信息。", self.island_info_check),
             SettingRow("dynamic_island_status", "显示状态灯", "显示右侧状态圆点。", self.island_status_check),
             SettingRow("dynamic_island_info_mode", "信息槽内容", "选择信息槽显示的内容；自定义文本在下方填写。", self.island_info_mode_select),
+            SettingRow("dynamic_island_style", "背景风格", "黑色 / 白色 / 苹果式玻璃质感。", self.island_style_select),
             SettingRow("dynamic_island_custom_text", "自定义短文本", "信息槽选择“自定义短文本”时显示的内容。", self.island_custom_text_edit, stacked=True),
         ], island_content))
         island_layout.addStretch(1)
@@ -1629,6 +1630,14 @@ class ModernSettingsDialog(QDialog):
         ):
             self.island_info_mode_select.addItem(label, value)
         self.island_info_mode_select.setCurrentData(str(island_cfg.get("info_mode") or "time"))
+        self.island_style_select = ModernSelect(self, width=160)
+        for label, value in (
+            ("黑色", "dark"),
+            ("白色", "light"),
+            ("玻璃质感", "glass"),
+        ):
+            self.island_style_select.addItem(label, value)
+        self.island_style_select.setCurrentData(str(island_cfg.get("style") or "dark"))
         self.island_custom_text_edit = _line_edit(str(island_cfg.get("custom_text") or ""), width=220)
 
     # ------------------------------------------------------------ 主动识屏
@@ -2161,6 +2170,7 @@ class ModernSettingsDialog(QDialog):
             "info_mode": str(self.island_info_mode_select.currentData() or "time"),
             "custom_text": self.island_custom_text_edit.text().strip(),
             "show_status": self.island_status_check.isChecked(),
+            "style": str(self.island_style_select.currentData() or "dark"),
             "x": existing_island.get("x"),
             "y": existing_island.get("y"),
         })

--- a/pet/modern_settings_dialog.py
+++ b/pet/modern_settings_dialog.py
@@ -1141,6 +1141,22 @@ class ModernSettingsDialog(QDialog):
         general_layout.addStretch(1)
         self._add_page("常规", "settings", self._page_shell("常规", general_content))
 
+        island_content = QWidget()
+        island_layout = QVBoxLayout(island_content)
+        island_layout.setContentsMargins(0, 0, 0, 0)
+        island_layout.setSpacing(18)
+        island_layout.addWidget(SettingsSection("灵动岛", [
+            SettingRow("dynamic_island_enabled", "启用灵动岛", "显示独立胶囊小窗；桌宠隐藏后仍可常驻。", self.island_enabled_check),
+            SettingRow("dynamic_island_icon", "显示图标", "在胶囊左侧显示角色图标。", self.island_icon_check),
+            SettingRow("dynamic_island_name", "显示名称", "显示当前角色名称。", self.island_name_check),
+            SettingRow("dynamic_island_info", "显示信息槽", "显示时间/余额/自定义短文本等信息。", self.island_info_check),
+            SettingRow("dynamic_island_status", "显示状态灯", "显示右侧状态圆点。", self.island_status_check),
+            SettingRow("dynamic_island_info_mode", "信息槽内容", "选择信息槽显示的内容；自定义文本在下方填写。", self.island_info_mode_select),
+            SettingRow("dynamic_island_custom_text", "自定义短文本", "信息槽选择“自定义短文本”时显示的内容。", self.island_custom_text_edit, stacked=True),
+        ], island_content))
+        island_layout.addStretch(1)
+        self._add_page("灵动岛", "island", self._page_shell("灵动岛", island_content))
+
         behavior_content = QWidget()
         behavior_layout = QVBoxLayout(behavior_content)
         behavior_layout.setContentsMargins(0, 0, 0, 0)
@@ -1179,6 +1195,7 @@ class ModernSettingsDialog(QDialog):
             SettingRow("self_talk_max", "最长间隔", "上一条气泡消失后，到下一条出现前的最长空闲时间。", self.max_spin),
             SettingRow("self_talk_texts", "候选内容", "每行一条；留空时恢复内置文本。", self.texts_edit, stacked=True),
             SettingRow("self_talk_images", "图片目录", "从目录中的常见图片格式随机选择；默认使用内置彩蛋图片池，留空时只显示文本。", self.self_talk_image_dir_picker, stacked=True),
+            SettingRow("click_talk_bindings", "点击动画台词绑定", "为每个点击动画设置专属自言自语台词。", self.click_talk_bindings_btn),
         ], behavior_content))
         # Agent 联动：每个 Agent 一行自定义思考文案
         agent_thinking_rows = []
@@ -1459,6 +1476,9 @@ class ModernSettingsDialog(QDialog):
             directory=True,
             parent=self,
         )
+        self.click_talk_bindings_btn = QPushButton("编辑…", self)
+        self.click_talk_bindings_btn.setObjectName("clickTalkBindingsButton")
+        self.click_talk_bindings_btn.clicked.connect(self._open_click_talk_bindings)
 
         # Agent 联动：每个 Agent 的自定义 thinking 气泡文案
         agent_link_cfg = self.config.get("agent_link", {})
@@ -1586,6 +1606,30 @@ class ModernSettingsDialog(QDialog):
         self.egg_avatar_picker = ResourcePathPicker(str(avatar.resolve()), parent=self)
         self.egg_image_dir_picker = ResourcePathPicker(str(image_dir.resolve()), directory=True, parent=self)
 
+        # 灵动岛
+        island_cfg = self.config.get("dynamic_island", {})
+        if not isinstance(island_cfg, dict):
+            island_cfg = {}
+        self.island_enabled_check = ToggleSwitch(self)
+        self.island_enabled_check.setChecked(bool(island_cfg.get("enabled", False)))
+        self.island_icon_check = ToggleSwitch(self)
+        self.island_icon_check.setChecked(bool(island_cfg.get("show_icon", True)))
+        self.island_name_check = ToggleSwitch(self)
+        self.island_name_check.setChecked(bool(island_cfg.get("show_name", True)))
+        self.island_info_check = ToggleSwitch(self)
+        self.island_info_check.setChecked(bool(island_cfg.get("show_info", True)))
+        self.island_status_check = ToggleSwitch(self)
+        self.island_status_check.setChecked(bool(island_cfg.get("show_status", True)))
+        self.island_info_mode_select = ModernSelect(self, width=160)
+        for label, value in (
+            ("当前时间", "time"),
+            ("余额峰谷", "balance_tier"),
+            ("余额数值", "balance"),
+            ("自定义短文本", "custom"),
+        ):
+            self.island_info_mode_select.addItem(label, value)
+        self.island_info_mode_select.setCurrentData(str(island_cfg.get("info_mode") or "time"))
+        self.island_custom_text_edit = _line_edit(str(island_cfg.get("custom_text") or ""), width=220)
 
     # ------------------------------------------------------------ 主动识屏
         if sys.platform == "win32" and self.include_ai:
@@ -1805,11 +1849,12 @@ class ModernSettingsDialog(QDialog):
         keys = (
             "self_talk_duration", "self_talk_min", "self_talk_max",
             "self_talk_texts", "self_talk_images", "click_self_talk",
+            "click_talk_bindings",
         )
         controls = (
             self.self_talk_duration_spin, self.min_spin, self.max_spin,
             self.texts_edit, self.self_talk_image_dir_picker,
-            self.click_self_talk_check,
+            self.click_self_talk_check, self.click_talk_bindings_btn,
         )
         for key, control in zip(keys, controls):
             control.setEnabled(bool(enabled))
@@ -1829,6 +1874,16 @@ class ModernSettingsDialog(QDialog):
         if self.menu_font_select.findData(current_font) < 0:
             self.menu_font_select.addItem(current_font, current_font)
         self.menu_font_select.setCurrentData(current_font)
+
+    def _open_click_talk_bindings(self) -> None:
+        from .click_talk_dialog import ClickTalkBindingsDialog
+
+        click_names = None
+        parent = self.parent()
+        if parent is not None and hasattr(parent, "clicks") and parent.clicks:
+            click_names = list(parent.clicks)
+        dialog = ClickTalkBindingsDialog(self.config, click_names=click_names, parent=self)
+        dialog.exec()
 
     def _preview_click_sound(self) -> None:
         """试听当前选择的点击音效配置（不保存配置）。"""
@@ -2095,6 +2150,20 @@ class ModernSettingsDialog(QDialog):
             self.config.get("click_sound_pack"),
             data_dir=self.config.dir,
         )
+        existing_island = self.config.get("dynamic_island", {})
+        if not isinstance(existing_island, dict):
+            existing_island = {}
+        self.config.set("dynamic_island", {
+            "enabled": self.island_enabled_check.isChecked(),
+            "show_icon": self.island_icon_check.isChecked(),
+            "show_name": self.island_name_check.isChecked(),
+            "show_info": self.island_info_check.isChecked(),
+            "info_mode": str(self.island_info_mode_select.currentData() or "time"),
+            "custom_text": self.island_custom_text_edit.text().strip(),
+            "show_status": self.island_status_check.isChecked(),
+            "x": existing_island.get("x"),
+            "y": existing_island.get("y"),
+        })
         if self.click_balance_check is not None:
             self.config.set("click_show_balance", self.click_balance_check.isChecked())
         self.config.set("click_show_self_talk", self.click_self_talk_check.isChecked())

--- a/pet/modern_settings_dialog.py
+++ b/pet/modern_settings_dialog.py
@@ -1153,6 +1153,7 @@ class ModernSettingsDialog(QDialog):
             SettingRow("dynamic_island_status", "显示状态灯", "显示右侧状态圆点。", self.island_status_check),
             SettingRow("dynamic_island_info_mode", "信息槽内容", "选择信息槽显示的内容；自定义文本在下方填写。", self.island_info_mode_select),
             SettingRow("dynamic_island_style", "背景风格", "黑色 / 白色 / 苹果式玻璃质感。", self.island_style_select),
+            SettingRow("dynamic_island_icon", "图标", "选择灵动岛左侧显示的预制 emoji 图标。", self.island_icon_select),
             SettingRow("dynamic_island_custom_text", "自定义短文本", "信息槽选择“自定义短文本”时显示的内容。", self.island_custom_text_edit, stacked=True),
         ], island_content))
         island_layout.addStretch(1)
@@ -1638,6 +1639,10 @@ class ModernSettingsDialog(QDialog):
         ):
             self.island_style_select.addItem(label, value)
         self.island_style_select.setCurrentData(str(island_cfg.get("style") or "dark"))
+        self.island_icon_select = ModernSelect(self, width=160)
+        for emoji in ("🐳", "🐟", "🐙", "🦭", "🐧", "🐱", "🐶", "🌟", "⚡", "❤️"):
+            self.island_icon_select.addItem(emoji, emoji)
+        self.island_icon_select.setCurrentData(str(island_cfg.get("icon") or "🐳"))
         self.island_custom_text_edit = _line_edit(str(island_cfg.get("custom_text") or ""), width=220)
 
     # ------------------------------------------------------------ 主动识屏
@@ -2171,6 +2176,7 @@ class ModernSettingsDialog(QDialog):
             "custom_text": self.island_custom_text_edit.text().strip(),
             "show_status": self.island_status_check.isChecked(),
             "style": str(self.island_style_select.currentData() or "dark"),
+            "icon": str(self.island_icon_select.currentData() or "🐳"),
             "x": existing_island.get("x"),
             "y": existing_island.get("y"),
         })

--- a/pet/window.py
+++ b/pet/window.py
@@ -2120,14 +2120,15 @@ class PetWindow(QWidget):
         # 点击可以打断当前动画（包括正在播放的点击回应），实现连续 Q 弹。
         # 先让 Q 弹/动画立刻开始，音效放到下一轮事件循环，避免任何音频
         # 初始化/文件扫描阻塞点击瞬间的画面更新。
+        click_name = self._pick(self.clicks)
         self._cancel_move()
         self._start_squash()
-        self._switch(self._pick(self.clicks))
+        self._switch(click_name)
         self._schedule_click_sound()
         if self.click_show_balance and callable(self.on_show_balance):
             self.on_show_balance(self)
         elif self.click_show_self_talk and self._self_talk_enabled:
-            if self._show_random_self_talk():
+            if self._show_click_self_talk(click_name):
                 self._schedule_self_talk(after_display=True)
 
     def _schedule_click_sound(self) -> None:
@@ -2338,6 +2339,16 @@ class PetWindow(QWidget):
             delay += self._self_talk_duration_seconds
         self._self_talk_timer.start(max(1000, int(round(delay * 1000))))
 
+    def _show_self_talk_text(self, text: str) -> bool:
+        if getattr(self, "_bubble_suppressed", False):
+            return False
+        duration_ms = int(round(self._self_talk_duration_seconds * 1000))
+        anchor = self.visible_content_rect()
+        self._speech_bubble.show_text(
+            text, anchor, duration_ms, pet_scale=self.scale
+        )
+        return True
+
     def _show_random_self_talk(self) -> bool:
         if getattr(self, "_bubble_suppressed", False):
             return False
@@ -2355,10 +2366,15 @@ class PetWindow(QWidget):
             return self._speech_bubble.show_image(
                 value, anchor, duration_ms, pet_scale=self.scale
             )
-        self._speech_bubble.show_text(
-            value, anchor, duration_ms, pet_scale=self.scale
-        )
-        return True
+        return self._show_self_talk_text(value)
+
+    def _show_click_self_talk(self, click_name: str) -> bool:
+        """优先播放当前点击动画绑定的台词；未绑定则回退全局随机自言自语。"""
+        character_id = str(self.cfg.get('character', catalog.DEFAULT_CHARACTER))
+        texts = self.cfg.click_talk_texts_for(character_id, click_name)
+        if texts:
+            return self._show_self_talk_text(random.choice(texts))
+        return self._show_random_self_talk()
 
     def _on_self_talk_timeout(self) -> None:
         if time.time() < self._bubble_busy_until:

--- a/tests/test_desktop_pet_features.py
+++ b/tests/test_desktop_pet_features.py
@@ -1143,7 +1143,7 @@ def test_modern_settings_panel_uses_sidebar_and_includes_ai_settings(tmp_path, m
     assert dialog.findChild(settings_mod.QFrame, "sidebarPane").width() == 188
     assert isinstance(dialog.sidebar, QListWidget)
     assert isinstance(dialog.pages, QStackedWidget)
-    expected_pages = ["常规", "桌宠行为", "外观", "快捷启动"]
+    expected_pages = ["常规", "灵动岛", "桌宠行为", "外观", "快捷启动"]
     if sys.platform == "win32":
         expected_pages.append("主动识屏")  # 主动识屏设置页仅 Windows + 有聊天能力时挂载
     expected_pages.append("AI 设置")
@@ -1200,18 +1200,18 @@ def test_modern_settings_panel_uses_sidebar_and_includes_ai_settings(tmp_path, m
         return next(index for index in range(dialog.pages.count()) if dialog.pages.widget(index).isAncestorOf(row))
 
     assert page_index(dialog.findChild(settings_mod.SettingRow, "settingRow_autostart")) == 0
-    assert page_index(dialog.findChild(settings_mod.SettingRow, "settingRow_playback_speed")) == 1
-    assert page_index(dialog.findChild(settings_mod.SettingRow, "settingRow_self_talk_texts")) == 1
-    assert page_index(dialog.findChild(settings_mod.SettingRow, "settingRow_scale")) == 2
-    assert page_index(dialog.findChild(settings_mod.SettingRow, "settingRow_chat_ui_style")) == 2
+    assert page_index(dialog.findChild(settings_mod.SettingRow, "settingRow_playback_speed")) == 2
+    assert page_index(dialog.findChild(settings_mod.SettingRow, "settingRow_self_talk_texts")) == 2
+    assert page_index(dialog.findChild(settings_mod.SettingRow, "settingRow_scale")) == 3
+    assert page_index(dialog.findChild(settings_mod.SettingRow, "settingRow_chat_ui_style")) == 3
     assert page_index(dialog.findChild(settings_mod.SettingRow, "settingRow_api_url")) == (
-        5 if sys.platform == "win32" else 4  # AI 设置页索引：Windows 上「主动识屏」占 index 4
+        6 if sys.platform == "win32" else 5  # AI 设置页索引：常规/灵动岛/桌宠行为/外观/快捷启动，Windows 再插主动识屏
     )
     if settings_mod.sys.platform != "win32":
         assert dialog.auto_hide_fullscreen_check is None
         assert dialog.stream_capture_check is None
     dialog.show()
-    dialog.pages.widget(1).findChild(settings_mod.QScrollArea, "settingsScroll").ensureWidgetVisible(texts_row)
+    dialog.pages.widget(2).findChild(settings_mod.QScrollArea, "settingsScroll").ensureWidgetVisible(texts_row)
     app.processEvents()
     label = texts_row.findChild(settings_mod.QLabel, "settingLabel")
     hint = texts_row.findChild(settings_mod.QLabel, "settingHint")
@@ -1473,8 +1473,8 @@ def test_modern_settings_search_locates_rows_and_return_does_not_close(tmp_path,
     dialog.search_edit.setFocus()
     dialog.search_edit.setText("API 地址")
     app.processEvents()
-    # AI 设置页索引：Windows 上「主动识屏」页占位 index 4，其余平台为 4
-    assert dialog.sidebar.currentRow() == (5 if sys.platform == "win32" else 4)
+    # AI 设置页索引：常规/灵动岛/桌宠行为/外观/快捷启动，Windows 再插主动识屏
+    assert dialog.sidebar.currentRow() == (6 if sys.platform == "win32" else 5)
     api_row = dialog.findChild(settings_mod.SettingRow, "settingRow_api_url")
     assert api_row.property("searchMatch") is True
     QTest.keyClick(dialog.search_edit, Qt.Key.Key_Return)

--- a/tests/test_first_batch_features.py
+++ b/tests/test_first_batch_features.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+"""第一批功能：灵动岛配置/点击台词绑定/聊天窗置顶的基础测试。"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from PySide6.QtWidgets import QApplication
+
+from pet.config import Config
+
+
+def _config(tmp_path: Path) -> Config:
+    return Config(tmp_path)
+
+
+def test_config_click_talk_bindings_roundtrip(tmp_path: Path):
+    cfg = _config(tmp_path)
+    cfg.set_click_talk_bindings("shenshen", {
+        "点击回应 - 开心跃动": ["好耶！", "今天也要开心～"],
+        "点击回应 - 傲娇生气": ["哼！"],
+    })
+
+    reloaded = Config(tmp_path)
+    assert reloaded.click_talk_texts_for("shenshen", "点击回应 - 开心跃动") == ["好耶！", "今天也要开心～"]
+    assert reloaded.click_talk_texts_for("shenshen", "点击回应 - 傲娇生气") == ["哼！"]
+    assert reloaded.click_talk_texts_for("shenshen", "未绑定动画") == []
+
+
+def test_config_dynamic_island_keeps_at_least_one_component(tmp_path: Path):
+    cfg = _config(tmp_path)
+    cfg.set("dynamic_island", {
+        "enabled": True,
+        "show_icon": False,
+        "show_name": False,
+        "show_info": False,
+        "info_mode": "time",
+        "custom_text": "",
+        "show_status": False,
+        "x": None,
+        "y": None,
+    })
+
+    island = cfg.get("dynamic_island")
+    assert island["enabled"] is True
+    assert island["show_info"] is True  # 至少保留一个组件
+
+
+def test_modern_chat_window_pin_toggle_persists(tmp_path: Path):
+    app = QApplication.instance() or QApplication([])
+    from pet.chat.widgets import ChatWindow
+
+    cfg = _config(tmp_path)
+    win = ChatWindow(cfg, "shenshen")
+    try:
+        assert hasattr(win, "pin_button")
+        win.pin_button.setChecked(True)
+        win.toggle_always_on_top()
+        assert cfg.get("chat_always_on_top") is True
+        assert bool(win.windowFlags() & __import__("PySide6.QtCore", fromlist=["Qt"]).Qt.WindowType.WindowStaysOnTopHint)
+        win.pin_button.setChecked(False)
+        win.toggle_always_on_top()
+        assert cfg.get("chat_always_on_top") is False
+    finally:
+        win.close()
+        app.processEvents()
+
+
+def test_dynamic_island_widget_import_and_signal(tmp_path: Path):
+    app = QApplication.instance() or QApplication([])
+    from pet.dynamic_island import DynamicIsland
+
+    cfg = _config(tmp_path)
+    cfg.set("dynamic_island", {
+        "enabled": True,
+        "show_icon": True,
+        "show_name": True,
+        "show_info": True,
+        "info_mode": "time",
+        "custom_text": "",
+        "show_status": True,
+        "x": 100,
+        "y": 100,
+    })
+    island = DynamicIsland(cfg)
+    clicks = []
+    island.clicked.connect(lambda: clicks.append(1))
+    island.show()
+    app.processEvents()
+    island.clicked.emit()
+    assert clicks == [1]
+    island.hide()
+    island.deleteLater()
+    app.processEvents()

--- a/tests/test_first_batch_features.py
+++ b/tests/test_first_batch_features.py
@@ -78,6 +78,7 @@ def test_dynamic_island_widget_import_and_signal(tmp_path: Path):
         "info_mode": "time",
         "custom_text": "",
         "show_status": True,
+        "style": "glass",
         "x": 100,
         "y": 100,
     })
@@ -88,6 +89,37 @@ def test_dynamic_island_widget_import_and_signal(tmp_path: Path):
     app.processEvents()
     island.clicked.emit()
     assert clicks == [1]
+    assert island.width() > 0
+    island.hide()
+    island.deleteLater()
+    app.processEvents()
+
+
+def test_dynamic_island_resizes_when_info_changes(tmp_path: Path):
+    app = QApplication.instance() or QApplication([])
+    from pet.dynamic_island import DynamicIsland
+
+    cfg = _config(tmp_path)
+    cfg.set("dynamic_island", {
+        "enabled": True,
+        "show_icon": True,
+        "show_name": True,
+        "show_info": True,
+        "info_mode": "balance",
+        "custom_text": "",
+        "show_status": True,
+        "style": "dark",
+        "x": 100,
+        "y": 100,
+    })
+    island = DynamicIsland(cfg)
+    width_before = island.width()
+    island.set_balance_info(
+        "当前高峰 · 下周一 09:00 切换",
+        "余额 ¥123.45（充值 ¥200.00 / 赠送 ¥0.00）",
+    )
+    app.processEvents()
+    assert island.width() > width_before
     island.hide()
     island.deleteLater()
     app.processEvents()


### PR DESCRIPTION
## 第一批功能

按之前评估，先落地低风险三项：

### 1. 独立灵动岛（Dynamic Island）
- 新增 `pet/dynamic_island.py`：独立胶囊顶层窗口（Frameless + Tool + StaysOnTop + 透明背景）
- 支持图标 / 名称 / 信息槽 / 状态灯组件显隐，至少保留一个组件
- 信息槽支持：当前时间 / 余额峰谷 / 余额数值 / 自定义短文本
- 支持拖拽、屏幕顶部吸附、位置持久化
- 单击胶囊切换桌宠显示/隐藏；桌宠隐藏后灵动岛继续常驻
- 设置页新增「灵动岛」页：整体开关 + 组件显隐 + 信息槽模式 + 自定义文本
- 余额信息通过 `set_balance_info` 同步给灵动岛

### 2. 聊天窗置顶图钉
- 配置项 `chat_always_on_top`
- 现代聊天窗与经典聊天窗标题栏均新增图钉按钮
- 切换置顶时保留窗口位置、尺寸、可见与激活状态
- 设置关闭后通过 `refresh_settings` 同步图钉状态

### 3. 点击动画台词绑定
- 配置层新增 `character_profiles[character_id].click_talk_bindings`
- 每个点击动画可绑定多条专属自言自语台词
- 点击角色时优先播放当前动画绑定的台词；未绑定回退全局随机自言自语
- 设置页「自言自语」新增「点击动画台词绑定」编辑对话框

## 测试
- 新增 `tests/test_first_batch_features.py`：配置往返、灵动岛最小组件、灵动岛信号、聊天窗图钉
- 更新设置页相关索引测试
- 全量测试：**528 passed / 5 skipped**
