### PR TITLE
fix(ipc): POSIX 协调者重选修复融合（#43 + #45 短服务名）

### DIFF
--- a/pet/collision_ipc.py
+++ b/pet/collision_ipc.py
@@ -107,27 +107,49 @@ class _CollisionWorker(QObject):
                 server.deleteLater()
                 self._connect_client()
                 return
-        if server.listen(self.name):
-            # 同一 Qt 进程中的 QLocalServer 在 Windows 上可能允许并行
-            # listen；进程内登记用于测试/嵌入式 harness 的同名候选收敛。
-            if self.name in self._local_election_names:
-                server.close()
-                server.deleteLater()
-                slot_manager.release_file_lock(self._coordinator_lock)
-                self._coordinator_lock = None
-                self._connect_client()
-                return
-            self._local_election_names.add(self.name)
-            self.server = server
-            self.epoch = secrets.token_hex(12)
-            server.newConnection.connect(self._accept_connection)
-            self._start_probe()
+        if not server.listen(self.name):
+            # POSIX 下被杀死/崩溃的旧协调者会残留 socket 文件，listen 报
+            # AddressInUseError（Windows 命名管道随进程死亡回收，无此问题）。
+            # 持有排他文件锁 ⇒ 旧协调者必死（flock 随进程死亡释放），先同步
+            # 探测同名服务确实无人应答，再清残留文件重试 listen（issue #42）。
+            if (sys.platform != "win32" and self._coordinator_lock is not None
+                    and not self._probe_live_server()):
+                QLocalServer.removeServer(self.name)
+                if server.listen(self.name):
+                    self._become_listener(server)
+                    return
+            server.deleteLater()
+            slot_manager.release_file_lock(self._coordinator_lock)
+            self._coordinator_lock = None
+            self._connect_client()
             return
-        # 只有连接验证失败并短暂重试后才清理残留服务。
-        server.deleteLater()
-        slot_manager.release_file_lock(self._coordinator_lock)
-        self._coordinator_lock = None
-        self._connect_client()
+        self._become_listener(server)
+
+    def _become_listener(self, server) -> None:
+        """listen 成功后的收敛：进程内同名候选去重，登记并启动决胜探测。"""
+        # 同一 Qt 进程中的 QLocalServer 在 Windows 上可能允许并行
+        # listen；进程内登记用于测试/嵌入式 harness 的同名候选收敛。
+        if self.name in self._local_election_names:
+            server.close()
+            server.deleteLater()
+            slot_manager.release_file_lock(self._coordinator_lock)
+            self._coordinator_lock = None
+            self._connect_client()
+            return
+        self._local_election_names.add(self.name)
+        self.server = server
+        self.epoch = secrets.token_hex(12)
+        server.newConnection.connect(self._accept_connection)
+        self._start_probe()
+
+    def _probe_live_server(self) -> bool:
+        """同步探测同名服务是否有活监听者（仅 POSIX 残留恢复路径使用）。"""
+        probe = QLocalSocket()
+        try:
+            probe.connectToServer(self.name)
+            return probe.waitForConnected(300)
+        finally:
+            probe.abort()
 
     def _start_probe(self) -> None:
         """Windows 命名管道允许并行 listen 时，用 QLocal 连接稳定决胜。"""
@@ -206,6 +228,10 @@ class _CollisionWorker(QObject):
             socket.readyRead.connect(lambda s=socket: self._read_socket(s))
             socket.disconnected.connect(lambda s=socket: self._peer_lost(s))
             socket.errorOccurred.connect(lambda _e, s=socket: self._peer_lost(s))
+            # POSIX 时序窗口：数据可能在 readyRead 槽连接之前就已到达，
+            # 不兜底读取的话这批数据不会再触发信号（表现为成员表为空）。
+            if socket.bytesAvailable():
+                self._read_socket(socket)
 
     def _register_self(self) -> None:
         self.members[self.runtime_id] = dict(self.latest_state, runtime_id=self.runtime_id,

--- a/tests/test_collision_ipc.py
+++ b/tests/test_collision_ipc.py
@@ -44,6 +44,11 @@ def _state(seq, x=0.0):
             "vx": 0.0, "vy": 0.0, "flags": collision.FLAG_VISIBLE | collision.FLAG_COLLISION_ENABLED}
 
 
