### PR TITLE
docs(AGENTS): 修正 POSIX IPC 清理描述，匹配探测后清理实现

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,8 +41,8 @@ classDiagram
 The IPC facade belongs to the GUI thread; `_CollisionWorker` and every
 `QLocalServer`, `QLocalSocket`, and IPC timer belong to its dedicated `QThread`.
 The shared kernel file lock is the coordinator authority. On POSIX, a lock
-holder may remove the stale Unix socket before listening because a live
-coordinator would still hold that lock.
+holder that fails to `listen()` because of a stale Unix socket first probes
+for a live listener, and only removes the stale endpoint when nobody answers.
 
 ```mermaid
 sequenceDiagram
@@ -56,7 +56,13 @@ sequenceDiagram
     IPC-->>W: queued signal
     W->>L: try acquire
     alt lock acquired
-        W->>Q: remove stale POSIX endpoint, listen
+        W->>Q: listen
+        alt listen fails (stale POSIX endpoint)
+            W->>Q: probe live server
+            alt no live listener
+                W->>Q: remove stale endpoint, listen
+            end
+        end
         W-->>IPC: role_changed(true, epoch)
     else lock busy
         W->>Q: connect as client, hello


### PR DESCRIPTION
# 修正 AGENTS.md 的 POSIX IPC 描述，匹配实际实现

#46 合并后的实际实现是：

1. 持锁候选者先 `listen()`
2. `listen()` 失败（POSIX 残留 Unix socket）时，先探测同名服务是否有活监听者
3. 只有确认无人应答时才 `removeServer()` 清理并重试 `listen()`

原 AGENTS.md 描述为“持锁后直接 removeServer 再 listen”，与实现不符。本 PR 同步修正文本和 mermaid 图。

纯文档改动，无代码/测试变更。