### PR TITLE
feat(quick-chat): 第二批——快速对话气泡

### DIFF
--- a/pet/app.py
+++ b/pet/app.py
@@ -180,6 +180,7 @@ class PetApp:
         self.chat_settings_dialog = None
         self.modern_settings_dialog = None
         self.island = None
+        self.quick_chat = None
         self._spawned_pet_count = 0
         self._pending_dialog_opens: set[str] = set()
         self._balance_busy = False
@@ -580,6 +581,21 @@ class PetApp:
         else:
             self.open_modern_chat()
 
+    def open_quick_chat(self) -> None:
+        """打开快速对话气泡；与完整聊天窗共用会话历史。"""
+        if not self.enable_chat or self.win is None:
+            return
+        from .quick_chat import QuickChatBubble
+
+        if self.quick_chat is None:
+            self.quick_chat = QuickChatBubble(self.config, pet_window=self.win)
+            self.quick_chat.open_chat_callback = self.open_chat
+        else:
+            self.quick_chat.pet_window = self.win
+            self.quick_chat.settings = self.config.chat_settings()
+            self.quick_chat.session = self.quick_chat._get_session()
+        self.quick_chat.show_for_pet(self.win)
+
     def open_legacy_chat(self) -> None:
         if not self.enable_chat or self.win is None:
             return
@@ -782,6 +798,7 @@ class PetApp:
 
         if self.enable_chat:
             menu.addAction('AI 对话', self.open_chat)
+            menu.addAction('快速对话（气泡）', self.open_quick_chat)
             menu.addAction('AI 设置', self.open_chat_settings)
         menu.addAction('桌宠设置', self.open_modern_settings)
 

--- a/pet/app.py
+++ b/pet/app.py
@@ -474,6 +474,7 @@ class PetApp:
         win = PetWindow(lib, self.config)
         win.on_switch_character = self.switch_character
         win.on_open_chat = self.open_chat if self.enable_chat else None
+        win.on_open_quick_chat = self.open_quick_chat if self.enable_chat else None
         win.on_open_chat_settings = self.open_chat_settings if self.enable_chat else None
         win.on_show_balance = self.show_balance if self.enable_chat else None
         win.on_check_update = self.check_update
@@ -534,6 +535,7 @@ class PetApp:
         win = PetWindow(lib, self.config)
         win.on_switch_character = self.switch_character
         win.on_open_chat = self.open_chat if self.enable_chat else None
+        win.on_open_quick_chat = self.open_quick_chat if self.enable_chat else None
         win.on_open_chat_settings = self.open_chat_settings if self.enable_chat else None
         win.on_show_balance = self.show_balance if self.enable_chat else None
         win.on_check_update = self.check_update

--- a/pet/quick_chat.py
+++ b/pet/quick_chat.py
@@ -40,11 +40,9 @@ class QuickChatBubble(QFrame):
             Qt.WindowType.Tool
             | Qt.WindowType.FramelessWindowHint
             | Qt.WindowType.WindowStaysOnTopHint
-            | Qt.WindowType.WindowDoesNotAcceptFocus
         )
         self.setWindowFlags(flags)
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
-        self.setAttribute(Qt.WidgetAttribute.WA_ShowWithoutActivating, True)
         self.setMinimumWidth(320)
         self.setMaximumWidth(460)
 
@@ -227,6 +225,7 @@ class QuickChatBubble(QFrame):
         self.position_near_pet()
         self.show()
         self.raise_()
+        self.activateWindow()
         self.input.setFocus()
 
     # ------------------------------------------------------------ 发送

--- a/pet/quick_chat.py
+++ b/pet/quick_chat.py
@@ -16,6 +16,7 @@ from PySide6.QtWidgets import (
     QLabel,
     QLineEdit,
     QPushButton,
+    QScrollArea,
     QVBoxLayout,
     QWidget,
 )
@@ -88,7 +89,15 @@ class QuickChatBubble(QFrame):
         self.output.setWordWrap(True)
         self.output.setMinimumHeight(60)
         self.output.setAlignment(Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignLeft)
