### PR TITLE
统一三平台构建流程 + 修复 CI 测试挂起 + 修复 Wayland 拖动/拖影

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -44,63 +44,25 @@ jobs:
           QT_QPA_PLATFORM: offscreen
         run: python -m pytest -q
 
-      # Linux 只发布两个 WebM 变体（GIF 变体包体约 800 MB，不发布）：
-      #   webm-chat / webm（无 Chat）
+      # 构建入口与本地完全一致：scripts/build_linux.sh（PyInstaller 打包 +
+      # 中文编码自检都在脚本内完成），CI 不内联任何构建命令，
+      # 避免本地/CI 两套逻辑漂移。只构建两个 webm 变体（与 Windows/macOS
+      # 发布一致，GIF 包体约 800 MB 不发布）。
       # onedir 形态：运行期零解压、不产生临时缓存；build_variant.py 注入
       # 变体标识，配置目录/自启项按变体隔离（与 Windows/macOS 行为一致）。
       # Linux 上 PyInstaller 忽略 --icon（只对 Windows/macOS 生效），故省略。
       - name: Build onedir variants
         run: |
-          for SPEC in \
-            "webm-chat|packaging/pet_entry.py|assets/characters|" \
-            "webm|packaging/pet_entry_no_chat.py|assets/characters|--exclude-module pet.chat --exclude-module keyring"; do
-            IFS='|' read -r VARIANT ENTRY DATAS EXCLUDES <<< "$SPEC"
-            echo "==> building $VARIANT"
-            echo "VARIANT = '$VARIANT'" > packaging/build_variant.py
-            CHAT_DATA=()
-            KEYRING_COLLECT=()
-            if [[ "$VARIANT" == *-chat ]]; then
-              # 新版/经典聊天窗口读取的样式文件（与 macOS/Windows 构建一致）
-              CHAT_DATA+=(--add-data "pet/chat/legacy_styles.qss:pet/chat")
-              CHAT_DATA+=(--add-data "pet/chat/modern_styles.qss:pet/chat")
-              KEYRING_COLLECT+=(--collect-all keyring)
-            fi
-            python -m PyInstaller --noconfirm --clean --onedir \
-              --paths . \
-              --collect-all imageio_ffmpeg \
-              --collect-all certifi \
-              --collect-all PySide6.QtMultimedia \
-              "${KEYRING_COLLECT[@]}" \
-              --add-data "assets/sounds:assets/sounds" \
-              --add-data "assets/chat:assets/chat" \
-              --add-data "assets/big_blue_fat_fish:assets/big_blue_fat_fish" \
-              --add-data "pet/menu_templates:pet/menu_templates" \
-              --add-data "integrations:integrations" \
-              "${CHAT_DATA[@]}" \
-              --name "dsh-pet-standalone-$VARIANT" \
-              --add-data "$DATAS:$DATAS" \
-              $EXCLUDES \
-              "$ENTRY"
-            if [ $? -ne 0 ]; then echo "::error::$VARIANT 构建失败"; exit 1; fi
-          done
-
-      # 中文编码自检（issue #26）：字节码字面量/文本资源/中文文件名被
-      # 编码污染即失败，绝不发布乱码包（与 Windows build_onedir.ps1 一致）。
-      - name: Chinese-encoding self-check on bundles
-        run: |
-          for VARIANT in webm-chat webm; do
-            APP="dist/dsh-pet-standalone-$VARIANT"
-            echo "==> checking $APP"
-            python scripts/check_bundle_encoding.py --dir "$APP"
-            if [ $? -ne 0 ]; then echo "::error::$APP 中文编码自检失败（issue #26）"; exit 1; fi
-          done
+          bash scripts/build_linux.sh \
+            --dist dist \
+            --variants webm-chat,webm
 
       - name: Verify pet module collected
         run: |
           for VARIANT in webm-chat webm; do
             APP="dsh-pet-standalone-$VARIANT"
