### PR TITLE
feat(agent-link): 自定义 Agent 联动通道 + 统一事件协议文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ pythonw -m pet
 ### Agent 联动（默认关闭）
 
 - 内置 DSH 桥接插件（`integrations/dsh-pet-bridge`）与 Claude hooks 安装器：感知 AI Agent 状态并切换动作，支持开始干活、过程汇报、任务完成三种气泡反馈，右键 Agent 联动子菜单可独立开关。
+- **自定义联动 Agent**：在 `config.json` 的 `agent_link.custom_agents` 里声明任意 Agent（key / 显示名 / 事件文件路径），桌宠即对其 JSONL 事件文件做只读监听，联动行为与内置 Agent 一致——不改代码即可接入任何能写本地文件的 Agent，协议详见 `docs/AGENT_LINK_PROTOCOL.md`。
 
 ### 看看屏幕（Chat 版）
 

--- a/docs/AGENT_LINK_PROTOCOL.md
+++ b/docs/AGENT_LINK_PROTOCOL.md
@@ -1,0 +1,171 @@
+# 多 Agent 联动统一事件协议与扩展指南
+
+> 文档用途：说明桌宠「Agent 联动」的底层事件协议，以及第三方如何接入任意 AI Agent（不改桌宠代码，或新增一个内置 Agent 各需要做什么）。
+> 读者：想把自家 Agent / CLI 工具接入桌宠联动的开发者与集成方。
+
+---
+
+## 1. 架构总览：本地文件事件总线（零网络）
+
+```
+Agent 侧（写方）                          桌宠侧（读方）
+┌──────────────────────────┐            ┌────────────────────────────────────┐
+│ 插件 / hooks / 直读适配    │   追加写    │ ByteOffsetTailer 字节偏移增量 tail   │
+│ DSH 桥接插件 (Node)       │  ────────▶ │ （1.5s QTimer，不回放历史）          │
+│ Claude Code hooks 脚本    │  JSONL 文件 │   ↓ normalize_event_state 归一      │
+│ Cursor/OpenCode 直读适配  │            │   ↓ 六态词汇                        │
+└──────────────────────────┘            │ AgentLinkManager 状态机             │
+                                        │   → 动画切换 / 气泡 / 音效           │
+                                        └────────────────────────────────────┘
+```
+
+- **通信方式**：纯本地文件追加写 + 增量读，无端口、无 HTTP、无 WebSocket。
+- **读方保证**：byte-offset tail 不回放历史事件；文件不存在时静默空转；半行缓冲不丢事件；单次读取有界（64KB）。
+- **低功耗**：联动默认全关；桌宠隐藏时监视器全线 pause，显示时 resume。
+
+## 2. 统一事件协议（写方契约）
+
+### 2.1 事件文件位置
+
+走统一通道的 Agent，事件文件固定为：
+
+```
+<config.dir>/agent-events/<agent>.jsonl
+```
+
+`<config.dir>` 按平台（`<变体>` 为 onedir 变体后缀，源码运行无后缀）：
+
+| 平台 | 路径 |
+|---|---|
+| Windows | `%APPDATA%\dsh-pet-standalone[-变体]\agent-events\` |
+| macOS | `~/Library/Application Support/dsh-pet-standalone[-变体]/agent-events/` |
+| Linux | `~/.config/dsh-pet-standalone[-变体]/agent-events/` |
+
+### 2.2 JSON 行格式
+
+文件每行一个 JSON 对象（JSON Lines，UTF-8 追加写）：
+
+```jsonc
+// 形态一：事件名（推荐，桌宠按内置映射归一为状态）
+{"ts": 1750000000.0, "agent": "myagent", "event": "PreToolUse", "tool": "bash"}
+
+// 形态二：显式状态（直接给六态词汇，优先级最高）
+{"ts": 1750000000.0, "agent": "myagent", "state": "working"}
+```
+
+| 字段 | 必填 | 说明 |
+|---|---|---|
+| `ts` | 建议 | 事件时间戳（秒，浮点）。桌宠当前不校验，但写方应带，便于排查 |
+| `agent` | 建议 | Agent 标识（与文件名一致即可）；桌宠以监视器的 agent_key 为准 |
+| `event` | 二选一 | 事件名，见 §2.4 内置映射；不认识的会被忽略 |
+| `state` | 二选一 | 显式状态，必须是 §2.3 六态词汇之一；优先于 `event` |
+| `tool` | 可选 | 工具名（小写），用于「过程汇报」气泡（如 `bash` → 「正在跑命令」） |
+
+### 2.3 六态状态词汇（读方统一词汇）
+
+| 状态 | 含义 | 桌宠反应 |
+|---|---|---|
+| `thinking` | 思考中/刚接受指令 | 联动动作池轮换（写代码/吃Token…），可选「开始干活」气泡 |
+| `working` | 执行中 | 同上 |
+| `attention` | 需要用户注意（如回合结束待确认） | 重要气泡「需要你看一眼～」或并入完成确认 |
+| `error` | 出错 | 重要气泡「好像遇到报错了…」+ error 音效 |
+| `idle` | 空闲 | 恢复待机动画；busy→idle 触发「干完活啦」完成通知（默认开） |
+| `sleeping` | 休眠 | 同 idle |
+
+### 2.4 内置事件名 → 状态映射
+
+写方若不想直接给 `state`，可使用以下事件名（与 Claude Code hooks 事件名兼容）：
+
+| 事件名 | 状态 |
+|---|---|
+| `SessionStart` / `SessionEnd` | `idle` |
+| `UserPromptSubmit` | `thinking` |
+| `PreToolUse` / `PostToolUse` | `working` |
+| `PostToolUseFailure` | `error` |
+| `Stop` / `SubagentStop` | `attention` |
+| `StopFailure` | `error` |
+| `error` / `idle` / `thinking` | 同名状态 |
+
+不在表内的事件名**一律忽略**（绝不默认当成 working，防止 transcript 类密集写入过度触发）。
+
+### 2.5 写方注意事项（对接清单）
+
+1. **追加写**（append），UTF-8 编码；PowerShell 写入方建议 `-Encoding UTF8`（读方已兼容首行 BOM）。
+2. **去重**：连续相同状态不要重复落盘（状态切换瞬间可能抖出重复事件，重复行会占住桌宠端换帧节流位）。
+3. **轮转**：事件文件超过约 1MB 时轮转（如 `dsh.jsonl` → `dsh.jsonl.1`，只留一代）；读方通过文件身份识别自动适配，无需特殊处理。
+4. **绝不阻塞宿主**：写事件失败时静默放弃——联动是锦上添花，不能影响 Agent 本体（参考 `integrations/dsh-pet-bridge/index.js` 的做法）。
+5. **隐私红线**：只写状态/事件元数据（状态、事件名、工具名），**不要**把代码内容、命令全文、文件内容、屏幕信息写进事件文件。
+
+## 3. 内置四种接入模式（现状分析）
+
+| Agent | 模式 | 事件来源 | 是否写外部配置 |
+|---|---|---|---|
+| DSH | 插件订阅 | 内置桥接插件 `integrations/dsh-pet-bridge/` 订阅 agent 生命周期事件，写桥目录 `<base>/dsh-pet-bridge/dsh.jsonl` | 安装/卸载 dsh 插件（弹窗同意） |
+| Claude Code | hooks 注入 | 向 `~/.claude/settings.json` 注入官方 hooks，落地脚本把事件写 `agent-events/claude.jsonl` | 注入/卸载 hooks（弹窗同意） |
+| Cursor | transcript 直读 | 直接 tail `~/.cursor/projects/**/agent-transcripts/*.jsonl`（官方转写文件，按 role/content 解析） | 否 |
+| OpenCode | 数据库直读 | 只读 `~/.local/share/opencode/opencode.db` 的 `event` 表（rowid 增量） | 否 |
+
+给新 Agent 选择接入模式的判断依据：
+
+- **Agent 有插件/hook 机制** → 优先「hook 注入 + 统一协议写文件」（模式同 Claude Code），这是侵入最小、协议最稳的方式。
+- **Agent 有现成的本地事件源**（transcript/日志/SQLite）→ 可以像 Cursor/OpenCode 那样写直读适配器（需要改桌宠代码，见 §5）。
+- **Agent 什么都没有** → 只要它能执行任意命令（几乎都能），就可以让它周期性地往统一协议文件追加一行 JSON——配合 §4 的自定义通道，零代码接入。
+
+## 4. 自定义 Agent 通道（不改桌宠代码）
+
+桌宠支持在 `config.json` 的 `agent_link` 块里声明任意数量的自定义联动 Agent：桌宠对其事件文件做**只读监听**（统一协议），不写任何外部配置、无需授权弹窗。
+
+```jsonc
+// <config.dir>/config.json
+{
+  "agent_link": {
+    "custom_agents": [
+      {
+        "key": "gemini",
+        "name": "Gemini CLI",
+        "path": "~/.gemini/pet-events.jsonl"
+      }
+    ]
+  }
+}
+```
+
+| 字段 | 约束 |
+|---|---|
+| `key` | `^[a-z0-9][a-z0-9_-]{0,31}$`，不得与内置键（`dsh`/`claude`/`cursor`/`opencode`）重复，全局唯一 |
+| `name` | 联动气泡/菜单显示名；留空时用 key |
+| `path` | 事件文件路径，支持 `~` 展开；文件不必预先存在（不存在时静默等待） |
+
+配置后重启桌宠（或重新加载配置）即生效：右键菜单「Agent 联动」会出现该 Agent 的开关，行为与内置 Agent 一致（六态映射、开始/过程/完成气泡、音效全部可用）。最多 8 个自定义条目。
+
+**接入示例**：让任意 Agent 在干活时执行（或由其 hook 执行）：
+
+```bash
+printf '{"ts": %s, "state": "working"}\n' "$(date +%s)" >> ~/.gemini/pet-events.jsonl   # 开工
+printf '{"ts": %s, "event": "PreToolUse", "tool": "bash"}\n' "$(date +%s)" >> ~/.gemini/pet-events.jsonl  # 过程
+printf '{"ts": %s, "state": "idle"}\n' "$(date +%s)" >> ~/.gemini/pet-events.jsonl      # 收工
+```
+
+## 5. 新增一个内置 Agent（改桌宠代码）
+
+若要走一等公民路径（内置开关、专属直读适配器），当前需要改动以下位置：
+
+| # | 位置 | 改什么 |
+|---|---|---|
+| 1 | `pet/config.py` `_default_agent_link_data()` | 新增默认开关键 |
+| 2 | `pet/config.py` `_clean_agent_link_data()` | 键列表加入新键 |
+| 3 | `pet/agent_link.py` `AgentLinkManager.__init__` | `monitors` 字典注册监视器实例 |
+| 4 | `pet/agent_link.py` `AgentLinkManager.AGENT_NAMES` | 显示名 |
+| 5 | `pet/context_menus/shared.py` `add_agent_link_menu()` | 菜单条目 |
+
+监视器实现上，走统一协议的只需继承 `BaseAgentMonitor`（参考 `CustomAgentMonitor`）；已有本地事件源的覆写 `_poll()`（参考 `CursorMonitor`/`OpenCodeMonitor`），把解析结果经 `state_changed`/`activity` 信号发出即可。
+
+> 后续演进方向（未实施）：把上述 5 处收敛为单一声明式注册表，内置与自定义 Agent 统一由注册表驱动。
+
+## 6. 隐私与安全红线（不可违反）
+
+1. **默认全关**：所有 Agent 联动开关默认关闭，用户显式勾选才启动。
+2. **零网络**：联动链路只碰本地文件/本地数据库，任何一方不得发起网络请求。
+3. **只存元数据**：事件文件只有状态/事件名/工具名，绝不写截图、代码内容、命令全文。
+4. **写外部配置必须先弹窗**：任何向 Agent 配置（如 `~/.claude/settings.json`、dsh profiles）注入内容的操作，必须先经用户确认，且卸载时只清理带本桌宠标记的条目。
+5. **自定义通道只读**：`custom_agents` 仅监听用户指定的文件，不创建目录、不写任何外部位置。

--- a/pet/agent_link.py
+++ b/pet/agent_link.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""多 Agent 状态感知与动作联动监视器模块（DSH / Claude Code / Cursor / OpenCode）。
+"""多 Agent 状态感知与动作联动监视器模块（DSH / Claude Code / Cursor / OpenCode / 自定义）。
 
 设计原则（手册 §8）：
 1. 绝不使用 mtime 盲轮询；
@@ -995,6 +995,30 @@ class OpenCodeMonitor(BaseAgentMonitor):
                 self.activity.emit("opencode", tool)
 
 
+class CustomAgentMonitor(BaseAgentMonitor):
+    """自定义联动 Agent 监视器（agent_link.custom_agents 配置驱动）。
+
+    只读监听用户指定路径的统一协议 JSONL 事件文件（docs/AGENT_LINK_PROTOCOL.md §4）：
+    不创建目录、不写任何外部位置、无需授权弹窗；文件不存在时静默空转等待，
+    出现后自动开始增量读取（backfill 防护跳过历史内容）。"""
+
+    def __init__(self, agent_key: str, config_dir: Path, events_path: str, parent=None) -> None:
+        super().__init__(agent_key, config_dir, parent)
+        self.events_file = Path(events_path).expanduser()
+        self.events_dir = self.events_file.parent
+        self._tailer = ByteOffsetTailer(self.events_file)
+
+    def start(self) -> None:
+        # 覆写基类 start：基类会 mkdir 事件目录，这里只读监听外部文件，
+        # 不替用户在任意路径创建目录
+        self._running = True
+        self._paused = False
+        self._tailer.reset()
+        if not self._timer.isActive():
+            self._timer.start()
+        log.info("Agent 监视器 [%s] 已启动 (%s)", self.agent_key, self.events_file)
+
+
 # ----------------------------------------------------------------------
 # Agent 联动总调度管理器
 # ----------------------------------------------------------------------
@@ -1060,6 +1084,19 @@ class AgentLinkManager(QObject):
             "cursor": CursorMonitor(self.config_dir, self),
             "opencode": OpenCodeMonitor(self.config_dir, self),
         }
+        # 自定义联动 Agent：配置驱动的只读监视器（key/path 已在 config 清洗时
+        # 保证合法唯一）；显示名合并进实例级 agent_names，类级 AGENT_NAMES
+        # 保持仅内置（modern_settings_dialog 等按内置枚举处不受影响）。
+        # 注意：运行中新增/修改 custom_agents 需重启桌宠生效。
+        self.agent_names: dict[str, str] = dict(self.AGENT_NAMES)
+        for item in (self.cfg.get("agent_link", {}).get("custom_agents") or []):
+            key = str(item.get("key") or "")
+            if not key or key in self.monitors:
+                continue
+            self.monitors[key] = CustomAgentMonitor(
+                key, self.config_dir, str(item.get("path") or ""), self,
+            )
+            self.agent_names[key] = str(item.get("name") or key)
 
         for mon in self.monitors.values():
             mon.state_changed.connect(self._on_agent_state)
@@ -1091,6 +1128,17 @@ class AgentLinkManager(QObject):
 
     def _warn_if_agent_absent(self, agent_key: str) -> None:
         """开启了联动但本机没装对应 Agent 时给用户提示（不然勾了永远没反应）。"""
+        # 自定义 Agent：事件文件尚未出现时提示路径，避免"勾了没反应"的困惑
+        mon = self.monitors.get(agent_key)
+        if isinstance(mon, CustomAgentMonitor):
+            if mon.events_file.exists() or not hasattr(self.win, "show_bubble"):
+                return
+            self.win.show_bubble(
+                f"已开启 {self.agent_names.get(agent_key, agent_key)} 联动监听，"
+                f"但事件文件还没出现——{mon.events_file} 有事件我才能感知到哦",
+                duration_ms=6000,
+            )
+            return
         hints = {
             "cursor": ("Cursor", Path.home() / ".cursor" / "projects"),
             "opencode": ("OpenCode", Path.home() / ".local" / "share" / "opencode" / "opencode.db"),
@@ -1373,11 +1421,11 @@ class AgentLinkManager(QObject):
         if not custom:
             custom = str(agent_cfg.get("thinking_text", "") or "").strip()
         if custom:
-            name = self.AGENT_NAMES.get(agent_key, agent_key)
+            name = self.agent_names.get(agent_key, agent_key)
             return custom.replace("{name}", name)
         if agent_key in self._THINKING_DEFAULTS:
             return self._THINKING_DEFAULTS[agent_key]
-        name = self.AGENT_NAMES.get(agent_key, agent_key)
+        name = self.agent_names.get(agent_key, agent_key)
         return f"{name} 正在深度烧烤……"
 
     def _maybe_notify_start(self, agent_key: str, prev_raw: str | None, state: str = "working") -> None:
@@ -1388,7 +1436,7 @@ class AgentLinkManager(QObject):
             return
         if prev_raw in self._BUSY_STATES:
             return
-        name = self.AGENT_NAMES.get(agent_key, agent_key)
+        name = self.agent_names.get(agent_key, agent_key)
         if state == "thinking":
             self._show_link_bubble(self._thinking_text(agent_key), important=False, duration_ms=3000)
         else:
@@ -1412,7 +1460,7 @@ class AgentLinkManager(QObject):
             return
         self._last_activity[agent_key] = (label, now)
         self._activity_global_last = now
-        name = self.AGENT_NAMES.get(agent_key, agent_key)
+        name = self.agent_names.get(agent_key, agent_key)
         # 低优先级：气泡位被占直接丢弃，不与重要气泡竞争
         self._show_link_bubble(f"{name} {label}…", important=False, duration_ms=2600)
 
@@ -1447,7 +1495,7 @@ class AgentLinkManager(QObject):
         if now - self._done_cooldown.get(agent_key, 0.0) < self._DONE_COOLDOWN_S:
             return
         self._done_cooldown[agent_key] = now
-        name = self.AGENT_NAMES.get(agent_key, agent_key)
+        name = self.agent_names.get(agent_key, agent_key)
         if agent_key in self._saw_alert:
             # busy 期间出现过 attention/error：不暗示"成功完成"
             text = f"{name} 那边停了，结果怎么样要主人自己看一眼哦"

--- a/pet/config.py
+++ b/pet/config.py
@@ -6,6 +6,7 @@ import copy
 import json
 import logging
 import os
+import re
 import shutil
 import sys
 from pathlib import Path
@@ -187,6 +188,9 @@ def _default_agent_link_data() -> dict:
         "claude": False,
         "cursor": False,
         "opencode": False,
+        # 自定义联动 Agent（协议见 docs/AGENT_LINK_PROTOCOL.md §4）：只读监听
+        # 用户指定的事件文件，不写外部配置、无需授权弹窗，默认空
+        "custom_agents": [],
         # 联动气泡：开始干活提醒（可选，默认关）、任务完成通知（默认开）
         "notify_state": False,
         "notify_done": True,
@@ -227,6 +231,41 @@ def _clean_click_sound_pack(value: Any) -> dict:
     }
 
 
+# 内置联动 Agent 键：custom_agents 的 key 不得与之重复
+_AGENT_LINK_BUILTIN_KEYS = ("dsh", "claude", "cursor", "opencode")
+# 自定义联动 Agent 条目上限（防配置文件被塞爆）
+_CUSTOM_AGENT_MAX = 8
+
+
+def _clean_custom_agents(raw: Any) -> list[dict]:
+    """清洗自定义联动 Agent 列表（agent_link.custom_agents）。
+
+    条目 {key, name, path}：key 为小写标识（不得与内置键/其他条目重复），
+    name 为显示名（缺省用 key），path 为事件文件路径（支持 ~，允许暂不存在）。
+    非法条目直接丢弃，超出上限截断。"""
+    if not isinstance(raw, list):
+        return []
+    result: list[dict] = []
+    seen: set[str] = set()
+    for item in raw:
+        if len(result) >= _CUSTOM_AGENT_MAX:
+            break
+        if not isinstance(item, dict):
+            continue
+        key = str(item.get("key") or "").strip().lower()
+        if not re.fullmatch(r"[a-z0-9][a-z0-9_-]{0,31}", key):
+            continue
+        if key in _AGENT_LINK_BUILTIN_KEYS or key in seen:
+            continue
+        path = str(item.get("path") or "").strip()[:500]
+        if not path:
+            continue
+        name = str(item.get("name") or "").strip()[:50] or key
+        seen.add(key)
+        result.append({"key": key, "name": name, "path": path})
+    return result
+
+
 def _clean_agent_link_data(raw: Any) -> dict:
     defaults = _default_agent_link_data()
     if not isinstance(raw, dict):
@@ -234,6 +273,7 @@ def _clean_agent_link_data(raw: Any) -> dict:
     result = dict(defaults)
     # 保留传入的额外合法键（例如 thinking_text, thinking_texts 等）
     result.update(raw)
+    result["custom_agents"] = _clean_custom_agents(raw.get("custom_agents"))
     for key in (
         "dsh", "claude", "cursor", "opencode", "notify_state", "notify_done", "notify_activity",
         "sound_enabled", "sound_start_enabled", "sound_done_enabled", "sound_error_enabled",

--- a/pet/context_menus/shared.py
+++ b/pet/context_menus/shared.py
@@ -328,7 +328,7 @@ def add_proactive_menu(menu: QMenu, pet) -> None:
 
 
 def add_agent_link_menu(menu: QMenu, pet) -> None:
-    """Agent 联动二级菜单（4 个 Agent 独立开关 + 气泡提醒选项，失败/拒绝自动回滚勾选）。"""
+    """Agent 联动二级菜单（4 个 Agent 独立开关 + 自定义 Agent + 气泡提醒选项，失败/拒绝自动回滚勾选）。"""
     sub = add_submenu(menu, "Agent 联动", None)
     agent_cfg = dict(pet.cfg.get('agent_link', {}))
     for agent_key, agent_label in (
@@ -341,6 +341,15 @@ def add_agent_link_menu(menu: QMenu, pet) -> None:
         act.setCheckable(True)
         act.setChecked(bool(agent_cfg.get(agent_key, False)))
         act.toggled.connect(lambda on, k=agent_key, a=act: pet._toggle_agent_link(k, on, a))
+    # 自定义联动 Agent（config.json 的 agent_link.custom_agents，只读监听）
+    for item in (agent_cfg.get('custom_agents') or []):
+        key = str(item.get('key') or '')
+        if not key:
+            continue
+        act = sub.addAction(str(item.get('name') or key))
+        act.setCheckable(True)
+        act.setChecked(bool(agent_cfg.get(key, False)))
+        act.toggled.connect(lambda on, k=key, a=act: pet._toggle_agent_link(k, on, a))
     sub.addSeparator()
     for opt_key, opt_label in (
         ('notify_state', '开始干活气泡提醒'),

--- a/tests/test_agent_link.py
+++ b/tests/test_agent_link.py
@@ -26,10 +26,12 @@ from pet.agent_link import (
     ByteOffsetTailer,
     ClaudeCodeMonitor,
     CursorMonitor,
+    CustomAgentMonitor,
     DshMonitor,
     normalize_event_state,
 )
 from pet.config import Config
+from pet.config import _clean_agent_link_data, _clean_custom_agents
 
 
 # ============================================================================
@@ -116,6 +118,7 @@ class TestAgentLinkManager:
             "claude": False,
             "cursor": False,
             "opencode": False,
+            "custom_agents": [],
             "notify_state": False,
             "notify_done": True,
             "notify_activity": False,
@@ -1478,3 +1481,216 @@ class TestOpenCodeSubagentFilter:
         assert mgr.busy_agent_owns_process("msedge.exe", "哔哩哔哩") is False
         mgr._last_raw["dsh"] = "idle"
         assert mgr.busy_agent_owns_process("msedge.exe", "审查结果 — DeepSeek Harness") is False
+
+
+# ============================================================================
+# 自定义联动 Agent（agent_link.custom_agents 配置驱动）
+# ============================================================================
+class TestCustomAgentConfigCleaning:
+    def test_valid_entry_kept_and_normalized(self):
+        cleaned = _clean_custom_agents([
+            {"key": "Gemini", "name": "  Gemini CLI  ", "path": " ~/.gemini/ev.jsonl "},
+        ])
+        assert cleaned == [{"key": "gemini", "name": "Gemini CLI", "path": "~/.gemini/ev.jsonl"}]
+
+    def test_name_defaults_to_key(self):
+        cleaned = _clean_custom_agents([{"key": "myagent", "path": "~/x.jsonl"}])
+        assert cleaned == [{"key": "myagent", "name": "myagent", "path": "~/x.jsonl"}]
+
+    def test_invalid_entries_dropped(self):
+        cleaned = _clean_custom_agents([
+            "not-a-dict",                                # 非对象
+            {"key": "Bad Key", "path": "~/x.jsonl"},     # key 含空格/大写
+            {"key": "claude", "path": "~/x.jsonl"},      # 与内置键冲突
+            {"key": "ok", "path": ""},                   # 空 path
+            {"key": "ok2"},                              # 缺 path
+        ])
+        assert cleaned == []
+
+    def test_duplicate_keys_deduped(self):
+        cleaned = _clean_custom_agents([
+            {"key": "gemini", "path": "~/a.jsonl"},
+            {"key": "gemini", "path": "~/b.jsonl"},
+        ])
+        assert len(cleaned) == 1
+        assert cleaned[0]["path"] == "~/a.jsonl"
+
+    def test_max_entries_truncated(self):
+        raw = [{"key": f"agent{i}", "path": f"~/{i}.jsonl"} for i in range(20)]
+        assert len(_clean_custom_agents(raw)) == 8
+
+    def test_non_list_returns_empty(self):
+        assert _clean_custom_agents(None) == []
+        assert _clean_custom_agents({"key": "gemini"}) == []
+
+    def test_clean_agent_link_data_cleans_and_keeps_custom_key_booleans(self):
+        cleaned = _clean_agent_link_data({
+            "custom_agents": [{"key": "gemini", "name": "Gemini CLI", "path": "~/ev.jsonl"}],
+            "gemini": True,       # 自定义键的开关布尔（set_enabled 写入路径）
+            "notify_done": False,
+        })
+        assert cleaned["custom_agents"] == [{"key": "gemini", "name": "Gemini CLI", "path": "~/ev.jsonl"}]
+        assert cleaned["gemini"] is True
+        assert cleaned["notify_done"] is False
+
+
+class TestCustomAgentMonitor:
+    def test_tail_events_and_signals(self, tmp_path):
+        """统一协议三种形态（state / event+tool / state 收尾）→ 信号正确。"""
+        app = QApplication.instance() or QApplication([])
+        events = tmp_path / "sub" / "gemini.jsonl"
+        events.parent.mkdir(parents=True)
+        events.touch()
+
+        states, tools = [], []
+        mon = CustomAgentMonitor("gemini", tmp_path / "cfg", str(events))
+        mon.state_changed.connect(lambda k, s: states.append((k, s)))
+        mon.activity.connect(lambda k, t: tools.append((k, t)))
+        mon.start()
+        mon._poll()  # backfill 初始化
+
+        with open(events, "a", encoding="utf-8") as f:
+            f.write(json.dumps({"ts": 1.0, "state": "working"}) + "\n")
+            f.write(json.dumps({"ts": 2.0, "event": "PreToolUse", "tool": "bash"}) + "\n")
+            f.write(json.dumps({"ts": 3.0, "state": "idle"}) + "\n")
+
+        mon._poll()
+        # PreToolUse 事件按内置映射同时产生 working 状态 + bash 工具过程
+        assert states == [("gemini", "working"), ("gemini", "working"), ("gemini", "idle")]
+        assert tools == [("gemini", "bash")]
+        mon.stop()
+
+    def test_missing_file_idle_then_appears(self, tmp_path):
+        """文件不存在时空转；出现后 backfill 防护跳过历史，只读新增行。"""
+        app = QApplication.instance() or QApplication([])
+        missing = tmp_path / "not_yet.jsonl"
+        mon = CustomAgentMonitor("gemini", tmp_path / "cfg", str(missing))
+        states = []
+        mon.state_changed.connect(lambda k, s: states.append((k, s)))
+        mon.start()
+        mon._poll()
+        mon._poll()
+        assert states == []
+
+        missing.write_text('{"state": "working"}\n', encoding="utf-8")
+        mon._poll()  # 首次发现文件：backfill，不回放历史
+        assert states == []
+
+        with open(missing, "a", encoding="utf-8") as f:
+            f.write('{"state": "idle"}\n')
+        mon._poll()
+        assert states == [("gemini", "idle")]
+        mon.stop()
+
+    def test_start_does_not_create_dirs(self, tmp_path):
+        """只读监听：绝不替用户在任意路径创建目录。"""
+        app = QApplication.instance() or QApplication([])
+        mon = CustomAgentMonitor(
+            "gemini", tmp_path / "cfg", str(tmp_path / "deep" / "nested" / "ev.jsonl"),
+        )
+        mon.start()
+        mon._poll()
+        assert not (tmp_path / "deep").exists()
+        mon.stop()
+
+    def test_tilde_path_expanded(self, tmp_path, monkeypatch):
+        # expanduser 在 Windows 读 USERPROFILE、POSIX 读 HOME，两个都设以保证跨平台
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+        monkeypatch.setenv("HOME", str(tmp_path))
+        mon = CustomAgentMonitor("gemini", tmp_path / "cfg", "~/events.jsonl")
+        assert mon.events_file == tmp_path / "events.jsonl"
+        assert "~" not in str(mon.events_file)
+
+
+class TestCustomAgentManager:
+    def test_registered_names_merged_and_generic_toggle(self, tmp_path):
+        """custom_agents → 监视器注册 + 显示名合并 + 通用开关联动（无需授权弹窗）。"""
+        app = QApplication.instance() or QApplication([])
+        cfg = Config(base=tmp_path)
+        ag = dict(cfg.get("agent_link", {}))
+        ag["custom_agents"] = [
+            {"key": "gemini", "name": "Gemini CLI", "path": str(tmp_path / "gemini.jsonl")},
+        ]
+        cfg.set("agent_link", ag)
+        cfg.save()
+
+        mgr = AgentLinkManager(None, cfg)
+        assert "gemini" in mgr.monitors
+        assert isinstance(mgr.monitors["gemini"], CustomAgentMonitor)
+        assert mgr.agent_names["gemini"] == "Gemini CLI"
+        # 类级 AGENT_NAMES 保持仅内置：设置页按内置枚举的遍历不受自定义影响
+        assert "gemini" not in AgentLinkManager.AGENT_NAMES
+        assert mgr.agent_names["dsh"] == "DSH"
+
+        # 通用开关：开启持久化并启动监视器
+        assert mgr.set_enabled("gemini", True) is True
+        assert cfg.data["agent_link"]["gemini"] is True
+        assert mgr.monitors["gemini"].is_running() is True
+
+        # 隐藏暂停 / 显示恢复
+        mgr.pause()
+        assert mgr.monitors["gemini"].is_running() is False
+        mgr.resume()
+        assert mgr.monitors["gemini"].is_running() is True
+
+        # 关闭
+        assert mgr.set_enabled("gemini", False) is True
+        assert cfg.data["agent_link"]["gemini"] is False
+        assert mgr.monitors["gemini"].is_running() is False
+
+    def test_builtin_key_in_custom_agents_ignored(self, tmp_path):
+        """config 清洗会拒绝与内置键冲突的自定义条目，管理器不覆盖内置监视器。"""
+        app = QApplication.instance() or QApplication([])
+        cfg = Config(base=tmp_path)
+        ag = dict(cfg.get("agent_link", {}))
+        ag["custom_agents"] = [{"key": "claude", "name": "Fake", "path": str(tmp_path / "x.jsonl")}]
+        cfg.set("agent_link", ag)
+        cfg.save()
+
+        mgr = AgentLinkManager(None, cfg)
+        assert not isinstance(mgr.monitors["claude"], CustomAgentMonitor)
+        assert mgr.agent_names["claude"] == "Claude Code"
+
+
+class TestCustomAgentMenu:
+    def test_menu_lists_custom_agent_and_toggle_routes(self, tmp_path):
+        """右键菜单动态渲染自定义 Agent，勾选走通用 _toggle_agent_link。"""
+        from PySide6.QtWidgets import QMenu
+        from pet.context_menus.shared import add_agent_link_menu
+
+        app = QApplication.instance() or QApplication([])
+        cfg = Config(base=tmp_path)
+        ag = dict(cfg.get("agent_link", {}))
+        ag["custom_agents"] = [
+            {"key": "gemini", "name": "Gemini CLI", "path": "~/gemini.jsonl"},
+        ]
+        cfg.set("agent_link", ag)
+        cfg.save()
+
+        toggles, options = [], []
+
+        class DummyPet:
+            def __init__(self):
+                self.cfg = cfg
+
+            def _toggle_agent_link(self, key, on, action=None):
+                toggles.append((key, on))
+
+            def _set_agent_link_option(self, key, on):
+                options.append((key, on))
+
+        menu = QMenu()
+        try:
+            add_agent_link_menu(menu, DummyPet())
+            sub = menu.actions()[0].menu()
+            texts = [a.text() for a in sub.actions()]
+            # 内置 4 项仍在，自定义项按显示名插入
+            for label in ("DeepSeek Harness (DSH)", "Claude Code", "Cursor", "OpenCode"):
+                assert label in texts
+            assert "Gemini CLI" in texts
+
+            gemini_act = next(a for a in sub.actions() if a.text() == "Gemini CLI")
+            gemini_act.setChecked(True)
+            assert toggles == [("gemini", True)]
+        finally:
+            menu.deleteLater()


### PR DESCRIPTION
## 概述

为「多 Agent 联动」新增**配置驱动的自定义 Agent 通道**：在 `config.json` 里声明 `{key, name, path}` 即可让桌宠只读监听任意符合统一事件协议的 JSONL 文件，**不改代码接入任何 AI Agent**；同时把既有的统一事件协议正式化为文档（`docs/AGENT_LINK_PROTOCOL.md`）。共 2 个提交（`docs(agent-link)` + `feat(agent-link)`），6 文件 +492/-7。

## 动机与现状分析

联动底层是本地 JSONL 文件事件总线（零网络）：agent 侧追加写事件文件 → 桌宠 `ByteOffsetTailer` 增量 tail → 归一为六态词汇 → 驱动动画/气泡/音效。协议本身已通用，但存在三个扩展痛点：

1. **协议无正式文档**，只散落在代码注释里，第三方无从接入；
2. **新增内置 Agent 触点多**：需改 5 处硬编码（config 默认值、config 清洗、`monitors` 字典、`AGENT_NAMES`、右键菜单元组）；
3. **缺零代码接入通道**：没有不写 Python 代码就能让新 Agent 接入的路径。

本 PR 补齐文档并提供 `agent_link.custom_agents` 通道解决以上三点；不重构既有 4 个内置 Agent 的接线（注册表化收敛作为后续方向记录在文档 §5）。

## 主要变更

| 文件 | 变更 |
|---|---|
| `docs/AGENT_LINK_PROTOCOL.md`（新增） | 统一事件协议规范：文件位置（三平台路径）、JSON 行字段、六态词汇表、内置事件名映射、写方对接清单（追加写/去重/轮转/不阻塞宿主/隐私红线）；四种内置接入模式分析；自定义通道接入示例 |
| `pet/config.py` | `agent_link.custom_agents` 默认值与清洗：`{key, name, path}` 校验（key 限 `^[a-z0-9][a-z0-9_-]{0,31}$` 且不得与内置键重复、去重、上限 8 条、path 非空），`~` 展开延迟到监视器层 |
| `pet/agent_link.py` | 新增 `CustomAgentMonitor(BaseAgentMonitor)`：按配置路径只读监听；覆写 `start()` 不创建目录（绝不替用户在任意路径建目录）、无需授权弹窗；`AgentLinkManager` 启动时动态注册自定义监视器并实例级合并显示名（类级 `AGENT_NAMES` 保持仅内置，设置页枚举不受影响）；`_warn_if_agent_absent` 支持自定义事件文件缺失提示 |
| `pet/context_menus/shared.py` | 「Agent 联动」菜单在内置 4 项后动态渲染自定义条目，勾选复用既有 `_toggle_agent_link`（失败回滚勾选态机制原样生效） |
| `README.md` | 「Agent 联动」节补充自定义 Agent 用法一句话 + 指向协议文档 |
| `tests/test_agent_link.py` | 新增 14 个用例：config 清洗（非法 key/内置键冲突/去重/上限/`~`）、监视器（增量 tail 三形态信号/文件缺失空转后出现/backfill 防护/不建目录）、管理器（注册/显示名合并/通用开关持久化/pause-resume）、菜单渲染与路由 |

## 测试与验证

**环境**：Windows 11（10.0.26200），Python 3.12.12，PySide6/Qt 6.11.2。

- 专项：`QT_QPA_PLATFORM=offscreen python -m pytest tests/test_agent_link.py -q` → **73 passed**（原 59 + 新增 14）
- 全量：**666 passed / 5 skipped**（完整态，含新增）；`python -m compileall -q pet tests` 通过；新增/修改文件均 UTF-8 无 BOM
- **实机验证**（源码实例，Windows 11 桌面）：配置自定义 Agent → 菜单出现勾选项并预启用；追加 `{"state":"working"}` 切干活动作；忙碌中 `{"state":"error"}` 走完成确认并弹中性文案（不误报「干完活啦」）；`{"state":"idle"}` 稳定 800ms 后弹「干完活啦」并回待机；修改 `name` 重启后菜单与气泡显示名同步更新

### 关于全量套件偶发失败的甄别（如实说明）

本机全量偶发出现 1-2 个竞态测试失败（碰撞 IPC / 槽位锁），**经甄别为 main 既有 flaky，与本 PR 无关**：

- `test_slot_locks_sequential_competition_and_preferred_fail` 在 **main（不含本 PR）上单独连跑 10 次即挂 1 次**；
- 将测试文件还原为 main 版本（仅保留本 PR 的 pet 代码变更）后全量依然偶发挂同类竞态测试——排除新增测试污染；
- 失败测试集合每轮游移（碰撞冲量/碰撞去重/槽位锁轮换），且挂过的测试单独复跑均 10/10 通过——符合负载相关时序抖动特征，无稳定因果指向本变更。

## 兼容性

- **既有配置键语义不变**；新增 `agent_link.custom_agents`（默认 `[]`）与各自定义开关布尔键（默认 `False`），均经 `_clean_agent_link_data` 清洗，非法条目静默丢弃
- **无新第三方依赖**（仅标准库 `re`）
- **自定义通道纯只读**：不创建目录、不写任何外部配置、无注入产物（`uninstall_cleanup` 无需改动）；写入外部配置必须弹窗的红线完全不触碰
- **默认全关**：`custom_agents` 默认为空，不改变任何既有 Agent 开关默认值
- 设置页对 `agent_link` 均为合并写回，`custom_agents` 字段不会被设置保存冲掉

## 已知边界（如实说明）

- **未在 macOS / Linux 实机验证**——该通道无任何平台特定代码（纯文件 tail + `expanduser`），跨平台由三平台 CI 的 offscreen 测试覆盖，建议合并前以 CI 结果为准；
- **运行中修改 `custom_agents` 需重启桌宠生效**（列表在启动时读取；开关布尔与内置 Agent 一致即时生效）——文档已注明。

## 如何验证

```jsonc
// <config.dir>/config.json
{ "agent_link": { "custom_agents": [
    { "key": "demo", "name": "测试Agent", "path": "~/pet-demo.jsonl" }
] } }
```

重启桌宠 → 右键「Agent 联动」勾选「测试Agent」→ 模拟事件：

```bash
echo '{"state":"working"}' >> ~/pet-demo.jsonl   # 切干活动作
echo '{"state":"idle"}'    >> ~/pet-demo.jsonl   # 800ms 后弹完成通知
```

## 建议 review 路径

1. `pet/config.py::_clean_custom_agents`：清洗规则与上限策略是否合理；
2. `pet/agent_link.py::CustomAgentMonitor`：`start()` 覆写不建目录的正确性、与 `ByteOffsetTailer` 的配合；
3. `AgentLinkManager` 动态注册与 `agent_names` 实例级合并（类级 `AGENT_NAMES` 不动）；
4. `context_menus/shared.py` 菜单渲染；
5. `docs/AGENT_LINK_PROTOCOL.md` 协议描述是否与实现一致。