-        layout.addWidget(self.output)
+        self.output_scroll = QScrollArea()
+        self.output_scroll.setObjectName("quick-chat-output-scroll")
+        self.output_scroll.setWidgetResizable(True)
+        self.output_scroll.setFrameShape(QFrame.Shape.NoFrame)
+        self.output_scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.output_scroll.setMinimumHeight(60)
+        self.output_scroll.setMaximumHeight(220)
+        self.output_scroll.setWidget(self.output)
+        layout.addWidget(self.output_scroll)
 
         self.page_widget = QWidget()
         self.page_row = QHBoxLayout(self.page_widget)
@@ -124,6 +133,7 @@ class QuickChatBubble(QFrame):
         self.setStyleSheet(f"""
             QLabel#quick-chat-title, QLabel#quick-chat-hint, QLabel#quick-chat-output,
             QLabel#quick-chat-page {{ background: transparent; color: {fg}; border: none; }}
+            QScrollArea#quick-chat-output-scroll {{ background: transparent; border: none; }}
             QPushButton {{
                 background: {border}; color: {fg}; border: none; border-radius: 8px;
                 padding: 3px 8px;

--- a/pet/quick_chat.py
+++ b/pet/quick_chat.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from PySide6.QtCore import Qt
-from PySide6.QtGui import QGuiApplication
+from PySide6.QtCore import QPointF, QRectF, Qt
+from PySide6.QtGui import QColor, QGuiApplication, QPainter, QPainterPath, QPen
 from PySide6.QtWidgets import (
     QFrame,
     QHBoxLayout,
@@ -19,6 +19,8 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+
+from .speech_bubble import BUBBLE_STYLE_PRESETS
 
 from .chat.models import ChatMessage
 from .chat.prompt import PromptBuilder
@@ -45,6 +47,10 @@ class QuickChatBubble(QFrame):
         self.setAttribute(Qt.WidgetAttribute.WA_ShowWithoutActivating, True)
         self.setMinimumWidth(320)
         self.setMaximumWidth(460)
+
+        style_id = str(config.get("self_talk_bubble_style", "classic_top") or "classic_top")
+        self._preset = BUBBLE_STYLE_PRESETS.get(style_id, BUBBLE_STYLE_PRESETS["classic_top"])
+        self._tail_up = False
 
         self.character_id = str(config.get("character", "shenshen"))
         self.settings = config.chat_settings()
@@ -114,6 +120,23 @@ class QuickChatBubble(QFrame):
         input_row.addWidget(self.send_btn)
         layout.addLayout(input_row)
 
+        bg = self._preset["background"]
+        fg = self._preset["foreground"]
+        border = self._preset["border"]
+        self.setStyleSheet(f"""
+            QLabel#quick-chat-title, QLabel#quick-chat-hint, QLabel#quick-chat-output,
+            QLabel#quick-chat-page {{ background: transparent; color: {fg}; border: none; }}
+            QPushButton {{
+                background: {border}; color: {fg}; border: none; border-radius: 8px;
+                padding: 3px 8px;
+            }}
+            QPushButton:hover {{ background: {fg}; color: {bg}; }}
+            QLineEdit {{
+                background: {bg}; color: {fg}; border: 1px solid {border};
+                border-radius: 8px; padding: 5px 8px;
+            }}
+        """)
+
     def _connect(self) -> None:
         self.close_btn.clicked.connect(self.close)
         self.send_btn.clicked.connect(self._send)
@@ -126,6 +149,43 @@ class QuickChatBubble(QFrame):
         self.service.finished.connect(self._finished)
         self.service.error.connect(self._error)
         self.service.stopped.connect(self._stopped)
+
+    # ------------------------------------------------------------ 绘制
+    def paintEvent(self, event) -> None:  # noqa: N802
+        del event
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+        rect = QRectF(self.rect()).adjusted(6, 8, -6, -8)
+        radius = float(self._preset.get("radius", 14))
+        body = QPainterPath()
+        body.addRoundedRect(rect, radius, radius)
+        tail = QPainterPath()
+        tip_x = rect.center().x()
+        if self._tail_up:
+            tip = QPointF(tip_x, rect.top() - 6)
+            tail.moveTo(QPointF(tip_x - 8, rect.top() + 2))
+            tail.lineTo(tip)
+            tail.lineTo(QPointF(tip_x + 8, rect.top() + 2))
+        else:
+            tip = QPointF(tip_x, rect.bottom() + 6)
+            tail.moveTo(QPointF(tip_x - 8, rect.bottom() - 2))
+            tail.lineTo(tip)
+            tail.lineTo(QPointF(tip_x + 8, rect.bottom() - 2))
+        tail.closeSubpath()
+        surface = body.united(tail).simplified()
+
+        # 柔和阴影
+        shadow = QPainterPath(surface)
+        shadow.translate(0, 2)
+        painter.setPen(Qt.PenStyle.NoPen)
+        painter.setBrush(QColor(self._preset.get("shadow", "#6b542b")))
+        painter.drawPath(shadow)
+
+        # 气泡主体
+        painter.setBrush(QColor(self._preset["background"]))
+        painter.setPen(QPen(QColor(self._preset["border"]), 1))
+        painter.drawPath(surface)
+        painter.end()
 
     # ------------------------------------------------------------ 会话
     def _get_session(self):
@@ -153,10 +213,13 @@ class QuickChatBubble(QFrame):
         h = self.height()
         x = anchor.center().x() - w // 2
         y = anchor.top() - h - 8
+        self._tail_up = False
         if y < available.top():
             y = anchor.bottom() + 8
+            self._tail_up = True
         x = max(available.left() + 4, min(x, available.right() - w - 4))
         self.move(x, y)
+        self.update()
 
     def show_for_pet(self, pet_window=None) -> None:
         if pet_window is not None:

--- a/pet/quick_chat.py
+++ b/pet/quick_chat.py
@@ -1,0 +1,260 @@
+# -*- coding: utf-8 -*-
+"""快速对话气泡（Quick Chat）。
+
+点击桌宠弹出的头顶小气泡输入框；回车发送，AI 回复在气泡内流式显示，
+与完整 AI 对话窗口共用同一会话历史（SessionStore / ChatService）。
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QGuiApplication
+from PySide6.QtWidgets import (
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from .chat.models import ChatMessage
+from .chat.prompt import PromptBuilder
+from .chat.service import ChatService
+from .chat.session_store import SessionStore
+
+_PAGE_SIZE = 500
+
+
+class QuickChatBubble(QFrame):
+    def __init__(self, config, pet_window=None, parent=None):
+        super().__init__(parent)
+        self.config = config
+        self.pet_window = pet_window
+        self.setObjectName("quick-chat-bubble")
+        flags = (
+            Qt.WindowType.Tool
+            | Qt.WindowType.FramelessWindowHint
+            | Qt.WindowType.WindowStaysOnTopHint
+            | Qt.WindowType.WindowDoesNotAcceptFocus
+        )
+        self.setWindowFlags(flags)
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+        self.setAttribute(Qt.WidgetAttribute.WA_ShowWithoutActivating, True)
+        self.setMinimumWidth(320)
+        self.setMaximumWidth(460)
+
+        self.character_id = str(config.get("character", "shenshen"))
+        self.settings = config.chat_settings()
+        self.prompt_builder = PromptBuilder(Path(__file__).resolve().parent.parent / "assets" / "characters")
+        self.store = SessionStore(config.dir, getattr(config, "instance_id", ""))
+        self.session = self._get_session()
+        self.service = ChatService(parent=self)
+        self._active_request_id: str | None = None
+        self._reply_text = ""
+        self._page = 0
+        self._pages: list[str] = []
+
+        self._build()
+        self._connect()
+
+    def _build(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(14, 12, 14, 12)
+        layout.setSpacing(8)
+
+        header = QHBoxLayout()
+        title = QLabel("快速对话")
+        title.setObjectName("quick-chat-title")
+        header.addWidget(title)
+        header.addStretch(1)
+        self.hint_label = QLabel("")
+        self.hint_label.setObjectName("quick-chat-hint")
+        header.addWidget(self.hint_label)
+        self.close_btn = QPushButton("×")
+        self.close_btn.setObjectName("quick-chat-close")
+        self.close_btn.setFixedSize(24, 24)
+        header.addWidget(self.close_btn)
+        layout.addLayout(header)
+
+        self.output = QLabel("")
+        self.output.setObjectName("quick-chat-output")
+        self.output.setWordWrap(True)
+        self.output.setMinimumHeight(60)
+        self.output.setAlignment(Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignLeft)
+        layout.addWidget(self.output)
+
+        self.page_widget = QWidget()
+        self.page_row = QHBoxLayout(self.page_widget)
+        self.page_row.setContentsMargins(0, 0, 0, 0)
+        self.prev_btn = QPushButton("←")
+        self.page_label = QLabel("")
+        self.next_btn = QPushButton("→")
+        for btn in (self.prev_btn, self.next_btn):
+            btn.setObjectName("quick-chat-page")
+            btn.setFixedSize(28, 24)
+        self.open_chat_btn = QPushButton("去聊天窗")
+        self.open_chat_btn.setObjectName("quick-chat-open")
+        self.page_row.addWidget(self.prev_btn)
+        self.page_row.addWidget(self.page_label)
+        self.page_row.addWidget(self.next_btn)
+        self.page_row.addStretch(1)
+        self.page_row.addWidget(self.open_chat_btn)
+        layout.addWidget(self.page_widget)
+        self.page_widget.setVisible(False)
+
+        input_row = QHBoxLayout()
+        self.input = QLineEdit()
+        self.input.setPlaceholderText("输入消息，回车发送…")
+        self.send_btn = QPushButton("发送")
+        self.send_btn.setObjectName("quick-chat-send")
+        input_row.addWidget(self.input, 1)
+        input_row.addWidget(self.send_btn)
+        layout.addLayout(input_row)
+
+    def _connect(self) -> None:
+        self.close_btn.clicked.connect(self.close)
+        self.send_btn.clicked.connect(self._send)
+        self.input.returnPressed.connect(self._send)
+        self.prev_btn.clicked.connect(lambda: self._show_page(self._page - 1))
+        self.next_btn.clicked.connect(lambda: self._show_page(self._page + 1))
+        self.open_chat_btn.clicked.connect(self._open_full_chat)
+        self.service.started.connect(self._started)
+        self.service.delta.connect(self._delta)
+        self.service.finished.connect(self._finished)
+        self.service.error.connect(self._error)
+        self.service.stopped.connect(self._stopped)
+
+    # ------------------------------------------------------------ 会话
+    def _get_session(self):
+        sessions = self.store.list(self.character_id)
+        return sessions[0] if sessions else self._new_session()
+
+    def _new_session(self):
+        session = self.store.create(
+            self.character_id,
+            self.settings.active_provider,
+            self.prompt_builder.effective_system_prompt(self.settings, self.character_id),
+        )
+        self.store.save(session)
+        return session
+
+    def position_near_pet(self) -> None:
+        pet = self.pet_window
+        if pet is None or not hasattr(pet, "visible_content_rect"):
+            return
+        anchor = pet.visible_content_rect()
+        screen = QGuiApplication.screenAt(anchor.center())
+        available = screen.availableGeometry() if screen else QGuiApplication.primaryScreen().availableGeometry()
+        self.adjustSize()
+        w = self.width()
+        h = self.height()
+        x = anchor.center().x() - w // 2
+        y = anchor.top() - h - 8
+        if y < available.top():
+            y = anchor.bottom() + 8
+        x = max(available.left() + 4, min(x, available.right() - w - 4))
+        self.move(x, y)
+
+    def show_for_pet(self, pet_window=None) -> None:
+        if pet_window is not None:
+            self.pet_window = pet_window
+        self.position_near_pet()
+        self.show()
+        self.raise_()
+        self.input.setFocus()
+
+    # ------------------------------------------------------------ 发送
+    def _send(self) -> None:
+        if self.service.busy:
+            self.service.stop()
+            return
+        text = self.input.text().strip()
+        if not text:
+            return
+        self.input.clear()
+        self.session.messages.append(ChatMessage("user", text))
+        self.store.save(self.session)
+        self.output.setText("")
+        self._reply_text = ""
+        self._page = 0
+        self._pages = []
+        self.page_widget.setVisible(False)
+        self.hint_label.setText("思考中…")
+        config = self.settings.active_config
+        config.api_key = self.config.resolve_api_key(config)
+        messages = self.prompt_builder.build_messages(
+            self.settings, self.character_id, self.session.messages[:-1], text
+        )
+        self._active_request_id = self.service.send(messages, config)
+
+    def _started(self, request_id: str) -> None:
+        if request_id != self._active_request_id:
+            return
+        self.hint_label.setText("生成中…")
+
+    def _delta(self, request_id: str, text: str) -> None:
+        if request_id != self._active_request_id:
+            return
+        self._reply_text += str(text)
+        self._render_reply()
+
+    def _finished(self, request_id: str, text: str) -> None:
+        if request_id != self._active_request_id:
+            return
+        self._reply_text = str(text or "")
+        self.session.messages.append(ChatMessage("assistant", self._reply_text))
+        self.store.save(self.session)
+        self._active_request_id = None
+        self.hint_label.setText("")
+        self._render_reply()
+
+    def _error(self, request_id: str, text: str) -> None:
+        if request_id != self._active_request_id:
+            return
+        self._active_request_id = None
+        self.hint_label.setText("")
+        self._reply_text = f"请求失败：{text}"
+        self._render_reply()
+
+    def _stopped(self, request_id: str) -> None:
+        if request_id != self._active_request_id:
+            return
+        self._active_request_id = None
+        self.hint_label.setText("已停止")
+
+    # ------------------------------------------------------------ 显示
+    def _render_reply(self) -> None:
+        text = self._reply_text
+        if len(text) > _PAGE_SIZE:
+            self._pages = [text[i:i + _PAGE_SIZE] for i in range(0, len(text), _PAGE_SIZE)]
+            self._show_page(0)
+            self.page_widget.setVisible(True)
+            self.open_chat_btn.setVisible(True)
+        else:
+            self._pages = []
+            self.page_widget.setVisible(False)
+            self.output.setText(text)
+
+    def _show_page(self, index: int) -> None:
+        if not self._pages:
+            return
+        self._page = max(0, min(index, len(self._pages) - 1))
+        self.output.setText(self._pages[self._page])
+        self.page_label.setText(f"{self._page + 1}/{len(self._pages)}")
+        self.prev_btn.setEnabled(self._page > 0)
+        self.next_btn.setEnabled(self._page < len(self._pages) - 1)
+
+    def _open_full_chat(self) -> None:
+        pet = self.pet_window
+        if pet is not None and callable(getattr(pet, "on_open_chat", None)):
+            pet.on_open_chat()
+        elif hasattr(self, "open_chat_callback") and callable(self.open_chat_callback):
+            self.open_chat_callback()
+
+    def closeEvent(self, event) -> None:  # noqa: N802
+        if self.service.busy:
+            self.service.stop()
+        super().closeEvent(event)

--- a/pet/speech_bubble.py
+++ b/pet/speech_bubble.py
@@ -15,7 +15,7 @@ import sys
 from math import ceil
 from pathlib import Path
 
-from PySide6.QtCore import QPoint, QPointF, QRect, QRectF, QSize, Qt, QTimer
+from PySide6.QtCore import QPoint, QPointF, QRect, QRectF, QSize, Qt, QTimer, Signal
 from PySide6.QtGui import (
     QColor, QFontMetrics, QGuiApplication, QPainter, QPainterPath, QPen,
     QPixmap, QTransform,
@@ -222,8 +222,11 @@ def bubble_rect_for_anchor(
 class PetSpeechBubble(QFrame):
     """不依赖桌宠透明窗口的独立气泡，支持跨屏幕边界自动选位。"""
 
+    clicked = Signal()
+
     def __init__(self, parent=None, style_id: str = "classic_top"):
         super().__init__(parent)
+        self._interactive = False
         self.setObjectName("pet-speech-bubble")
         flags = (
             Qt.WindowType.Tool
@@ -416,6 +419,18 @@ class PetSpeechBubble(QFrame):
                 width += min(104, ceil((length - 24) / 8) * 14)
         width = max(base_size.width(), min(320, width))
         return QSize(width, int(width * 195 / 240 + 0.5))
+
+    def set_interactive(self, on: bool) -> None:
+        """开启后气泡可被鼠标点击（用于触发快速对话），默认全透明穿透。"""
+        self._interactive = bool(on)
+        self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents, not self._interactive)
+
+    def mouseReleaseEvent(self, event) -> None:  # noqa: N802
+        if self._interactive and event.button() == Qt.MouseButton.LeftButton:
+            self.clicked.emit()
+            event.accept()
+            return
+        super().mouseReleaseEvent(event)
 
     def show_text(
         self,

--- a/pet/window.py
+++ b/pet/window.py
@@ -352,6 +352,7 @@ class PetWindow(QWidget):
         self.cfg = config
         self.on_switch_character = None  # 由 app 注入，用于运行时切换角色
         self.on_open_chat = None
+        self.on_open_quick_chat = None
         self.on_open_modern_chat = None
         self.on_open_chat_settings = None
         self.on_show_balance = None
@@ -2095,7 +2096,8 @@ class PetWindow(QWidget):
             if self.idles:
                 self._switch(self._pick(self.idles))  # 回待机缓冲
         elif dist < catalog.DRAG_THRESHOLD * self.scale:
-            self._on_click()
+            if not self._try_open_quick_chat_from_bubble(g):
+                self._on_click()
         self._dragging = False
         self._interaction_state = "IDLE"
         self._press_global = None
@@ -2108,6 +2110,19 @@ class PetWindow(QWidget):
 
     def _clear_just_dragged(self) -> None:
         self._just_dragged = False
+
+    def _try_open_quick_chat_from_bubble(self, global_pos) -> bool:
+        """点击桌宠头顶的气泡时打开快速对话（而不是触发 Q 弹）。"""
+        callback = getattr(self, "on_open_quick_chat", None)
+        if not callable(callback):
+            return False
+        bubble = getattr(self, "_speech_bubble", None)
+        if bubble is None or not bubble.isVisible():
+            return False
+        if not bubble.geometry().contains(global_pos):
+            return False
+        callback()
+        return True
 
     def _on_click(self) -> None:
         """真点击 → 随机一个点击回应动画，并重置当前动画（可连续点击打断）。"""

--- a/pet/window.py
+++ b/pet/window.py
@@ -297,6 +297,13 @@ def _set_windows_click_through(hwnd: int, enabled: bool, user32=None) -> bool:
     return True
 
 
+def _set_speech_bubble_interactive(pet) -> None:
+    """按当前是否可打开快速对话，切换气泡鼠标穿透/可点击。"""
+    setter = getattr(pet._speech_bubble, "set_interactive", None)
+    if callable(setter):
+        setter(callable(getattr(pet, "on_open_quick_chat", None)))
+
+
 class WindowsPerPixelInputController:
     """根据光标所在像素动态切换 layered window 的输入穿透。
 
@@ -409,6 +416,7 @@ class PetWindow(QWidget):
         self._speech_bubble = PetSpeechBubble(
             style_id=str(config.get('self_talk_bubble_style', DEFAULT_SELF_TALK_BUBBLE_STYLE))
         )
+        self._speech_bubble.clicked.connect(self._on_speech_bubble_clicked)
         self._look_busy = False
         self._last_look_ts = 0.0
         self.look_done.connect(self._on_look_done)
@@ -2111,6 +2119,10 @@ class PetWindow(QWidget):
     def _clear_just_dragged(self) -> None:
         self._just_dragged = False
 
+    def _on_speech_bubble_clicked(self) -> None:
+        if callable(getattr(self, "on_open_quick_chat", None)):
+            self.on_open_quick_chat()
+
     def _try_open_quick_chat_from_bubble(self, global_pos) -> bool:
         """点击桌宠头顶的气泡时打开快速对话（而不是触发 Q 弹）。"""
         callback = getattr(self, "on_open_quick_chat", None)
@@ -2359,6 +2371,7 @@ class PetWindow(QWidget):
             return False
         duration_ms = int(round(self._self_talk_duration_seconds * 1000))
         anchor = self.visible_content_rect()
+        _set_speech_bubble_interactive(self)
         self._speech_bubble.show_text(
             text, anchor, duration_ms, pet_scale=self.scale
         )
@@ -2377,6 +2390,7 @@ class PetWindow(QWidget):
         kind, value = random.choice(choices)
         duration_ms = int(round(self._self_talk_duration_seconds * 1000))
         anchor = self.visible_content_rect()
+        _set_speech_bubble_interactive(self)
         if kind == "image":
             return self._speech_bubble.show_image(
                 value, anchor, duration_ms, pet_scale=self.scale
@@ -2438,6 +2452,7 @@ class PetWindow(QWidget):
         """向桌宠头顶冒泡提示（app 层反馈用，非侵入）。重要气泡会占用气泡位。"""
         if not self.isVisible() or self._bubble_suppressed:
             return
+        _set_speech_bubble_interactive(self)
         self.hold_bubble(duration_ms / 1000.0 + 2.0)
         self._speech_bubble.show_text(
             str(text), self.visible_content_rect(), duration_ms,
@@ -2561,6 +2576,7 @@ class PetWindow(QWidget):
             return
         if not self.isVisible():
             return
+        _set_speech_bubble_interactive(self)
         self._speech_bubble.show_text(
             text, self.visible_content_rect(), duration_ms=2200,
             pet_scale=self.scale,

--- a/tests/test_second_batch.py
+++ b/tests/test_second_batch.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""第二批功能：快速对话气泡基础测试。"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from PySide6.QtWidgets import QApplication
+
+from pet.config import Config
+
+
+def _config(tmp_path: Path) -> Config:
+    return Config(tmp_path)
+
+
+def test_quick_chat_bubble_instantiates(tmp_path: Path):
+    app = QApplication.instance() or QApplication([])
+    from pet.quick_chat import QuickChatBubble
+
+    cfg = _config(tmp_path)
+    bubble = QuickChatBubble(cfg)
+    try:
+        assert bubble.input is not None
+        assert bubble.send_btn is not None
+        assert bubble.close_btn is not None
+    finally:
+        bubble.close()
+        app.processEvents()
+
+
+def test_quick_chat_long_reply_uses_pagination(tmp_path: Path):
+    app = QApplication.instance() or QApplication([])
+    from pet.quick_chat import QuickChatBubble
+
+    cfg = _config(tmp_path)
+    bubble = QuickChatBubble(cfg)
+    try:
+        bubble._reply_text = "长" * 1200
+        bubble._render_reply()
+        assert bubble.page_widget.isVisibleTo(bubble) or bubble.page_widget.isVisible()
+        assert len(bubble._pages) == 3
+        assert bubble.page_label.text() == "1/3"
+    finally:
+        bubble.close()
+        app.processEvents()


### PR DESCRIPTION
## 第二批功能

> 根据反馈，第二批只保留**快速对话气泡**；全局快捷键、AI 设置四页签不做。

### 快速对话气泡（Quick Chat）
- 新增 `pet/quick_chat.py`
- 独立气泡输入框，锚定桌宠 `visible_content_rect` 上方，空间不足时放到下方
- 回车发送，AI 回复在气泡内流式显示
- 复用 `ChatService` / `SessionStore` / `PromptBuilder`，与完整 AI 对话窗口**共用同一会话历史**
- 回复超过 500 字时自动分页（← / → 翻页），并提供「去聊天窗」入口
- 关闭时停止正在生成的请求
- 托盘菜单新增「快速对话（气泡）」入口（Chat 版）

## 测试
- 新增 `tests/test_second_batch.py`
- 全量测试：**534 passed / 5 skipped**