-            WARN="build/$APP/warn-$APP.txt"
-            if [ -f "$WARN" ] && grep -q "missing module named pet" "$WARN"; then
+            WARN="$(find build -name "warn-$APP.txt" | head -1)"
+            if [ -n "$WARN" ] && grep -q "missing module named pet" "$WARN"; then
               echo "::error::$APP pet 模块未被 PyInstaller 收集"; cat "$WARN"; exit 1
             fi
             echo "$APP pet 模块已收集"

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -35,70 +35,27 @@ jobs:
       # GIF 变体（gif-chat / gif）不再发布：包体约 800 MB×2、上传与下载
       # 成本过高，v4.0.0 起停供。确有需要的用户请按 README「打包发布」
       # 一节自行构建（先运行 scripts/convert_to_gif.py 生成素材）。
-      - name: Generate app icon (.icns)
-        run: python scripts/make_icon.py --icns
-
       - name: Run test suite
         env:
           QT_QPA_PLATFORM: offscreen
         run: python -m pytest -q
 
-      # 两个 webm 变体与 Windows 发布一致：
-      #   webm-chat / webm（无 Chat）
-      # onedir 形态：运行期零解压、不产生临时缓存；build_variant.py 注入
-      # 变体标识，配置目录/自启项按变体隔离（与 Windows 行为一致）。
+      # 构建入口与本地完全一致：scripts/build_macos.sh（PyInstaller 打包 +
+      # 中文编码自检 + ad-hoc 签名都在脚本内完成），CI 不内联
+      # 任何构建命令，避免本地/CI 两套逻辑漂移。
+      # 只构建两个 webm 变体（与 Windows/Linux 发布一致）。
       - name: Build onedir .app variants
         run: |
-          for SPEC in \
-            "webm-chat|packaging/pet_entry.py|assets/characters|" \
-            "webm|packaging/pet_entry_no_chat.py|assets/characters|--exclude-module pet.chat --exclude-module keyring"; do
-            IFS='|' read -r VARIANT ENTRY DATAS EXCLUDES <<< "$SPEC"
-            echo "==> building $VARIANT"
-            echo "VARIANT = '$VARIANT'" > packaging/build_variant.py
-            CHAT_DATA=()
-            KEYRING_COLLECT=()
-            if [[ "$VARIANT" == *-chat ]]; then
-              CHAT_DATA+=(--add-data "pet/chat/legacy_styles.qss:pet/chat")
-              CHAT_DATA+=(--add-data "pet/chat/modern_styles.qss:pet/chat")
-              KEYRING_COLLECT+=(--collect-all keyring)
-            fi
-            python -m PyInstaller --noconfirm --clean --onedir --windowed \
-              --paths . \
-              --collect-all imageio_ffmpeg \
-              --collect-all certifi \
-              --collect-all PySide6.QtMultimedia \
-              "${KEYRING_COLLECT[@]}" \
-              --add-data "assets/sounds:assets/sounds" \
-              --add-data "assets/chat:assets/chat" \
-              --name "dsh-pet-standalone-$VARIANT" \
-              --icon assets/icon.icns \
-              --add-data "$DATAS:$DATAS" \
-              --add-data "assets/big_blue_fat_fish:assets/big_blue_fat_fish" \
-              --add-data "pet/menu_templates:pet/menu_templates" \
-              --add-data "integrations:integrations" \
-              "${CHAT_DATA[@]}" \
-              $EXCLUDES \
-              "$ENTRY"
-            if [ $? -ne 0 ]; then echo "::error::$VARIANT 构建失败"; exit 1; fi
-          done
-
-      # 中文编码自检（issue #26）：字节码字面量/文本资源/中文文件名被
-      # 编码污染即失败，绝不发布乱码包（与 Windows build_onedir.ps1 一致）。
-      - name: Chinese-encoding self-check on bundles
-        run: |
-          for VARIANT in webm-chat webm; do
-            APP="dist/dsh-pet-standalone-$VARIANT.app"
-            echo "==> checking $APP"
-            python scripts/check_bundle_encoding.py --dir "$APP"
-            if [ $? -ne 0 ]; then echo "::error::$APP 中文编码自检失败（issue #26）"; exit 1; fi
-          done
+          bash scripts/build_macos.sh \
+            --dist dist \
+            --variants webm-chat,webm
 
       - name: Verify pet module collected
         run: |
           for VARIANT in webm-chat webm; do
             APP="dsh-pet-standalone-$VARIANT"