+def _server_name(label: str) -> str:
+    """Keep POSIX Unix-socket paths below the platform length limit."""
+    return f"d42-{label}-{uuid.uuid4().hex[:8]}"
+
+
 def test_fake_socket_join_duplicate_seq_and_disconnect():
     worker = _CollisionWorker("unused-" + uuid.uuid4().hex, "coordinator", "", {
         "collision_enabled": True, "collision_restitution": .82,
@@ -356,7 +361,7 @@ def test_runtime_id_has_session_randomness(instance_id):
 
 def test_two_sessions_elect_one_coordinator_and_stop(tmp_path):
     QApplication.instance() or QApplication([])
-    name = "dsh-test-collision-" + uuid.uuid4().hex
+    name = _server_name("elect")
     first = CollisionIpcSession(Config(tmp_path, instance_id="slot-a"), server_name=name)
     second = CollisionIpcSession(Config(tmp_path, instance_id="slot-b"), server_name=name)
     roles = []
@@ -375,7 +380,7 @@ def test_two_sessions_elect_one_coordinator_and_stop(tmp_path):
 
 
 def test_subprocess_sessions_send_frames_and_reelect_after_parent_exits(tmp_path):
-    name = "dsh-test-collision-subprocess-" + uuid.uuid4().hex
+    name = _server_name("sub")
     script = r'''
 import json, sys, time
 from PySide6.QtCore import QEventLoop
@@ -428,7 +433,7 @@ session.stop()
 def test_submit_leave_removes_member_immediately(tmp_path):
     """客户端 submit_leave 后，协调者成员表即时移除（不等 stale 超时）。"""
     QApplication.instance() or QApplication([])
-    name = "dsh-test-collision-leave-" + uuid.uuid4().hex
+    name = _server_name("leave")
     coordinator = CollisionIpcSession(Config(tmp_path, instance_id="slot-c"), server_name=name)
     client = CollisionIpcSession(Config(tmp_path, instance_id="slot-p"), server_name=name)
     coordinator.start()
@@ -468,7 +473,7 @@ def test_submit_leave_removes_member_immediately(tmp_path):
 def test_update_policy_live_applies_to_worker(tmp_path):
     """运行中 update_policy：经 queued 接线更新到 worker 线程的 policy。"""
     QApplication.instance() or QApplication([])
-    name = "dsh-test-collision-policy-" + uuid.uuid4().hex
+    name = _server_name("policy")
     session = CollisionIpcSession(Config(tmp_path, instance_id="slot-p"), server_name=name)
     session.start()
     try:

--- a/tests/test_collision_ipc.py
+++ b/tests/test_collision_ipc.py
@@ -374,7 +374,6 @@ def test_two_sessions_elect_one_coordinator_and_stop(tmp_path):
     assert not second._thread.isRunning()
 
 
-@pytest.mark.skipif(sys.platform != "win32", reason="QLocalServer 子进程选举在 POSIX CI 上不稳定，Windows 覆盖即可")
 def test_subprocess_sessions_send_frames_and_reelect_after_parent_exits(tmp_path):
     name = "dsh-test-collision-subprocess-" + uuid.uuid4().hex
     script = r'''
@@ -426,7 +425,6 @@ session.stop()
     assert survivor.wait(timeout=5) == 0
 
 
-@pytest.mark.skipif(sys.platform != "win32", reason="QLocalServer 双会话成员同步在 POSIX CI 上不稳定，Windows 覆盖即可")
 def test_submit_leave_removes_member_immediately(tmp_path):
     """客户端 submit_leave 后，协调者成员表即时移除（不等 stale 超时）。"""
     QApplication.instance() or QApplication([])


### PR DESCRIPTION
# 融合修复 issue #42：POSIX 碰撞 IPC 协调者重选

本 PR 融合 #43 与 #45 对同一问题的修复，目标是：
- 采用 #43 更安全的“探测后清理”方案
- 吸收 #45 的 macOS 测试服务名缩短
- 不再混入 #45 的右键菜单重构（菜单已拆为独立 PR）

## 内容

### 来自 #43（全部保留）
- `listen()` 失败后先 `waitForConnected(300ms)` 探测同名服务是否真有活监听者；
  - 无人应答才 `QLocalServer.removeServer()` 清残留 socket 并重试 `listen()`
  - 有活服务则回退客户端，避免误删不使用文件锁的旧版存活服务
- 抽取 `_become_listener()`，listen 成功后的收敛逻辑不再重复
- `_accept_connection` 增加 `bytesAvailable()` 兜底读取，修复 POSIX 下数据早于 `readyRead` 到达导致成员表为空
- 移除两个 POSIX `skipif`，恢复 Linux/macOS 真实覆盖

### 来自 #45（仅吸收这一项）
- `_server_name()` 测试辅助：缩短测试服务名，规避 macOS Unix socket 路径长度上限
- `tests/test_collision_ipc.py` 相关测试改用短服务名

## 验证
- Windows 本地：`tests/test_collision_ipc.py` 19 passed
- 三平台 CI 待跑（不发布 Release）

Closes #43
Closes #45