### PR TITLE
fix(ipc): 修复 POSIX 下协调者被杀后选举死循环（issue #42 根因）

### DIFF
--- a/pet/collision_ipc.py
+++ b/pet/collision_ipc.py
@@ -107,27 +107,49 @@ class _CollisionWorker(QObject):
                 server.deleteLater()
                 self._connect_client()
                 return
-        if server.listen(self.name):
-            # 同一 Qt 进程中的 QLocalServer 在 Windows 上可能允许并行
-            # listen；进程内登记用于测试/嵌入式 harness 的同名候选收敛。
-            if self.name in self._local_election_names:
-                server.close()
-                server.deleteLater()
-                slot_manager.release_file_lock(self._coordinator_lock)
-                self._coordinator_lock = None
-                self._connect_client()
-                return
-            self._local_election_names.add(self.name)
-            self.server = server
-            self.epoch = secrets.token_hex(12)
-            server.newConnection.connect(self._accept_connection)
-            self._start_probe()
+        if not server.listen(self.name):
+            # POSIX 下被杀死/崩溃的旧协调者会残留 socket 文件，listen 报
+            # AddressInUseError（Windows 命名管道随进程死亡回收，无此问题）。
+            # 持有排他文件锁 ⇒ 旧协调者必死（flock 随进程死亡释放），先同步
+            # 探测同名服务确实无人应答，再清残留文件重试 listen（issue #42）。
+            if (sys.platform != "win32" and self._coordinator_lock is not None
+                    and not self._probe_live_server()):
+                QLocalServer.removeServer(self.name)
+                if server.listen(self.name):
+                    self._become_listener(server)
+                    return
+            server.deleteLater()
+            slot_manager.release_file_lock(self._coordinator_lock)
+            self._coordinator_lock = None
+            self._connect_client()
             return
-        # 只有连接验证失败并短暂重试后才清理残留服务。
-        server.deleteLater()
-        slot_manager.release_file_lock(self._coordinator_lock)
-        self._coordinator_lock = None
-        self._connect_client()
+        self._become_listener(server)
+
+    def _become_listener(self, server) -> None:
+        """listen 成功后的收敛：进程内同名候选去重，登记并启动决胜探测。"""
+        # 同一 Qt 进程中的 QLocalServer 在 Windows 上可能允许并行
+        # listen；进程内登记用于测试/嵌入式 harness 的同名候选收敛。
+        if self.name in self._local_election_names:
+            server.close()
+            server.deleteLater()
+            slot_manager.release_file_lock(self._coordinator_lock)
+            self._coordinator_lock = None
+            self._connect_client()
+            return
+        self._local_election_names.add(self.name)
+        self.server = server
+        self.epoch = secrets.token_hex(12)
+        server.newConnection.connect(self._accept_connection)
+        self._start_probe()
+
+    def _probe_live_server(self) -> bool:
+        """同步探测同名服务是否有活监听者（仅 POSIX 残留恢复路径使用）。"""
+        probe = QLocalSocket()
+        try:
+            probe.connectToServer(self.name)
+            return probe.waitForConnected(300)
+        finally:
+            probe.abort()
 
     def _start_probe(self) -> None:
         """Windows 命名管道允许并行 listen 时，用 QLocal 连接稳定决胜。"""
@@ -206,6 +228,10 @@ class _CollisionWorker(QObject):
             socket.readyRead.connect(lambda s=socket: self._read_socket(s))
             socket.disconnected.connect(lambda s=socket: self._peer_lost(s))
             socket.errorOccurred.connect(lambda _e, s=socket: self._peer_lost(s))