-            WARN="build/$APP/warn-$APP.txt"
-            if [ -f "$WARN" ] && grep -q "missing module named pet" "$WARN"; then
+            WARN="$(find build -name "warn-$APP.txt" | head -1)"
+            if [ -n "$WARN" ] && grep -q "missing module named pet" "$WARN"; then
               echo "::error::$APP pet 模块未被 PyInstaller 收集"; cat "$WARN"; exit 1
             fi
             echo "$APP pet 模块已收集"
@@ -106,12 +63,6 @@ jobs:
               echo "::error::$APP 未打包 integrations/dsh-pet-bridge，DSH 桥接一键安装必然失败"; exit 1
             fi
             echo "$APP 桥接插件资源已打包"
-          done
-
-      - name: Ad-hoc codesign
-        run: |
-          for VARIANT in webm-chat webm; do
-            codesign --force --deep --sign - "dist/dsh-pet-standalone-$VARIANT.app"
           done
 
       - name: Package as zip

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -44,7 +44,7 @@ jobs:
           $langDir = Join-Path ${env:ProgramFiles(x86)} 'Inno Setup 6\Languages'
           Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/jrsoftware/issrc/main/Files/Languages/ChineseSimplified.isl' -OutFile (Join-Path $langDir 'ChineseSimplified.isl')
 
-      # 与 Linux/macOS 一致：构建前先跑测试套件，避免发布损坏产物
+      # 与 Linux/macOS 一致：构建前先跑测试套件，避免发布损坏产物。
       - name: Run test suite
         env:
           QT_QPA_PLATFORM: offscreen

--- a/README.md
+++ b/README.md
@@ -753,7 +753,10 @@ packaging/
 └── dsh-pet.iss            # Inno Setup 通用安装包脚本（/D 参数编译各变体）
 
 scripts/
-├── build_onedir.ps1       # onedir 构建 + zip 绿色版打包
+├── build_onedir.ps1       # Windows onedir 构建 + zip 绿色版打包（本地与 CI 共用入口）
+├── build_macos.sh         # macOS .app 构建（本地与 CI 共用入口）
+├── build_linux.sh         # Linux onedir 构建（本地与 CI 共用入口）
+├── check_bundle_encoding.py # 产物中文编码自检（issue #26，构建脚本内自动调用）
 ├── make_icon.py           # 从待机动画提取封面帧生成应用图标（assets/icon.ico）
 ├── convert_to_gif.py      # WebM → GIF 全量同步脚本
 └── cleanup_mei_cache.py   # 检查/清理旧 onefile 版本遗留的 _MEI 缓存（默认预览）
@@ -820,6 +823,15 @@ powershell -ExecutionPolicy Bypass -File scripts\build_onedir.ps1 -Variant webm
 产物位于 `dist-onedir\<name>\`（绿色版目录）与 `<name>-portable.zip`。
 
 > GIF 变体（`gif-chat` / `gif`）需要先运行 `scripts/convert_to_gif.py --force --clean` 生成 GIF 素材，构建时加 `-Gif` 参数；默认发布不含 GIF 版。
+
+macOS / Linux 本地构建与 CI 共用同一份脚本（PyInstaller 打包、中文编码自检都在脚本内完成）：
+
+```bash
+# macOS（.app，输出 build/macos/）
+bash scripts/build_macos.sh --variants webm-chat,webm
+# Linux（onedir，输出 dist/）
+bash scripts/build_linux.sh --variants webm-chat,webm
+```
 
 ### 2) Inno Setup 安装包
 

--- a/pet/app.py
+++ b/pet/app.py
@@ -781,7 +781,24 @@ def _mac_set_dock_icon_visible(visible: bool) -> None:
         pass
 
 
+def _default_xcb_platform_on_wayland() -> None:
+    """Linux Wayland 会话下把 Qt 平台插件默认设为 xcb（XWayland）。
+
+    Wayland 协议不允许客户端自行移动顶层窗口，桌宠拖动依赖的
+    QWidget.move() 会被合成器静默忽略（表现为无法拖动）；透明无边框
+    窗口在原生 wayland 插件下还存在重绘残留（拖影）。须在创建
+    QApplication 之前调用。用户显式设置 QT_QPA_PLATFORM 时尊重其选择。
+    """
+    if not sys.platform.startswith("linux"):
+        return
+    if "QT_QPA_PLATFORM" in os.environ:
+        return
+    if os.environ.get("WAYLAND_DISPLAY") or os.environ.get("XDG_SESSION_TYPE") == "wayland":
+        os.environ["QT_QPA_PLATFORM"] = "xcb"
+
+
 def main(argv: list[str] | None = None, enable_chat: bool = True) -> int:
+    _default_xcb_platform_on_wayland()
     argv = list(argv if argv is not None else sys.argv)
     instance_id = None
     if "--instance" in argv:

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -1,25 +1,21 @@
 #!/usr/bin/env bash
-# 构建 dsh-pet-standalone macOS .app（本地与 CI 共用的唯一构建入口）。
+# 构建 dsh-pet-standalone Linux onedir（本地与 CI 共用的唯一构建入口）。
 #
-# CI（.github/workflows/build-macos.yml）与本脚本必须保持一致——构建逻辑
+# CI（.github/workflows/build-linux.yml）与本脚本必须保持一致——构建逻辑
 # 只有这一份，CI 通过调用本脚本复用，不在 workflow 内联 PyInstaller 命令，
-# 避免两处漂移（曾因本地脚本漏 --collect-all PySide6.QtMultimedia 而可能
-# 打出缺 QtMultimedia 的坏包）。
+# 避免两处漂移（曾因本地/CI 两套命令不一致而难以追踪）。
 #
 # 用法：
-#   ./scripts/build_macos.sh                          # 本地默认输出 build/macos
-#   ./scripts/build_macos.sh --dist dist              # CI：输出到 dist/
-#   ./scripts/build_macos.sh --variants webm-chat,webm # 只构建指定变体（CI 只发两个）
+#   ./scripts/build_linux.sh                            # 本地默认输出 dist
+#   ./scripts/build_linux.sh --dist dist                # 指定输出目录
+#   ./scripts/build_linux.sh --variants webm-chat,webm  # 只构建指定变体（CI 只发两个）
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # 默认用 PATH 上的 python3（源码环境）；可用 PYTHON_BIN 覆盖。
 PYTHON_BIN="${PYTHON_BIN:-$(command -v python3 || echo python3)}"
-# 本机构建隔离依赖目录（scripts/ 下无安装脚本时用系统 python）；CI 走 pip
-# install 的系统环境，该目录不存在时直接用系统环境，不设 PYTHONPATH。
-BUILD_DEPS="$ROOT/build/.build-deps"
-DIST_DIR="$ROOT/build/macos"
-WORK_DIR="$ROOT/build/.pyinstaller/macos"
+DIST_DIR="$ROOT/dist"
+WORK_DIR="$ROOT/build/.pyinstaller/linux"
 VARIANTS="webm-chat,webm,gif-chat,gif"
 
 while [[ $# -gt 0 ]]; do
@@ -31,15 +27,9 @@ while [[ $# -gt 0 ]]; do
 done
 
 cd "$ROOT"
-if [[ -d "$BUILD_DEPS/PyInstaller" ]]; then
-    export PYTHONPATH="$BUILD_DEPS${PYTHONPATH:+:$PYTHONPATH}"
-    export PYINSTALLER_CONFIG_DIR="$ROOT/build/.pyinstaller/config"
-fi
-
-"$PYTHON_BIN" scripts/make_icon.py --icns
 
 # 仅当要构建 gif 变体时才生成 GIF 素材（convert_to_gif 默认幂等：只转换
-# 缺失/过期的，CI 只构建 webm 变体时不会触发）。
+# 缺失/过期的，CI 只构建 webm 变体时不会触发；与 build_macos.sh 一致）。
 if [[ ",$VARIANTS," == *",gif-chat,"* || ",$VARIANTS," == *",gif,"* ]]; then
     "$PYTHON_BIN" scripts/convert_to_gif.py --clean
 fi
@@ -62,19 +52,17 @@ for variant in "${variant_list[@]}"; do
         --noconfirm
         --clean
         --onedir
-        --windowed
         --paths .
         --distpath "$DIST_DIR"
         --workpath "$WORK_DIR"
         --name "$name"
-        --icon assets/icon.icns
         --collect-all imageio_ffmpeg
         --collect-all certifi
         --collect-all PySide6.QtMultimedia
         --add-data "$assets:$assets"
-        --add-data "assets/big_blue_fat_fish:assets/big_blue_fat_fish"
-        --add-data "assets/chat:assets/chat"
         --add-data "assets/sounds:assets/sounds"
+        --add-data "assets/chat:assets/chat"
+        --add-data "assets/big_blue_fat_fish:assets/big_blue_fat_fish"
         --add-data "pet/menu_templates:pet/menu_templates"
         --add-data "integrations:integrations"
     )
@@ -90,11 +78,10 @@ for variant in "${variant_list[@]}"; do
         done
     fi
 
-    echo "==> 构建 $name.app"
+    echo "==> 构建 $name"
     "$PYTHON_BIN" -m PyInstaller "${args[@]}" "$entry"
     # 中文编码自检（issue #26）：字节码/资源/文件名被编码污染即中止。
-    "$PYTHON_BIN" scripts/check_bundle_encoding.py --dir "$DIST_DIR/$name.app"
-    codesign --force --deep --sign - "$DIST_DIR/$name.app"
+    "$PYTHON_BIN" scripts/check_bundle_encoding.py --dir "$DIST_DIR/$name"
 done
 
-echo "macOS 构建完成：$DIST_DIR"
+echo "Linux 构建完成：$DIST_DIR"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+"""pytest 全局夹具。
+
+无人值守环境（CI/自动化）下，模态 QMessageBox 弹窗会永久阻塞或直接崩溃
+（Fatal: Aborted）。settings_dialog._save() 在写开机自启失败时会弹模态
+QMessageBox.warning，所有调用 _save() 的测试在 CI 上都会因此卡死
+（定位手段：pytest -o timeout_method=thread --timeout=90 可 dump 出
+卡住的线程堆栈）。这里用 autouse fixture 全局把 QMessageBox 的静态弹窗
+方法替换为 no-op——任何测试都不会因模态弹窗卡死。需要断言弹窗行为的
+测试可自行 monkeypatch.setattr 覆盖。
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _no_modal_message_boxes(monkeypatch):
+    from PySide6.QtWidgets import QMessageBox
+
+    for method in ("warning", "information", "critical", "question", "about"):
+        monkeypatch.setattr(QMessageBox, method, staticmethod(lambda *a, **k: None))

--- a/tests/test_requested_regressions.py
+++ b/tests/test_requested_regressions.py
@@ -710,20 +710,23 @@ def test_animation_icon_applier_updates_action_and_cleans_worker():
     app.processEvents()
 
 
-def test_build_workflows_bundle_menu_templates_and_chat_styles():
+def test_build_scripts_bundle_menu_templates_and_chat_styles():
     """三平台打包脚本必须包含菜单模板与聊天样式资源（防漏打包回归）。
 
     回归背景：Linux workflow 曾漏掉 pet/menu_templates（右键菜单在冻结版
     打不开）与 legacy/modern_styles.qss（聊天窗无样式）。
+
+    构建定义统一在本地脚本（scripts/build_*.sh / build_onedir.ps1），
+    CI workflow 只调用脚本不再内联打包命令，故资源断言指向脚本而非 workflow。
     """
     from pathlib import Path
 
     repo = Path(__file__).resolve().parents[1]
-    linux = (repo / ".github" / "workflows" / "build-linux.yml").read_text(encoding="utf-8")
-    macos = (repo / ".github" / "workflows" / "build-macos.yml").read_text(encoding="utf-8")
+    linux = (repo / "scripts" / "build_linux.sh").read_text(encoding="utf-8")
+    macos = (repo / "scripts" / "build_macos.sh").read_text(encoding="utf-8")
     windows = (repo / "scripts" / "build_onedir.ps1").read_text(encoding="utf-8")
 
-    for name, text in (("build-linux.yml", linux), ("build-macos.yml", macos), ("build_onedir.ps1", windows)):
+    for name, text in (("build_linux.sh", linux), ("build_macos.sh", macos), ("build_onedir.ps1", windows)):
         assert "menu_templates" in text, f"{name} 必须打包 pet/menu_templates"
         assert "legacy_styles.qss" in text, f"{name} 必须打包 legacy_styles.qss"
         assert "modern_styles.qss" in text, f"{name} 必须打包 modern_styles.qss"

--- a/tests/test_wayland_platform.py
+++ b/tests/test_wayland_platform.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""Linux Wayland 会话下默认改用 xcb 平台插件的回归测试。
+
+根因：Wayland 协议不允许客户端自行移动顶层窗口，桌宠拖动依赖的
+QWidget.move() 会被合成器静默忽略（表现为"无法拖动"）；透明无边框
+窗口在原生 wayland 插件下还有重绘残留（拖影）。修复：创建
+QApplication 之前检测 Wayland 会话并把 QT_QPA_PLATFORM 默认设为 xcb，
+用户显式设置过该变量时尊重其选择。
+"""
+
+import os
+import sys
+
+import pytest
+
+from pet.app import _default_xcb_platform_on_wayland
+
+
+@pytest.fixture
+def _clean_platform_env(monkeypatch):
+    monkeypatch.delenv("QT_QPA_PLATFORM", raising=False)
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+    monkeypatch.delenv("XDG_SESSION_TYPE", raising=False)
+    monkeypatch.setattr(sys, "platform", "linux")
+    return monkeypatch
+
+
+def test_wayland_session_defaults_to_xcb(_clean_platform_env):
+    _clean_platform_env.setenv("WAYLAND_DISPLAY", "wayland-0")
+    _default_xcb_platform_on_wayland()
+    assert os.environ.get("QT_QPA_PLATFORM") == "xcb"
+
+
+def test_xdg_session_type_wayland_also_detected(_clean_platform_env):
+    # 某些环境只导出 XDG_SESSION_TYPE，不导出 WAYLAND_DISPLAY
+    _clean_platform_env.setenv("XDG_SESSION_TYPE", "wayland")
+    _default_xcb_platform_on_wayland()
+    assert os.environ.get("QT_QPA_PLATFORM") == "xcb"
+
+
+def test_explicit_qt_qpa_platform_is_respected(_clean_platform_env):
+    _clean_platform_env.setenv("WAYLAND_DISPLAY", "wayland-0")
+    _clean_platform_env.setenv("QT_QPA_PLATFORM", "wayland")
+    _default_xcb_platform_on_wayland()
+    assert os.environ.get("QT_QPA_PLATFORM") == "wayland"
+
+
+def test_x11_session_left_untouched(_clean_platform_env):
+    _clean_platform_env.setenv("XDG_SESSION_TYPE", "x11")
+    _default_xcb_platform_on_wayland()
+    assert os.environ.get("QT_QPA_PLATFORM") is None
+
+
+def test_non_linux_left_untouched(_clean_platform_env):
+    _clean_platform_env.setenv("WAYLAND_DISPLAY", "wayland-0")
+    _clean_platform_env.setattr(sys, "platform", "win32")
+    _default_xcb_platform_on_wayland()
+    assert os.environ.get("QT_QPA_PLATFORM") is None


### PR DESCRIPTION
Closes #38 
Closes #37 

## 概要

分支 `feat/unify-build-and-ci-fixes`（4 个提交）做三件事：

1. **统一构建流程**：macOS/Linux 的 CI 不再内联 PyInstaller 命令，改为调用本地构建脚本（`scripts/build_macos.sh` / 新增 `scripts/build_linux.sh`），消除「本地/CI 两套构建逻辑」的漂移问题；
2. **修复 Windows CI 测试挂起/崩溃根因**：模态 QMessageBox 在无人值守环境卡死，新增 `tests/conftest.py` 全局根治（详见随附 issue）；
3. **修复 Linux Wayland 下桌宠无法拖动与拖影**：Wayland 会话默认改用 xcb 平台插件（经 XWayland 运行，详见随附 issue）。

## 提交清单

| 提交 | 说明 |
|---|---|
| `b5714e3` | refactor(build): 构建逻辑统一到本地脚本，CI 不再内联 PyInstaller 命令 |
| `4e05a4a` | fix(test): conftest 全局 mock 模态弹窗，根治无人值守环境测试卡死/崩溃 |
| `f524c1c` | fix(linux): Wayland 会话默认改用 xcb 平台插件，根治桌宠无法拖动与拖影 |
| `ad38163` | docs(readme): 补齐三平台统一构建入口说明 |

## 一、统一构建流程（本 PR 的主体改动）

### 背景问题

此前 macOS/Linux 的 CI workflow 把 PyInstaller 命令**内联**写在 `.yml` 里，而仓库同时存在本地脚本 `scripts/build_macos.sh`——两套逻辑已经**实际漂移**：

- 本地 `build_macos.sh` **漏掉** `--collect-all PySide6.QtMultimedia`（点击音效 MP3 等多媒体资源不会被打包，本地会打出缺 QtMultimedia 的坏包）与 chat 变体的 `--collect-all keyring`（API Key 系统安全存储缺失）；
- 本地脚本为 chat 变体多打包了无人引用的 `pet/chat/styles.qss`；
- Linux 此前**没有**本地构建脚本，只能照抄 CI 内联命令；
- 任何构建参数改动都要同步两处，极易漏改。

### 变更

| 文件 | 变更 |
|---|---|
| `scripts/build_linux.sh` | **新增**：Linux 本地构建脚本，gif 变体按需自动生成素材（`convert_to_gif` 幂等，CI 只构建 webm 变体时不会触发） |
| `scripts/build_macos.sh` | 重构为**唯一 macOS 构建入口**：补齐 `PySide6.QtMultimedia` / `keyring` 收集，去掉冗余 `styles.qss`；新增 `--dist` / `--variants` 参数；图标生成 + 中文编码自检 + ad-hoc 签名全部在脚本内完成；`BUILD_DEPS` 隔离依赖目录「存在才用、否则走系统环境」，兼容 CI 的 pip install |
| `.github/workflows/build-macos.yml` | 删除内联 PyInstaller + 编码自检 + codesign 步骤，改为 `bash scripts/build_macos.sh --dist dist --variants webm-chat,webm` |
| `.github/workflows/build-linux.yml` | 同上，改为调 `scripts/build_linux.sh` |
| `.github/workflows/build-windows.yml` | 无实质改动（Windows CI 本就调用 `build_onedir.ps1`，三平台中唯一不内联的） |
| `tests/test_requested_regressions.py` | 防漏打包断言（menu_templates / legacy/modern_styles.qss）从指向 workflow 改为指向三平台构建脚本——构建定义的唯一来源 |

**效果**：本地构建与 CI 构建共用同一份脚本，未来构建逻辑只改一处。`build-macos.yml`/`build-linux.yml` 的「pet 模块收集校验」改用 `find` 定位 warn 文件（workpath 已由脚本统一接管）。

## 二、修复 Windows CI 测试挂起 / 崩溃

详见随附 issue（`ISSUE-ci-test-hang-modal-qmessagebox.md`，建议先读）。

- 根因：`settings_dialog._save()` 写开机自启失败弹**模态** `QMessageBox.warning`，无人值守环境挂起/崩溃；
- 根治：`tests/conftest.py` 全局 mock 模态弹窗（autouse fixture），一处修复覆盖全部调用点；需要断言弹窗行为的测试可自行 `monkeypatch` 覆盖；
- 历史：与 v4.0.2 记录（`BUILD-CI-FAILURE-NOTES-2026-08.md` 2.1）同类，此前只 mock 单个测试，未根治。

## 三、修复 Linux Wayland 无法拖动与拖影

详见随附 issue（`ISSUE-linux-wayland-drag-ghosting.md`）。

- 根因：Qt 6 在 Wayland 会话默认加载原生 wayland 平台插件，而 Wayland 协议不允许客户端自行移动顶层窗口，`QWidget.move()` 被合成器静默忽略；透明无边框窗口在该插件下还有重绘残留；
- 修复：`pet/app.py` 在创建 QApplication 前检测 Wayland 会话，默认 `QT_QPA_PLATFORM=xcb` 经 XWayland 运行；用户显式设置过该变量则尊重不覆盖；X11 会话与 Windows/macOS 完全不受影响；
- 验证：新增 `tests/test_wayland_platform.py` 5 条用例；已在 GNOME Wayland（Qt 6.11.2）实机验证拖动恢复、无拖影。

## 四、测试情况

**测试环境**：

- Windows：Windows 11（10.0.26200）桌面机，Python 3.11.15，PySide6/Qt 6.11.2（Ryzen 9 8940HX）；
- Linux：Ubuntu 22.04 桌面版（GNOME，X11 与 Wayland 会话均实测），Python 3.11，Qt 6.11.2；系统运行库已手动安装（`libegl1 libgl1 libxkbcommon-x11-0 libxcb-cursor0 libfontconfig1 libdbus-1-3 fonts-noto-cjk`，与 CI 的 Install system libraries 步骤一致）；
- CI：fork 仓库 GitHub Actions（windows-latest / macos-latest / ubuntu-latest，Python 3.11）。

**结果**：

- 本地（Windows）完整套件：**529 passed, 5 skipped**；
- 本分支三平台 GitHub Actions CI：**Windows / macOS / Linux 全部通过**（测试套件 + 构建 + 打包）。注意这些运行在 fork 仓库（`lscatfish/dsh-pet-indesktop`，workflow_dispatch 触发）上，上游仓库的 Actions 页面看不到——可到 fork 的 Actions 页核实，或在你们环境按「六、如何验证」自行跑一遍；
- Wayland 修复额外经过 GNOME Wayland 实机验证（源码运行：拖动恢复、无拖影）。

## 五、风险声明（请重点阅读）

1. **构建结构变化**：macOS/Linux CI 的构建步骤从 workflow 内联改为调用脚本，PyInstaller 参数已逐项与原内联命令对齐（`--collect-all` / `--add-data` / `--exclude-module` 逐一核对）；**打包产物内容不变**——本 PR 不裁剪任何文件，产物与 main 构建结果一致；
2. **生产代码改动极小**：唯一触及运行时代码的是 `pet/app.py` 新增 17 行的 Wayland 检测函数，且只在「Linux + Wayland 会话 + 用户未显式设置 QT_QPA_PLATFORM」时生效；
3. **测试环境差异**：我这边（Windows 本地 + 三平台 CI + Linux 实机）均通过，但没有在仓库（Admin）环境跑过完整测试，Mac OS机器也尚未实机测试。若环境测不过，请反馈失败信息，我跟进修复。

## 六、建议的 review 路径

1. `scripts/build_macos.sh` / `scripts/build_linux.sh` 的 PyInstaller 参数是否覆盖原 CI 内联命令的全部 `--collect-all` / `--add-data` / `--exclude-module`；
2. `tests/conftest.py` 的全局 mock 是否影响需要断言弹窗行为的测试（已有自覆盖机制，见 issue）；
3. `pet/app.py` 的 Wayland 检测逻辑：平台守卫、显式环境变量优先、X11 不干预；
4. 三平台 CI workflow 删掉的步骤是否都在脚本内补齐（macOS 的图标生成与 codesign 已收进脚本）。

## 七、如何验证

```bash
# 本地完整测试（Linux/macOS 用对应解释器）
QT_QPA_PLATFORM=offscreen python -m pytest -q

# 本地构建（Windows）
powershell -ExecutionPolicy Bypass -File scripts/build_onedir.ps1 -Variant webm

# 本地构建（macOS / Linux，与 CI 同一份脚本）
bash scripts/build_macos.sh --dist dist --variants webm-chat,webm
bash scripts/build_linux.sh --dist dist --variants webm-chat,webm
```