+            # POSIX 时序窗口：数据可能在 readyRead 槽连接之前就已到达，
+            # 不兜底读取的话这批数据不会再触发信号（表现为成员表为空）。
+            if socket.bytesAvailable():
+                self._read_socket(socket)
 
     def _register_self(self) -> None:
         self.members[self.runtime_id] = dict(self.latest_state, runtime_id=self.runtime_id,

--- a/tests/test_collision_ipc.py
+++ b/tests/test_collision_ipc.py
@@ -374,7 +374,6 @@ def test_two_sessions_elect_one_coordinator_and_stop(tmp_path):
     assert not second._thread.isRunning()
 
 
-@pytest.mark.skipif(sys.platform != "win32", reason="QLocalServer 子进程选举在 POSIX CI 上不稳定，Windows 覆盖即可")
 def test_subprocess_sessions_send_frames_and_reelect_after_parent_exits(tmp_path):
     name = "dsh-test-collision-subprocess-" + uuid.uuid4().hex
     script = r'''
@@ -426,7 +425,6 @@ session.stop()
     assert survivor.wait(timeout=5) == 0
 
 
-@pytest.mark.skipif(sys.platform != "win32", reason="QLocalServer 双会话成员同步在 POSIX CI 上不稳定，Windows 覆盖即可")
 def test_submit_leave_removes_member_immediately(tmp_path):
     """客户端 submit_leave 后，协调者成员表即时移除（不等 stale 超时）。"""
     QApplication.instance() or QApplication([])


### PR DESCRIPTION
# 修复 issue #42：POSIX 下协调者被杀后选举死循环

修复 #42 中记录的碰撞 IPC 技术债（QLocalServer 在 Linux/macOS 上的根因）。

## 根因（已实测复现，非推测）

**平台差异**：QLocalServer 在 Windows 底层是命名管道（进程死亡后内核自动回收），在 Linux/macOS 底层是 `/tmp` 下的真实 socket 文件（进程被杀后**文件残留**）。Qt 官方文档明确说明：Unix 下 server 崩溃后未正常 close，`listen()` 会失败并返回 `AddressInUseError`，需先 `removeServer()`。

**死循环链条**（`_CollisionWorker._try_election`）：

1. 协调者进程被 terminate → socket 文件残留在 `/tmp`
2. 幸存者经 flock 文件锁拿到选举权（锁随进程死亡释放，此步正常）
3. `listen()` → AddressInUseError → 转客户端 → 连接死 socket 被 ConnectionRefused → 重新调度选举 → `listen()` 再次失败 → **无限循环**
4. 原代码中唯一的 `removeServer` 在 `_welcome_timed_out` 路径，但该路径要求先成功连接（`_had_client_connection=True`）——死协调者永远连不上，所以残留文件**永远不会被清理**

Windows 上因为命名管道无残留，`listen()` 总能成功，所以此前测试全过，问题被掩盖。

## 修复内容（`pet/collision_ipc.py`，+46/-22）

1. **listen 失败恢复**：`listen()` 失败且持有排他文件锁时（锁随进程死亡释放 ⇒ 锁在手即证明旧协调者已死），先用 `QLocalSocket.waitForConnected(300ms)` 同步探测同名服务是否真有活监听者；无人应答才 `QLocalServer.removeServer()` 清残留并重试 `listen()`。探测步骤是为了避免误删不使用文件锁的旧版本实例的存活服务。仍失败才回退客户端模式。
2. **`_accept_connection` 加 `bytesAvailable()` 兜底读取**：数据在 `readyRead` 槽连接之前到达时（POSIX 时序窗口），立即主动读取——修复"客户端上报 state 但协调者成员表为空"的症状。
3. **恢复测试覆盖**：删除 `test_collision_ipc.py` 中两个用例的 POSIX `skipif`（`test_subprocess_sessions_send_frames_and_reelect_after_parent_exits`、`test_submit_leave_removes_member_immediately`），Linux/macOS 恢复真实覆盖。

Windows 行为不变：`listen()` 首次即成功，走不到新增路径。

## 验证过程（诚实声明边界）

**已验证：**

- WSL2（Fedora 43, 内核 6.6, PySide6, Python 3.14）上先用独立复现脚本确认根因：A 进程 listen 后被 `kill -9` → B 进程 `listen()` 返回 `AddressInUseError`、`connectToServer` 返回 `ConnectionRefusedError` → 与 CI 失败现象一致；`removeServer` 后 `listen()` 成功
- 同一 WSL 环境跑项目真实测试（手动摘掉 skipif）：修复前 `test_subprocess_sessions_...` **复现失败**（幸存者 6 秒内未成为协调者，与 CI 一致）；修复后 `test_collision_ipc.py` **19/19 全部通过**（含两个原被跳过的用例）
- Windows 11 全量回归：**652 passed / 5 skipped**，无回归

**未验证（如实说明）：**

- **未在真实 macOS 上测试**——修复依赖的 `removeServer` 语义是 Qt 官方文档明确支持的跨平台行为，理论上 macOS 同样适用，但没有实机验证；macOS 的 socket 路径在 `/var/folders/xx/.../T/` 下（QTBUG-67472），与 Linux 的 `/tmp` 不同，无法完全排除路径相关差异
- **未在真实 Linux 桌面环境做功能性验证**——只跑了 pytest 测试（offscreen 模式），没有实际运行多开桌宠验证碰撞功能在 Linux 桌面上的真实表现
- WSL2 与 GitHub Actions runner 环境存在差异（WSL2 是完整内核虚拟机），CI 上的最终表现建议合并前跑一轮三平台 workflow_dispatch 确认

## 测试

```
WSL2 Fedora 43: tests/test_collision_ipc.py 19/19 passed（含原 POSIX 跳过的 2 个用例）
Windows 11:     652 passed / 5 skipped（全量，QT_QPA_PLATFORM=offscreen）
```
