### PR TITLE
fix(ipc): 加固碰撞协议与协调者生命周期（issue #42）

### DIFF
--- a/pet/collision.py
+++ b/pet/collision.py
@@ -7,7 +7,7 @@
 3. 冲量求解（恢复系数默认 0.82、切向摩擦 mu=0.08、库仑上限、每质量 9000px/s 限制）
 4. 位置分离（逆质量分摊、每次最多 60% 重叠、min 1px / max 12px、0.5px slop、连续 3 tick 强制完整分离）
 5. 稳定重合方向（两 ID 稳定哈希，禁用随机）
-6. 协议帧解析与编码（4 字节大端长度前缀 + UTF-8 JSON，4096 字节上限超限丢弃）
+6. 协议帧解析与编码（4 字节大端长度前缀 + UTF-8 JSON，256 KiB 有界载荷）
 7. 水位去重（按 epoch 记录每个 pair 最高已应用 tick）
 8. 多体碰撞冲量合并与迭代分离
 """
@@ -28,7 +28,8 @@ DEFAULT_IMPULSE_CAP: float = 9000.0     # 每单位质量等效冲量上限 (px/
 IMPULSE_MIN_APPROACH_SPEED: float = 80.0  # 低于此接近速度只做位置分离 (px/s)
 DEFAULT_BASE_SCALE: float = 0.72        # 基准缩放
 
-FRAME_MAX_LENGTH: int = 4096            # 单帧最大字节数（含/不含前缀，此处限制载荷<=4096）
+FRAME_MAX_LENGTH: int = 256 * 1024       # coordinator 下行；覆盖最多 128 个槽位的完整快照
+STATE_FRAME_MAX_LENGTH: int = 4 * 1024   # client 上行状态；阻止单成员耗尽聚合快照预算
 HEADER_SIZE: int = 4                    # 4字节无符号大端整数长度头
 
 # ---- 状态 Flags 位定义 (plan4 §2.1) ----
@@ -718,16 +719,18 @@ class DecodeError:
     raw_data: bytes = b""
 
 
-def encode_frame(obj: Any) -> bytes:
+def encode_frame(obj: Any, max_frame_len: int = FRAME_MAX_LENGTH) -> bytes:
     """将 Python 对象编码为 4 字节大端长度前缀 + UTF-8 JSON 字节帧。"""
     payload = json.dumps(obj, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
     length = len(payload)
+    if length > max_frame_len:
+        raise ValueError(f"Frame length {length} exceeds limit {max_frame_len}")
     header = length.to_bytes(HEADER_SIZE, byteorder="big", signed=False)
     return header + payload
 
 
 class FrameStreamDecoder:
-    """流式帧解析器，支持粘包与半包解析，超过 4096 字节安全丢弃。"""
+    """流式帧解析器，支持粘包与半包解析，超过配置上限时安全丢弃。"""
 
     def __init__(self, max_frame_len: int = FRAME_MAX_LENGTH) -> None:
         self._buffer = bytearray()

--- a/pet/collision_ipc.py
+++ b/pet/collision_ipc.py
@@ -17,12 +17,106 @@ from dataclasses import asdict
 from typing import Any
 
 from PySide6.QtCore import QMetaObject, QObject, QThread, QTimer, Qt, Signal, Slot
-from PySide6.QtNetwork import QLocalServer, QLocalSocket
+from PySide6.QtNetwork import QAbstractSocket, QLocalServer, QLocalSocket
 
 from . import collision
 from . import collision_debug
 from .config import APP_DIR_NAME
 from . import slot_manager
+
+MAX_COLLISION_MEMBERS = 128
+PUBLIC_MEMBER_MAX_LENGTH = 1536
+RUNTIME_ID_MAX_LENGTH = 128
+CHARACTER_MAX_LENGTH = 512
+MAX_COLLISION_CIRCLES = 3
+ACTIVE_MEMBER_MAX_AGE = 1.2
+_KNOWN_FLAGS_MASK = (1 << 11) - 1
+
+
+def _bounded_text(value: Any, max_bytes: int) -> str:
+    raw = str(value or "").encode("utf-8", errors="replace")
+    if len(raw) <= max_bytes:
+        return raw.decode("utf-8")
+    return raw[:max_bytes].decode("utf-8", errors="ignore")
+
+
+def _valid_runtime_id(value: Any) -> str:
+    text = str(value or "")
+    try:
+        encoded = text.encode("utf-8")
+    except UnicodeEncodeError:
+        return ""
+    if (not text or len(encoded) > RUNTIME_ID_MAX_LENGTH
+            or "|" in text or "\0" in text):
+        return ""
+    return text
+
+
+def _finite_float(value: Any, default: float = 0.0) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return default
+    return number if math.isfinite(number) else default
+
+
+def _normalize_circles(value: Any) -> list[list[float]] | None:
+    if not isinstance(value, (list, tuple)):
+        return None
+    circles: list[list[float]] = []
+    for raw in value[:MAX_COLLISION_CIRCLES]:
+        if not isinstance(raw, (list, tuple)) or len(raw) < 3:
+            continue
+        circles.append([
+            _finite_float(raw[0]),
+            _finite_float(raw[1]),
+            _finite_float(raw[2]),
+        ])
+    return circles
+
+
+def _normalize_state(raw: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the bounded, protocol-owned subset of one member state."""
+    try:
+        seq = int(raw.get("seq", -1))
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if seq < 0 or seq > (1 << 63) - 1:
+        return None
+    try:
+        flags = int(raw.get("flags", 0)) & _KNOWN_FLAGS_MASK
+    except (TypeError, ValueError, OverflowError):
+        return None
+    state: dict[str, Any] = {
+        "seq": seq,
+        "ts": _finite_float(raw.get("ts", 0.0)),
+        "x": _finite_float(raw.get("x", 0.0)),
+        "y": _finite_float(raw.get("y", 0.0)),
+        "w": _finite_float(raw.get("w", 0.0)),
+        "h": _finite_float(raw.get("h", 0.0)),
+        "radius_x": _finite_float(raw.get("radius_x", 0.0)),
+        "radius_y": _finite_float(raw.get("radius_y", 0.0)),
+        "vx": _finite_float(raw.get("vx", 0.0)),
+        "vy": _finite_float(raw.get("vy", 0.0)),
+        "flags": flags,
+        "character": _bounded_text(raw.get("character", ""), CHARACTER_MAX_LENGTH),
+        "scale": _finite_float(raw.get("scale", collision.DEFAULT_BASE_SCALE),
+                               collision.DEFAULT_BASE_SCALE),
+    }
+    circles = _normalize_circles(raw.get("circles"))
+    if circles is not None:
+        state["circles"] = circles
+    for key in ("bounce_vx", "bounce_vy", "bounce_x", "bounce_y"):
+        if key in raw:
+            state[key] = _finite_float(raw.get(key))
+    bounce_circles = _normalize_circles(raw.get("bounce_circles"))
+    if bounce_circles is not None:
+        state["bounce_circles"] = bounce_circles
+    try:
+        collision.encode_frame(state, max_frame_len=collision.STATE_FRAME_MAX_LENGTH)
+    except (TypeError, ValueError):
+        return None
+    return state
 
 
 def collision_server_name(base=None) -> str:
@@ -31,12 +125,14 @@ def collision_server_name(base=None) -> str:
         identity = os.environ.get("USERDOMAIN", "") + "\\" + os.environ.get("USERNAME", "")
     else:
         identity = str(getattr(os, "getuid", lambda: 0)())
-    digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:16]
-    return f"{APP_DIR_NAME}-{digest}-collision"
+    namespace = f"{APP_DIR_NAME}\0{identity}"
+    digest = hashlib.sha256(namespace.encode("utf-8")).hexdigest()[:20]
+    return f"dsh-pet-collision-{digest}"
 
 
 def make_runtime_id(instance_id: str = "", pid: int | None = None) -> str:
-    prefix = str(instance_id or "").strip() or "instance"
+    prefix = _bounded_text(str(instance_id or "").strip() or "instance", 64)
+    prefix = prefix.replace("|", "-").replace("\0", "-")
     return f"{prefix}-pid{pid or os.getpid()}-{secrets.token_hex(4)}"
 
 
@@ -65,6 +161,8 @@ class _CollisionWorker(QObject):
         self._predicted_pair_ticks: dict[str, int] = {}
         self._position_only_pairs: dict[str, tuple[tuple[float, ...], int]] = {}
         self.latest_state: dict[str, Any] = {}
+        self._participating = False
+        self._membership_dirty = False
         self.epoch = ""
         self.tick = 0
         self.overlap_history: dict[str, int] = {}
@@ -72,7 +170,6 @@ class _CollisionWorker(QObject):
         self._timers: list[QTimer] = []
         self._election_timer = None
         self._welcome_timer = None
-        self._welcome_retries = 0
         self._hello_sent = False
         self._welcomed_peers: set[Any] = set()
         self._last_control_message = 0.0
@@ -89,11 +186,12 @@ class _CollisionWorker(QObject):
     def _schedule_election(self) -> None:
         if self._stopping:
             return
-        if self._election_timer:
+        if self._election_timer is None:
+            self._election_timer = QTimer(self)
+            self._election_timer.setSingleShot(True)
+            self._election_timer.timeout.connect(self._try_election)
+        else:
             self._election_timer.stop()
-        self._election_timer = QTimer(self)
-        self._election_timer.setSingleShot(True)
-        self._election_timer.timeout.connect(self._try_election)
         self._election_timer.start(secrets.randbelow(201) + 50)
 
     @Slot()
@@ -112,7 +210,9 @@ class _CollisionWorker(QObject):
             # AddressInUseError（Windows 命名管道随进程死亡回收，无此问题）。
             # 持有排他文件锁 ⇒ 旧协调者必死（flock 随进程死亡释放），先同步
             # 探测同名服务确实无人应答，再清残留文件重试 listen（issue #42）。
-            if (sys.platform != "win32" and self._coordinator_lock is not None
+            if (sys.platform != "win32"
+                    and server.serverError() == QAbstractSocket.SocketError.AddressInUseError
+                    and self._coordinator_lock is not None
                     and not self._probe_live_server()):
                 QLocalServer.removeServer(self.name)
                 if server.listen(self.name):
@@ -155,6 +255,9 @@ class _CollisionWorker(QObject):
         """Windows 命名管道允许并行 listen 时，用 QLocal 连接稳定决胜。"""
         probe = QLocalSocket(self)
         self._probe = probe
+        probe._collision_decoder = collision.FrameStreamDecoder(
+            max_frame_len=collision.STATE_FRAME_MAX_LENGTH,
+        )
         probe.connected.connect(lambda: self._send(probe, {
             "type": "probe", "runtime_id": self.runtime_id,
         }))
@@ -208,7 +311,7 @@ class _CollisionWorker(QObject):
             self._welcome_timed_out()
 
     def _welcome_timed_out(self) -> None:
-        """A connected but silent listener is a stale service endpoint."""
+        """放弃无控制消息的客户端会话，端点清理由持锁选举路径决定。"""
         if self._stopping or self.socket is None or not self._had_client_connection:
             return
         socket = self.socket
@@ -216,14 +319,14 @@ class _CollisionWorker(QObject):
         self._had_client_connection = False
         socket.abort()
         socket.deleteLater()
-        self._welcome_retries += 1
-        if self._welcome_retries > 1:
-            QLocalServer.removeServer(self.name)
         self._schedule_election()
 
     def _accept_connection(self) -> None:
         while self.server and self.server.hasPendingConnections():
             socket = self.server.nextPendingConnection()
+            socket._collision_decoder = collision.FrameStreamDecoder(
+                max_frame_len=collision.STATE_FRAME_MAX_LENGTH,
+            )
             self.peers[socket] = ""
             socket.readyRead.connect(lambda s=socket: self._read_socket(s))
             socket.disconnected.connect(lambda s=socket: self._peer_lost(s))
@@ -233,9 +336,47 @@ class _CollisionWorker(QObject):
             if socket.bytesAvailable():
                 self._read_socket(socket)
 
+    def _member_from_state(
+        self,
+        runtime_id: str,
+        state: dict[str, Any],
+        instance_id: str = "",
+    ) -> dict[str, Any] | None:
+        runtime_id = _valid_runtime_id(runtime_id)
+        if not runtime_id:
+            return None
+        if runtime_id not in self.members and len(self.members) >= MAX_COLLISION_MEMBERS:
+            return None
+        member = dict(
+            state,
+            runtime_id=runtime_id,
+            instance_id=_bounded_text(instance_id, RUNTIME_ID_MAX_LENGTH),
+            last_seen=self._now(),
+        )
+        try:
+            collision.encode_frame(
+                self._public_member(member),
+                max_frame_len=PUBLIC_MEMBER_MAX_LENGTH,
+            )
+        except (TypeError, ValueError):
+            return None
+        return member
+
     def _register_self(self) -> None:
-        self.members[self.runtime_id] = dict(self.latest_state, runtime_id=self.runtime_id,
-                                             instance_id=self.instance_id, last_seen=self._now())
+        if not self._participating or not self.latest_state:
+            return
+        member = self._member_from_state(
+            self.runtime_id,
+            self.latest_state,
+            self.instance_id,
+        )
+        if member is None:
+            return
+        is_new = self.runtime_id not in self.members
+        if not is_new:
+            self.previous_members[self.runtime_id] = dict(self.members[self.runtime_id])
+        self.members[self.runtime_id] = member
+        self._membership_dirty = self._membership_dirty or is_new
 
     @staticmethod
     def _now() -> float:
@@ -245,18 +386,53 @@ class _CollisionWorker(QObject):
     def _welcome(self) -> dict[str, Any]:
         return {"type": "welcome", "epoch": self.epoch, "coordinator_id": self.runtime_id,
                 "tick": self.tick, "policy": self.policy,
-                "members": [self._public_member(v) for v in self.members.values()]}
+                "members": (
+                    [self._public_member(v)
+                     for v in self._fresh_member_values(self._now())]
+                    if self.policy.get("collision_enabled", True)
+                    else []
+                )}
 
     @staticmethod
     def _public_member(member: dict[str, Any]) -> dict[str, Any]:
         return {k: v for k, v in member.items() if k != "last_seen"}
 
+    def _fresh_member_values(self, now: float) -> list[dict[str, Any]]:
+        """Return members inside the shared solver/publication freshness window."""
+        return [
+            value for value in self.members.values()
+            if now - float(value.get("last_seen", now)) <= ACTIVE_MEMBER_MAX_AGE
+        ]
+
     def _send(self, socket, message: dict[str, Any]) -> None:
         try:
-            socket.write(collision.encode_frame(message))
+            max_frame_len = (
+                collision.STATE_FRAME_MAX_LENGTH
+                if message.get("type") == "state"
+                else collision.FRAME_MAX_LENGTH
+            )
+            frame = collision.encode_frame(message, max_frame_len=max_frame_len)
+        except Exception:
+            logging.debug("碰撞 IPC 编码失败", exc_info=True)
+            return
+        self._write_frame(socket, frame)
+
+    @staticmethod
+    def _write_frame(socket, frame: bytes) -> None:
+        try:
+            socket.write(frame)
             socket.flush()
         except Exception:
             logging.debug("碰撞 IPC 写入失败", exc_info=True)
+
+    def _broadcast(self, sockets, message: dict[str, Any]) -> None:
+        try:
+            frame = collision.encode_frame(message)
+        except Exception:
+            logging.debug("碰撞 IPC 广播编码失败", exc_info=True)
+            return
+        for socket in tuple(sockets):
+            self._write_frame(socket, frame)
 
     def _read_socket(self, socket) -> None:
         decoder = getattr(socket, "_collision_decoder", None)
@@ -286,7 +462,7 @@ class _CollisionWorker(QObject):
                     self._send(socket, self._welcome())
                 return
             if kind == "hello":
-                runtime_id = str(message.get("runtime_id") or "")
+                runtime_id = _valid_runtime_id(message.get("runtime_id"))
                 if not runtime_id:
                     return
                 self.peers[socket] = runtime_id
@@ -297,22 +473,32 @@ class _CollisionWorker(QObject):
                     self._welcomed_peers.add(socket)
                     self._send(socket, self._welcome())
             elif kind == "state":
-                runtime_id = self.peers.get(socket, self.runtime_id)
-                seq = int(message.get("seq", -1))
+                runtime_id = _valid_runtime_id(self.peers.get(socket, ""))
+                state = _normalize_state(message)
+                if not runtime_id or state is None:
+                    return
+                seq = int(state["seq"])
                 old = self.members.get(runtime_id, {})
                 if seq <= int(old.get("seq", -1)):
                     return
-                state = dict(message, runtime_id=runtime_id, last_seen=self._now())
                 if not (int(state.get("flags", 0)) & collision.FLAG_COLLISION_ENABLED):
                     self._remove_member(runtime_id)
+                    return
+                member = self._member_from_state(runtime_id, state)
+                if member is None:
                     return
                 if (int(state.get("flags", 0)) & collision.FLAG_PREDICTED_BOUNCE
                         and state.get("bounce_vx") is not None
                         and state.get("bounce_vy") is not None):
-                    self._pending_predicted[runtime_id] = {**state, "_captured_at": self._now()}
-                if runtime_id in self.members:
+                    self._pending_predicted[runtime_id] = {
+                        **member,
+                        "_captured_at": self._now(),
+                    }
+                is_new = runtime_id not in self.members
+                if not is_new:
                     self.previous_members[runtime_id] = dict(self.members[runtime_id])
-                self.members[runtime_id] = state
+                self.members[runtime_id] = member
+                self._membership_dirty = self._membership_dirty or is_new
             elif kind == "leave":
                 self._remove_member(self.peers.get(socket, ""))
         elif kind == "coordinator":
@@ -320,7 +506,6 @@ class _CollisionWorker(QObject):
         elif kind == "welcome":
             epoch = str(message.get("epoch") or "")
             if epoch:
-                self._welcome_retries = 0
                 if self._welcome_timer:
                     self._welcome_timer.stop()
                     self._welcome_timer.deleteLater()
@@ -333,8 +518,10 @@ class _CollisionWorker(QObject):
                     self.latest_state.pop("bounce_vx", None)
                     self.latest_state.pop("bounce_vy", None)
                     self.role_changed.emit(False, epoch)
-                    self.policy_changed.emit(message.get("policy") or {})
-                    self.snapshot_ready.emit(message)
+                # 同一 coordinator/epoch 的断线重连也必须用 welcome 刷新
+                # policy 与权威成员表；只有角色变更通知受 changed 门禁。
+                self.policy_changed.emit(message.get("policy") or {})
+                self.snapshot_ready.emit(message)
         elif kind == "snapshot":
             if message.get("epoch", self.epoch) == self.epoch:
                 self._last_control_message = self._now()
@@ -369,10 +556,8 @@ class _CollisionWorker(QObject):
             socket.deleteLater()
         self.peers.clear()
         self.members.clear()
-        self._pending_predicted.clear()
-        self.previous_members.clear()
-        self._swept_pair_versions.clear()
-        self._predicted_pair_ticks.clear()
+        self._membership_dirty = False
+        self._clear_solver_history()
         for timer in self._timers:
             timer.stop()
             timer.deleteLater()
@@ -390,26 +575,44 @@ class _CollisionWorker(QObject):
     def submit_state(self, state: dict[str, Any]) -> None:
         if self._stopping:
             return
-        self.latest_state = dict(state)
+        normalized = _normalize_state(state)
+        if normalized is None:
+            return
+        self.latest_state = normalized
+        if not (int(normalized.get("flags", 0)) & collision.FLAG_COLLISION_ENABLED):
+            self.submit_leave()
+            return
+        self._participating = True
         if self.server is not None:
+            member = self._member_from_state(
+                self.runtime_id,
+                normalized,
+                self.instance_id,
+            )
+            if member is None:
+                return
             # 协调者自身的预测反弹也要进捕获队列：本进程状态走进程内直送，
             # 不经过 _handle_message 的 socket 路径，漏掉会导致"主桌宠撞
             # 别人时目标收不到权威冲量"（只有协调者自己的 pet 会踩中）。
-            if (int(state.get("flags", 0)) & collision.FLAG_PREDICTED_BOUNCE
-                    and state.get("bounce_vx") is not None
-                    and state.get("bounce_vy") is not None):
+            if (int(normalized.get("flags", 0)) & collision.FLAG_PREDICTED_BOUNCE
+                    and normalized.get("bounce_vx") is not None
+                    and normalized.get("bounce_vy") is not None):
                 self._pending_predicted[self.runtime_id] = {
-                    **state, "runtime_id": self.runtime_id, "_captured_at": self._now()}
-            if self.runtime_id in self.members:
+                    **member,
+                    "_captured_at": self._now(),
+                }
+            is_new = self.runtime_id not in self.members
+            if not is_new:
                 self.previous_members[self.runtime_id] = dict(self.members[self.runtime_id])
-            self.members[self.runtime_id] = dict(state, runtime_id=self.runtime_id,
-                                                 instance_id=self.instance_id, last_seen=self._now())
+            self.members[self.runtime_id] = member
+            self._membership_dirty = self._membership_dirty or is_new
             if collision_debug.ENABLED:
                 collision_debug.log(self.runtime_id, 'state_arrive', runtime_id=self.runtime_id,
-                                    x=state.get('x'), y=state.get('y'), vx=state.get('vx'),
-                                    vy=state.get('vy'), seq=state.get('seq'))
+                                    x=normalized.get('x'), y=normalized.get('y'),
+                                    vx=normalized.get('vx'), vy=normalized.get('vy'),
+                                    seq=normalized.get('seq'))
         elif self.socket:
-            self._send(self.socket, dict(state, type="state"))
+            self._send(self.socket, dict(normalized, type="state"))
 
     @Slot(object)
     def set_policy(self, policy: dict[str, Any]) -> None:
@@ -420,18 +623,41 @@ class _CollisionWorker(QObject):
         """
         if self._stopping:
             return
+        enabled_changed = (
+            bool(self.policy.get("collision_enabled", True))
+            != bool(policy.get("collision_enabled", True))
+        )
         self.policy = dict(policy)
+        if enabled_changed:
+            self._membership_dirty = True
+            self._clear_solver_history()
+
+    def _clear_solver_history(self) -> None:
+        """Clear caches whose meaning is scoped to one continuous solver run."""
+        self._pending_predicted.clear()
+        self.previous_members.clear()
+        self._swept_pair_versions.clear()
+        self._predicted_pair_ticks.clear()
+        self._position_only_pairs.clear()
+        self.overlap_history.clear()
 
     @Slot()
     def submit_leave(self) -> None:
-        """客户端主动离开：立即向协调者发送 leave 帧，成员即时移除（不等 stale 超时）。
+        """主动离开：协调者移除自身，客户端向协调者发送 leave 帧。
 
         与 stop() 不同：只发 leave 不断开 socket，供 detach_collision_session 等
         不销毁会话的退出路径使用。
         """
-        if self._stopping or self.socket is None:
+        if self._stopping:
             return
-        self._send(self.socket, {"type": "leave", "seq": int(self.latest_state.get("seq", 0)) + 1})
+        self._participating = False
+        if self.server is not None:
+            self._remove_member(self.runtime_id)
+        elif self.socket is not None:
+            self._send(
+                self.socket,
+                {"type": "leave", "seq": int(self.latest_state.get("seq", 0)) + 1},
+            )
 
     def _start_coordinator_timers(self) -> None:
         heartbeat = QTimer(self)
@@ -443,7 +669,7 @@ class _CollisionWorker(QObject):
         self._timers.extend((heartbeat, tick))
 
     def _heartbeat(self) -> None:
-        if self.socket and self.latest_state:
+        if self.socket and self._participating and self.latest_state:
             self._send(self.socket, dict(self.latest_state, type="state"))
         if self.server is not None:
             now = self._now()
@@ -452,6 +678,36 @@ class _CollisionWorker(QObject):
                 if age > 3.0:
                     self._remove_member(runtime_id)
 
+    def _publish_snapshot_if_due(self, now: float) -> bool:
+        """Publish control-plane membership even when no collision can run."""
+        solver_enabled = bool(self.policy.get("collision_enabled", True))
+        fresh_members = self._fresh_member_values(now)
+        moving = solver_enabled and any(
+            math.hypot(float(value.get("vx", 0)), float(value.get("vy", 0))) > 20
+            or int(value.get("flags", 0)) & (collision.FLAG_THROWN | collision.FLAG_DRAGGING)
+            for value in fresh_members
+        )
+        interval = 0.05 if moving else 0.5
+        if not self._membership_dirty and now - self._last_snapshot_at < interval:
+            return False
+        payload = {
+            "type": "snapshot",
+            "epoch": self.epoch,
+            "tick": self.tick,
+            # solver disabled 时对客户端发布空权威表，阻断其本地预测反弹；
+            # 内部 members 仍保留，重新启用后可恢复其中仍新鲜的成员。
+            "members": (
+                [self._public_member(value) for value in fresh_members]
+                if solver_enabled
+                else []
+            ),
+        }
+        self._broadcast(self.peers, payload)
+        self.snapshot_ready.emit(payload)
+        self._last_snapshot_at = now
+        self._membership_dirty = False
+        return True
+
     def _coordinator_tick(self) -> None:
         if self._stopping or self.server is None:
             return
@@ -459,9 +715,7 @@ class _CollisionWorker(QObject):
         active = []
         active_previous: dict[str, collision.MemberState] = {}
         # 迭代期间会 _remove_member（隐藏/暂停成员即时移除），必须用快照
-        for state in list(self.members.values()):
-            if now - float(state.get("last_seen", now)) > 1.2:
-                continue
+        for state in self._fresh_member_values(now):
             flags = int(state.get("flags", 0))
             if (flags & collision.FLAG_PAUSED) or not (flags & collision.FLAG_VISIBLE):
                 self._remove_member(str(state.get("runtime_id", "")))
@@ -487,6 +741,7 @@ class _CollisionWorker(QObject):
                     previous_values["runtime_id"] = values["runtime_id"]
                     active_previous[str(values["runtime_id"])] = collision.MemberState(**previous_values)
         if len(active) < 2 or not self.policy.get("collision_enabled", True):
+            self._publish_snapshot_if_due(now)
             return
         self.tick += 1
         swept = {}
@@ -608,16 +863,7 @@ class _CollisionWorker(QObject):
         }
         for pair in predicted_pairs:
             self._predicted_pair_ticks[pair] = self.tick
-        moving = any(math.hypot(float(v.get("vx", 0)), float(v.get("vy", 0))) > 20 or
-                     int(v.get("flags", 0)) & (collision.FLAG_THROWN | collision.FLAG_DRAGGING)
-                     for v in self.members.values())
-        if now - self._last_snapshot_at >= (0.05 if moving else 0.5):
-            self._last_snapshot_at = now
-            payload = {"type": "snapshot", "epoch": self.epoch, "tick": self.tick,
-                       "members": [self._public_member(v) for v in self.members.values()]}
-            for peer in self.peers:
-                self._send(peer, payload)
-            self.snapshot_ready.emit(payload)
+        self._publish_snapshot_if_due(now)
         for result in results:
             if result.j == 0 and result.sep == 0:
                 continue
@@ -629,13 +875,14 @@ class _CollisionWorker(QObject):
                     continue
                 self._position_only_pairs[result.pair] = (signature, self.tick)
             payload = {"type": "impulse", "epoch": self.epoch, **asdict(result)}
-            for peer in self.peers:
-                self._send(peer, payload)
+            self._broadcast(self.peers, payload)
             self.impulse_ready.emit(payload)
 
     def _remove_member(self, runtime_id: str) -> None:
         if runtime_id:
-            self.members.pop(runtime_id, None)
+            removed = self.members.pop(runtime_id, None)
+            if removed is not None:
+                self._membership_dirty = True
             self._pending_predicted.pop(runtime_id, None)
             self.previous_members.pop(runtime_id, None)
             self._swept_pair_versions = {
@@ -648,6 +895,10 @@ class _CollisionWorker(QObject):
             }
             self._position_only_pairs = {
                 pair: value for pair, value in self._position_only_pairs.items()
+                if runtime_id not in pair.split("|")
+            }
+            self.overlap_history = {
+                pair: count for pair, count in self.overlap_history.items()
                 if runtime_id not in pair.split("|")
             }
 
@@ -680,6 +931,7 @@ class _CollisionWorker(QObject):
     @Slot()
     def stop(self) -> None:
         self._stopping = True
+        self._participating = False
         owns_server = self.server is not None
         if self._election_timer:
             self._election_timer.stop()
@@ -706,8 +958,12 @@ class _CollisionWorker(QObject):
                 socket.deleteLater()
             except RuntimeError:
                 pass
-        for socket in list(self.peers):
-            self._send(socket, {"type": "snapshot", "epoch": self.epoch, "tick": self.tick, "members": []})
+        peer_sockets = list(self.peers)
+        self._broadcast(
+            peer_sockets,
+            {"type": "snapshot", "epoch": self.epoch, "tick": self.tick, "members": []},
+        )
+        for socket in peer_sockets:
             socket.disconnectFromServer()
             socket.deleteLater()
         self.peers.clear()
@@ -716,14 +972,16 @@ class _CollisionWorker(QObject):
             self.server.deleteLater()
             self.server = None
             self._local_election_names.discard(self.name)
-        slot_manager.release_file_lock(self._coordinator_lock)
-        self._coordinator_lock = None
+        if owns_server:
+            # 必须在释放协调者文件锁前清理自己拥有的端点；否则继任者可在
+            # 两者之间 listen 成功，随后被旧协调者 removeServer 误删。
+            QLocalServer.removeServer(self.name)
         for timer in self._timers:
             timer.stop()
             timer.deleteLater()
         self._timers.clear()
-        if owns_server:
-            QLocalServer.removeServer(self.name)
+        slot_manager.release_file_lock(self._coordinator_lock)
+        self._coordinator_lock = None
         QTimer.singleShot(0, self.thread().quit)
 
 

--- a/pet/slot_manager.py
+++ b/pet/slot_manager.py
@@ -87,20 +87,32 @@ def _format_pid_record(pid: int) -> bytes:
 
 
 def _open_lock_file(path: Path) -> BinaryIO:
-    """Open or atomically create a lock file without truncating it."""
+    """Open or create a lock file and ensure the lock byte exists.
+
+    The absolute truncate is intentionally idempotent.  Multiple first-time
+    openers may all observe size zero before any of them acquires the kernel
+    lock; appending the observed deficit would grow the file to 32+ bytes.
+    """
     fd = os.open(path, os.O_RDWR | os.O_CREAT)
     handle = os.fdopen(fd, "r+b")
     try:
         size = os.fstat(fd).st_size
         if size < PID_RECORD_LEN:
-            handle.seek(0, os.SEEK_END)
-            handle.write(b" " * (PID_RECORD_LEN - size))
-            handle.flush()
+            os.ftruncate(fd, PID_RECORD_LEN)
         handle.seek(0)
         return handle
     except Exception:
         handle.close()
         raise
+
+
+def _write_pid_record(file_obj: BinaryIO) -> None:
+    """Write this process PID and restore the fixed-size lock-file format."""
+    file_obj.seek(0)
+    file_obj.write(_format_pid_record(os.getpid()))
+    file_obj.flush()
+    os.ftruncate(file_obj.fileno(), PID_RECORD_LEN)
+    file_obj.seek(0)
 
 
 def _try_acquire_slot_lock(config_dir: Path, slot_id: int) -> BinaryIO | None:
@@ -123,10 +135,7 @@ def _try_acquire_slot_lock(config_dir: Path, slot_id: int) -> BinaryIO | None:
 
     # 加锁成功后，写入定长 PID 记录到文件头并 flush
     try:
-        f.seek(0)
-        f.write(_format_pid_record(os.getpid()))
-        f.flush()
-        f.seek(0)
+        _write_pid_record(f)
     except OSError:
         _unlock_file(f)
         return None
@@ -146,10 +155,7 @@ def acquire_file_lock(lock_path: Path | str) -> BinaryIO | None:
         handle.close()
         return None
     try:
-        handle.seek(0)
-        handle.write(_format_pid_record(os.getpid()))
-        handle.flush()
-        handle.seek(0)
+        _write_pid_record(handle)
     except OSError:
         _unlock_file(handle)
         return None

--- a/pet/window.py
+++ b/pet/window.py
@@ -1083,10 +1083,10 @@ class PetWindow(QWidget):
         session = self._collision_session
         if session is None:
             return
-        # 断开前先发 leave：协调者即时移除成员，不必等 stale 超时
-        submit_leave = getattr(session, 'submit_leave', None)
-        if callable(submit_leave):
-            submit_leave()
+        # 先关闭所有状态生产路径，再把 leave 排入同一 worker 队列；否则一个
+        # 已排队的 timer tick 可能在 leave 之后重新提交状态并复活成员。
+        self._collision_timer.stop()
+        self._collision_session = None
         try:
             session.impulse_ready.disconnect(self._on_collision_impulse)
         except (RuntimeError, TypeError):
@@ -1095,8 +1095,9 @@ class PetWindow(QWidget):
             session.snapshot_ready.disconnect(self._on_collision_snapshot)
         except (RuntimeError, TypeError):
             pass
-        self._collision_timer.stop()
-        self._collision_session = None
+        submit_leave = getattr(session, 'submit_leave', None)
+        if callable(submit_leave):
+            submit_leave()
         self._collision_epoch = ''
         self._collision_peer_snapshots.clear()
         self._predicted_bounces.clear()
@@ -1111,6 +1112,10 @@ class PetWindow(QWidget):
         非协调者时本地 policy 仅在本进程未来接管协调者时才生效。
         """
         session = getattr(self, '_collision_session', None)
+        if session is None:
+            # 本地成员 detach 后，app-owned worker 仍可能是其他实例的协调者；
+            # 策略必须继续同步，尤其是 collision_enabled=False。
+            session = getattr(self, '_collision_app_session', None)
         policy = {
             'collision_enabled': bool(self.cfg.get('collision_enabled', True)),
             'collision_restitution': float(self.cfg.get('collision_restitution', .82)),
@@ -1224,9 +1229,10 @@ class PetWindow(QWidget):
     @Slot(object)
     def _on_collision_snapshot(self, message: dict[str, Any]) -> None:
         epoch = str(message.get('epoch') or '')
-        if not epoch or (self._collision_epoch and epoch != self._collision_epoch):
+        if not epoch:
             return
         if epoch != self._collision_epoch:
+            self._predicted_bounces.clear()
             self._pending_predicted_bounce = None
             self._pending_predicted_contact = None
         self._collision_epoch = epoch
@@ -2990,6 +2996,8 @@ class PetWindow(QWidget):
         if collision_enabled and self._collision_session is None:
             self.attach_collision_session(getattr(self, '_collision_app_session', None))
         elif not collision_enabled and self._collision_session is not None:
+            # 先让协调 worker 停止求解，再提交本地成员 leave。
+            self._sync_collision_policy()
             self.detach_collision_session()
         self._sync_collision_policy()
         desired_scale = float(self.cfg.get('scale', self.scale))

--- a/tests/test_collision.py
+++ b/tests/test_collision.py
@@ -9,7 +9,7 @@
 5. 两两碰撞与三体及以上多体碰撞（最深重叠优先、迭代分离）
 6. 动量守恒（误差 < 1e-6）
 7. 分离后不重叠或残余重叠量 < 0.5px
-8. 协议帧流式解析（4 字节大端长度前缀、粘包/半包、超长帧丢弃、空帧、坏 JSON、不抛未捕获异常）
+8. 协议帧流式解析（4 字节大端长度前缀、有界大快照、粘包/半包、超长帧丢弃、空帧、坏 JSON）
 9. 水位去重（重复 tick 拒绝、低于水位拒绝、epoch 切换整体重置）
 10. 合速度 9000+9000 施加冲量后，经 physics.soft_clamp_speed 钳制后严格不超过 cap
 """
@@ -565,7 +565,7 @@ class TestPhysicsSoftClampSpeedIntegration:
 
 
 class TestProtocolFrameEncodingAndDecoding:
-    """协议帧（4 字节大端长度前缀、4096 上限、粘包/半包、坏 JSON/空帧）测试。"""
+    """协议帧（4 字节大端长度前缀、有限载荷、粘包/半包、坏 JSON/空帧）测试。"""
 
     def test_encode_and_decode_normal_frame(self):
         """正常帧编解码 round-trip。"""
@@ -622,6 +622,46 @@ class TestProtocolFrameEncodingAndDecoding:
         assert len(all_res) == 2
         assert all_res[0] == msg1
         assert all_res[1] == msg2
+
+    def test_default_limit_accepts_realistic_multi_member_snapshot(self):
+        """默认协议容量必须覆盖正常的多桌宠全量快照。"""
+        members = [
+            {
+                "runtime_id": f"slot-{index}-pid{1000 + index}-abcdefgh",
+                "instance_id": f"slot-{index}",
+                "seq": index,
+                "ts": 1000.0 + index,
+                "x": float(index * 32),
+                "y": float(index * 16),
+                "w": 461.0,
+                "h": 281.0,
+                "radius_x": 115.0,
+                "radius_y": 82.0,
+                "vx": 12.5,
+                "vy": -7.5,
+                "flags": 3,
+                "character": "shenshen",
+                "scale": 0.72,
+                "circles": [[float(index * 32 + offset), 64.0, 28.0]
+                            for offset in (0, 28, 56, 84)],
+            }
+            for index in range(128)
+        ]
+        snapshot = {
+            "type": "snapshot",
+            "epoch": "0123456789abcdef01234567",
+            "tick": 42,
+            "members": members,
+        }
+
+        frame = collision.encode_frame(snapshot)
+        assert len(frame) - collision.HEADER_SIZE > 4096
+        assert collision.FrameStreamDecoder().feed(frame) == [snapshot]
+
+    def test_encoder_rejects_payload_over_protocol_limit(self):
+        """发送端和接收端必须共享同一个最大帧边界。"""
+        with pytest.raises(ValueError, match="exceeds limit"):
+            collision.encode_frame({"blob": "x" * collision.FRAME_MAX_LENGTH})
 
     def test_empty_frame_corrupted_json_and_oversized_frame_no_exception(self):
         """坏 JSON、空帧、超长帧返回 DecodeError 且不抛未捕获异常。"""

--- a/tests/test_collision_ipc.py
+++ b/tests/test_collision_ipc.py
@@ -10,11 +10,18 @@ import time
 import uuid
 
 import pytest
-from PySide6.QtCore import QEventLoop
+from PySide6.QtCore import QEventLoop, QTimer
+from PySide6.QtNetwork import QAbstractSocket, QLocalServer, QLocalSocket
 from PySide6.QtWidgets import QApplication
 
 from pet import collision
-from pet.collision_ipc import CollisionIpcSession, _CollisionWorker, make_runtime_id
+from pet import collision_ipc
+from pet.collision_ipc import (
+    CollisionIpcSession,
+    _CollisionWorker,
+    collision_server_name,
+    make_runtime_id,
+)
 from pet.config import Config
 
 
@@ -28,6 +35,16 @@ class FakeSocket:
 
     def flush(self):
         return True
+
+
+class IncomingSocket(FakeSocket):
+    def __init__(self, data: bytes):
+        super().__init__()
+        self.data = data
+
+    def readAll(self):
+        data, self.data = self.data, b""
+        return data
 
 
 def _pump(seconds: float) -> None:
@@ -49,6 +66,479 @@ def _server_name(label: str) -> str:
     return f"d42-{label}-{uuid.uuid4().hex[:8]}"
 
 
+def test_collision_server_name_is_short_stable_and_variant_scoped(monkeypatch):
+    monkeypatch.setattr(collision_ipc, "APP_DIR_NAME", "dsh-pet-standalone-webm-chat")
+    chat_name = collision_server_name()
+
+    assert chat_name == collision_server_name()
+    assert len(chat_name.encode("utf-8")) <= 40
+
+    monkeypatch.setattr(collision_ipc, "APP_DIR_NAME", "dsh-pet-standalone-webm")
+    assert collision_server_name() != chat_name
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX Unix-socket path regression")
+def test_collision_server_name_listens_with_long_variant_namespace(monkeypatch):
+    monkeypatch.setattr(
+        collision_ipc,
+        "APP_DIR_NAME",
+        f"dsh-pet-standalone-webm-chat-test-{uuid.uuid4().hex}",
+    )
+    name = collision_server_name()
+    server = QLocalServer()
+    client = QLocalSocket()
+    QLocalServer.removeServer(name)
+    try:
+        assert server.listen(name), server.errorString()
+        client.connectToServer(name)
+        assert client.waitForConnected(1000), client.errorString()
+    finally:
+        client.abort()
+        server.close()
+        QLocalServer.removeServer(name)
+
+
+def test_welcome_for_all_supported_slots_round_trips_default_protocol():
+    worker = _CollisionWorker(_server_name("welcome"), "coordinator", "slot-0", {})
+    worker.epoch = "0123456789abcdef01234567"
+    worker.members = {
+        f"slot-{index}-pid{1000 + index}-abcdefgh": {
+            **_state(index, float(index * 32)),
+            "runtime_id": f"slot-{index}-pid{1000 + index}-abcdefgh",
+            "instance_id": f"slot-{index}",
+            "character": "character-" + "x" * 244,
+            "circles": [[float(index * 32 + offset), 64.0, 28.0]
+                        for offset in (0, 28, 56, 84)],
+            "last_seen": time.monotonic(),
+        }
+        for index in range(128)
+    }
+
+    welcome = worker._welcome()
+    frame = collision.encode_frame(welcome)
+
+    assert len(frame) - collision.HEADER_SIZE > 4096
+    assert collision.FrameStreamDecoder().feed(frame) == [welcome]
+
+
+def test_large_inbound_state_cannot_poison_the_aggregate_snapshot():
+    worker = _CollisionWorker(_server_name("large-state"), "coordinator", "slot-0", {})
+    worker.server = object()
+    worker.epoch = "epoch-a"
+    message = {
+        "type": "state",
+        **_state(1),
+        "padding": "x" * (collision.FRAME_MAX_LENGTH - 8192),
+        "character": "界" * 1000,
+        "circles": [[float(index), 1.0, 2.0] for index in range(12)],
+    }
+    oversized_frame = collision.encode_frame(message)
+    assert len(oversized_frame) - collision.HEADER_SIZE > collision.STATE_FRAME_MAX_LENGTH
+    valid_frame = collision.encode_frame(
+        {"type": "state", **_state(2, x=42.0)},
+        max_frame_len=collision.STATE_FRAME_MAX_LENGTH,
+    )
+    socket = IncomingSocket(oversized_frame + valid_frame)
+    socket._collision_decoder = collision.FrameStreamDecoder(
+        max_frame_len=collision.STATE_FRAME_MAX_LENGTH,
+    )
+    worker.peers[socket] = "remote"
+
+    worker._read_socket(socket)
+
+    member = worker.members["remote"]
+    assert member["seq"] == 2
+    assert member["x"] == 42.0
+    assert "padding" not in member
+    snapshot = {
+        "type": "snapshot",
+        "epoch": worker.epoch,
+        "tick": worker.tick,
+        "members": [worker._public_member(item) for item in worker.members.values()],
+    }
+    collision.encode_frame(snapshot)
+
+
+def test_state_ingestion_caps_members_and_preserves_snapshot_budget():
+    worker = _CollisionWorker(_server_name("member-budget"), "coordinator", "slot-0", {})
+    worker.server = object()
+    worker.epoch = "epoch-a"
+
+    for index in range(129):
+        socket = FakeSocket()
+        worker.peers[socket] = f"slot-{index}-pid{1000 + index}-abcdefgh"
+        worker._handle_message(socket, {
+            "type": "state",
+            **_state(1, float(index)),
+            "padding": "must-not-enter-snapshot",
+            "character": "character-" + "x" * 500,
+            "circles": [[float(index + offset), 64.0, 28.0]
+                        for offset in range(8)],
+        })
+
+    assert len(worker.members) == 128
+    assert all("padding" not in member for member in worker.members.values())
+    assert all(len(member["character"].encode("utf-8")) <= 512
+               for member in worker.members.values())
+    assert all(len(member["circles"]) <= 3 for member in worker.members.values())
+    assert (collision_ipc.MAX_COLLISION_MEMBERS
+            * (collision_ipc.PUBLIC_MEMBER_MAX_LENGTH + 1)
+            + collision.STATE_FRAME_MAX_LENGTH < collision.FRAME_MAX_LENGTH)
+    frame = collision.encode_frame(worker._welcome())
+    assert len(frame) - collision.HEADER_SIZE <= collision.FRAME_MAX_LENGTH
+    assert collision.FrameStreamDecoder().feed(frame) == [worker._welcome()]
+
+
+def test_schedule_election_reuses_one_timer():
+    QApplication.instance() or QApplication([])
+    worker = _CollisionWorker(_server_name("timer"), "client", "", {})
+
+    for _ in range(20):
+        worker._schedule_election()
+
+    assert len(worker.findChildren(QTimer)) == 1
+    assert worker._election_timer.isActive()
+
+
+@pytest.mark.parametrize(
+    ("listen_error", "probe_is_live", "should_recover"),
+    [
+        (QAbstractSocket.SocketError.AddressInUseError, False, True),
+        (QAbstractSocket.SocketError.AddressInUseError, True, False),
+        (QAbstractSocket.SocketError.HostNotFoundError, False, False),
+    ],
+)
+def test_posix_listen_recovery_only_removes_address_in_use(
+        monkeypatch, listen_error, probe_is_live, should_recover):
+    class FakeLocalServer:
+        removed = []
+
+        def __init__(self, _parent=None):
+            self.listen_calls = 0
+
+        def listen(self, _name):
+            self.listen_calls += 1
+            return should_recover and self.listen_calls == 2
+
+        def serverError(self):
+            return listen_error
+
+        def deleteLater(self):
+            pass
+
+        @classmethod
+        def removeServer(cls, name):
+            cls.removed.append(name)
+            return True
+
+    lock = object()
+    released = []
+    probes = []
+    listeners = []
+    client_attempts = []
+    monkeypatch.setattr(collision_ipc, "QLocalServer", FakeLocalServer)
+    monkeypatch.setattr(collision_ipc.sys, "platform", "darwin")
+    monkeypatch.setattr(collision_ipc.slot_manager, "acquire_file_lock", lambda _path: lock)
+    monkeypatch.setattr(
+        collision_ipc.slot_manager,
+        "release_file_lock",
+        lambda held: released.append(held),
+    )
+    worker = _CollisionWorker(_server_name("listen"), "runtime", "", {}, lock_path="lock")
+    monkeypatch.setattr(
+        worker,
+        "_probe_live_server",
+        lambda: probes.append(True) or probe_is_live,
+    )
+    monkeypatch.setattr(worker, "_become_listener", listeners.append)
+    monkeypatch.setattr(worker, "_connect_client", lambda: client_attempts.append(True))
+
+    worker._try_election()
+
+    assert bool(FakeLocalServer.removed) is should_recover
+    assert bool(probes) is (listen_error == QAbstractSocket.SocketError.AddressInUseError)
+    assert bool(listeners) is should_recover
+    assert bool(client_attempts) is (not should_recover)
+    assert released == ([] if should_recover else [lock])
+
+
+def test_watchdog_timeout_never_removes_named_endpoint(monkeypatch):
+    removed = []
+    scheduled = []
+    aborted = []
+
+    class TimedOutSocket:
+        def abort(self):
+            aborted.append(True)
+
+        def deleteLater(self):
+            pass
+
+    monkeypatch.setattr(
+        collision_ipc.QLocalServer,
+        "removeServer",
+        lambda name: removed.append(name),
+    )
+    worker = _CollisionWorker(_server_name("watchdog"), "client", "", {})
+    monkeypatch.setattr(worker, "_schedule_election", lambda: scheduled.append(True))
+
+    for _ in range(2):
+        worker.socket = TimedOutSocket()
+        worker._had_client_connection = True
+        worker._welcome_timed_out()
+
+    assert aborted == [True, True]
+    assert scheduled == [True, True]
+    assert removed == []
+
+
+def test_stop_removes_owned_endpoint_before_releasing_lock(monkeypatch):
+    events = []
+
+    class OwnedServer:
+        def close(self):
+            events.append("close")
+
+        def deleteLater(self):
+            pass
+
+    worker = _CollisionWorker(_server_name("stop"), "coordinator", "", {})
+    worker.server = OwnedServer()
+    worker._coordinator_lock = object()
+    monkeypatch.setattr(
+        collision_ipc.QLocalServer,
+        "removeServer",
+        lambda _name: events.append("remove"),
+    )
+    monkeypatch.setattr(
+        collision_ipc.slot_manager,
+        "release_file_lock",
+        lambda _lock: events.append("release"),
+    )
+    monkeypatch.setattr(collision_ipc.QTimer, "singleShot", lambda *_args: None)
+
+    worker.stop()
+
+    assert events == ["close", "remove", "release"]
+
+
+def test_coordinator_submit_leave_broadcasts_remaining_members():
+    worker = _CollisionWorker(_server_name("own-leave"), "coordinator", "", {
+        "collision_enabled": True,
+    })
+    worker.server = object()
+    worker.epoch = "epoch-a"
+    worker._participating = True
+    worker.latest_state = _state(1)
+    peer_socket = FakeSocket()
+    worker.peers[peer_socket] = "peer"
+    worker.members = {
+        "coordinator": {**_state(1), "runtime_id": "coordinator", "last_seen": 1.0},
+        "peer": {**_state(1), "runtime_id": "peer", "last_seen": 1.0},
+    }
+    worker._now = staticmethod(lambda: 1.0)
+    worker._last_snapshot_at = 1.0
+
+    worker.submit_leave()
+    worker._coordinator_tick()
+
+    assert "coordinator" not in worker.members
+    assert "peer" in worker.members
+    assert len(peer_socket.sent) == 1
+    snapshot = collision.FrameStreamDecoder().feed(peer_socket.sent[0])[0]
+    assert snapshot["type"] == "snapshot"
+    assert [member["runtime_id"] for member in snapshot["members"]] == ["peer"]
+
+
+@pytest.mark.parametrize("collision_enabled", [True, False])
+def test_single_member_snapshot_heartbeat_does_not_require_solver(collision_enabled):
+    worker = _CollisionWorker(_server_name("one-member"), "coordinator", "", {
+        "collision_enabled": collision_enabled,
+    })
+    worker.server = object()
+    worker.epoch = "epoch-a"
+    peer_socket = FakeSocket()
+    worker.peers[peer_socket] = "peer"
+    worker.members = {
+        "peer": {**_state(1), "runtime_id": "peer", "last_seen": 1.0},
+    }
+    times = iter((1.0, 1.6, 1.6))
+    worker._now = staticmethod(lambda: next(times))
+
+    worker._coordinator_tick()
+    worker._coordinator_tick()
+
+    assert len(peer_socket.sent) == 2
+    assert worker.tick == 0
+    snapshots = [
+        collision.FrameStreamDecoder().feed(frame)[0]
+        for frame in peer_socket.sent
+    ]
+    if collision_enabled:
+        assert all(len(snapshot["members"]) == 1 for snapshot in snapshots)
+        assert len(worker._welcome()["members"]) == 1
+    else:
+        assert all(snapshot["members"] == [] for snapshot in snapshots)
+        assert worker._welcome()["members"] == []
+
+
+def test_authoritative_membership_excludes_solver_stale_members():
+    worker = _CollisionWorker(_server_name("stale-member"), "coordinator", "", {
+        "collision_enabled": True,
+    })
+    worker.server = object()
+    worker.epoch = "epoch-a"
+    peer_socket = FakeSocket()
+    worker.peers[peer_socket] = "fresh"
+    worker.members = {
+        "fresh": {**_state(1), "runtime_id": "fresh", "last_seen": 10.0},
+        # Solver 已不再使用，但尚未达到 heartbeat 的 3 秒清理阈值。
+        "stale": {**_state(1), "runtime_id": "stale", "last_seen": 8.7},
+    }
+    worker._now = staticmethod(lambda: 10.0)
+    worker._membership_dirty = True
+
+    worker._coordinator_tick()
+
+    assert "stale" in worker.members
+    snapshot = collision.FrameStreamDecoder().feed(peer_socket.sent[0])[0]
+    assert [member["runtime_id"] for member in snapshot["members"]] == ["fresh"]
+    assert [member["runtime_id"] for member in worker._welcome()["members"]] == ["fresh"]
+
+
+def test_policy_toggle_forces_empty_then_full_membership_snapshot():
+    worker = _CollisionWorker(_server_name("policy-snapshot"), "coordinator", "", {
+        "collision_enabled": True,
+    })
+    worker.server = object()
+    worker.epoch = "epoch-a"
+    peer_socket = FakeSocket()
+    worker.peers[peer_socket] = "peer"
+    worker.members = {
+        "peer": {**_state(1), "runtime_id": "peer", "last_seen": 1.0},
+    }
+    worker._now = staticmethod(lambda: 1.0)
+    worker._last_snapshot_at = 1.0
+
+    def seed_solver_history():
+        worker._pending_predicted = {"peer": {"_captured_at": 1.0}}
+        worker.previous_members = {"peer": {"seq": 0}}
+        worker._swept_pair_versions = {"a|b": (1, 1)}
+        worker._predicted_pair_ticks = {"a|b": 3}
+        worker._position_only_pairs = {"a|b": ((1.0, 2.0), 3)}
+        worker.overlap_history = {"a|b": 2}
+
+    def assert_solver_history_cleared():
+        assert worker._pending_predicted == {}
+        assert worker.previous_members == {}
+        assert worker._swept_pair_versions == {}
+        assert worker._predicted_pair_ticks == {}
+        assert worker._position_only_pairs == {}
+        assert worker.overlap_history == {}
+
+    seed_solver_history()
+    worker.set_policy({"collision_enabled": False})
+    assert_solver_history_cleared()
+    worker._coordinator_tick()
+    seed_solver_history()
+    worker.set_policy({"collision_enabled": True})
+    assert_solver_history_cleared()
+    worker._coordinator_tick()
+
+    snapshots = [
+        collision.FrameStreamDecoder().feed(frame)[0]
+        for frame in peer_socket.sent
+    ]
+    assert [snapshot["members"] for snapshot in snapshots] == [[], [
+        worker._public_member(worker.members["peer"])
+    ]]
+
+
+def test_same_epoch_welcome_refreshes_policy_and_membership_snapshot():
+    worker = _CollisionWorker(_server_name("same-epoch"), "client", "", {})
+    worker.epoch = "epoch-a"
+    snapshots = []
+    policies = []
+    roles = []
+    worker.snapshot_ready.connect(snapshots.append)
+    worker.policy_changed.connect(policies.append)
+    worker.role_changed.connect(lambda coordinator, epoch: roles.append((coordinator, epoch)))
+    welcome = {
+        "type": "welcome",
+        "epoch": "epoch-a",
+        "tick": 9,
+        "policy": {"collision_enabled": False},
+        "members": [],
+    }
+
+    worker._handle_message(FakeSocket(), welcome)
+
+    assert snapshots == [welcome]
+    assert policies == [welcome["policy"]]
+    assert roles == []
+
+
+def test_client_leave_suppresses_heartbeat_and_stale_failover_registration(monkeypatch):
+    worker = _CollisionWorker(_server_name("leave-intent"), "client", "slot-1", {})
+    client_socket = FakeSocket()
+    worker.socket = client_socket
+    worker.latest_state = _state(1)
+    worker._participating = True
+
+    worker.submit_leave()
+    assert len(client_socket.sent) == 1
+    worker._heartbeat()
+    assert len(client_socket.sent) == 1
+
+    worker.socket = None
+    worker.server = object()
+    monkeypatch.setattr(worker, "_start_coordinator_timers", lambda: None)
+    worker._announce_coordinator()
+    assert worker.runtime_id not in worker.members
+
+    worker.submit_state(_state(2, x=42.0))
+    assert worker.members[worker.runtime_id]["x"] == 42.0
+
+
+def test_accept_connection_reads_bytes_that_arrived_before_signal_hooks():
+    class ConnectableSignal:
+        def connect(self, _callback):
+            pass
+
+    class PendingSocket:
+        readyRead = ConnectableSignal()
+        disconnected = ConnectableSignal()
+        errorOccurred = ConnectableSignal()
+
+        @staticmethod
+        def bytesAvailable():
+            return 1
+
+    class PendingServer:
+        def __init__(self, socket):
+            self.socket = socket
+            self.pending = True
+
+        def hasPendingConnections(self):
+            return self.pending
+
+        def nextPendingConnection(self):
+            self.pending = False
+            return self.socket
+
+    socket = PendingSocket()
+    worker = _CollisionWorker(_server_name("early-bytes"), "coordinator", "", {})
+    worker.server = PendingServer(socket)
+    reads = []
+    worker._read_socket = reads.append
+
+    worker._accept_connection()
+
+    assert worker.peers[socket] == ""
+    assert socket._collision_decoder.max_frame_len == collision.STATE_FRAME_MAX_LENGTH
+    assert reads == [socket]
+
+
 def test_fake_socket_join_duplicate_seq_and_disconnect():
     worker = _CollisionWorker("unused-" + uuid.uuid4().hex, "coordinator", "", {
         "collision_enabled": True, "collision_restitution": .82,
@@ -62,9 +552,37 @@ def test_fake_socket_join_duplicate_seq_and_disconnect():
     worker._handle_message(socket, {"type": "state", **_state(2, 10)})
     worker._handle_message(socket, {"type": "state", **_state(1, 99)})
     assert worker.members["remote"]["x"] == 10
+    worker.overlap_history = {"coordinator|remote": 2, "other|pair": 1}
+    worker._position_only_pairs = {
+        "coordinator|remote": ((1.0, 2.0), 3),
+        "other|pair": ((4.0, 5.0), 6),
+    }
     worker.peers.pop(socket)
     worker._remove_member("remote")
     assert "remote" not in worker.members
+    assert worker.overlap_history == {"other|pair": 1}
+    assert worker._position_only_pairs == {"other|pair": ((4.0, 5.0), 6)}
+
+
+def test_resign_clears_all_epoch_scoped_collision_history(monkeypatch):
+    class Server:
+        def close(self):
+            pass
+
+        def deleteLater(self):
+            pass
+
+    worker = _CollisionWorker(_server_name("resign-history"), "coordinator", "", {})
+    worker.server = Server()
+    worker.overlap_history = {"a|b": 2}
+    worker._position_only_pairs = {"a|b": ((1.0, 2.0), 3)}
+    monkeypatch.setattr(collision_ipc.slot_manager, "release_file_lock", lambda _lock: None)
+    monkeypatch.setattr(worker, "_connect_client", lambda: None)
+
+    worker._resign_to("winner")
+
+    assert worker.overlap_history == {}
+    assert worker._position_only_pairs == {}
 
 
 def test_coordinator_sweeps_fast_circle_chain_and_emits_impulse():
@@ -118,6 +636,35 @@ def _coordinator_with_members(*states):
                 and state.get("bounce_vy") is not None):
             worker._pending_predicted[state["runtime_id"]] = {**state, "_captured_at": 1.0}
     return worker
+
+
+def test_snapshot_broadcast_encodes_once_for_all_peers(monkeypatch):
+    flags = collision.FLAG_VISIBLE | collision.FLAG_COLLISION_ENABLED
+    first = {
+        "runtime_id": "a", "seq": 1, "x": 0.0, "y": 0.0,
+        "radius_x": 30.0, "radius_y": 30.0, "circles": [[0.0, 0.0, 30.0]],
+        "vx": 100.0, "vy": 0.0, "flags": flags,
+    }
+    second = {
+        "runtime_id": "b", "seq": 1, "x": 500.0, "y": 0.0,
+        "radius_x": 30.0, "radius_y": 30.0, "circles": [[500.0, 0.0, 30.0]],
+        "vx": 0.0, "vy": 0.0, "flags": flags,
+    }
+    worker = _coordinator_with_members(first, second)
+    sockets = [FakeSocket() for _ in range(3)]
+    worker.peers = {socket: f"peer-{index}" for index, socket in enumerate(sockets)}
+    encoded = []
+    original_encode = collision.encode_frame
+    monkeypatch.setattr(
+        collision,
+        "encode_frame",
+        lambda message: encoded.append(message) or original_encode(message),
+    )
+
+    worker._coordinator_tick()
+
+    assert len(encoded) == 1
+    assert all(len(socket.sent) == 1 for socket in sockets)
 
 
 @pytest.mark.parametrize(
@@ -385,30 +932,47 @@ def test_subprocess_sessions_send_frames_and_reelect_after_parent_exits(tmp_path
 import json, sys, time
 from PySide6.QtCore import QEventLoop
 from PySide6.QtWidgets import QApplication
+from pet import collision
 from pet.collision_ipc import CollisionIpcSession
 from pet.config import Config
 
 app = QApplication([])
 session = CollisionIpcSession(Config(sys.argv[3], instance_id=sys.argv[2]), server_name=sys.argv[1])
 roles = []
+snapshots = []
 session.role_changed.connect(lambda coordinator, epoch: roles.append((coordinator, epoch)))
+session.snapshot_ready.connect(snapshots.append)
 session.start()
 deadline = time.monotonic() + 6
 while time.monotonic() < deadline and not roles:
     app.processEvents(QEventLoop.AllEvents, 10)
     time.sleep(.005)
+flags = collision.FLAG_VISIBLE | collision.FLAG_COLLISION_ENABLED
 for seq in range(1000):
     session.submit_state({"seq": seq, "ts": time.monotonic(), "x": float(seq), "y": 0,
                           "w": 10, "h": 10, "radius_x": 5, "radius_y": 5,
-                          "vx": 0, "vy": 0, "flags": 3})
+                          "vx": 0, "vy": 0, "flags": flags})
     app.processEvents(QEventLoop.AllEvents, 1)
-print(json.dumps({"roles": roles, "frames": 1000}), flush=True)
+deadline = time.monotonic() + 6
+while time.monotonic() < deadline and not any(len(item.get("members") or ()) >= 2 for item in snapshots):
+    app.processEvents(QEventLoop.AllEvents, 10)
+    time.sleep(.005)
+initial_roles = list(roles)
+initial_epochs = {epoch for _, epoch in initial_roles if epoch}
+print(json.dumps({
+    "roles": initial_roles,
+    "frames_sent": 1000,
+    "snapshot_count": len(snapshots),
+    "max_members": max((len(item.get("members") or ()) for item in snapshots), default=0),
+}), flush=True)
 if sys.argv[4] == "hold":
-    deadline = time.monotonic() + 12
-    while time.monotonic() < deadline:
+    deadline = time.monotonic() + 8
+    while time.monotonic() < deadline and not any(
+            coordinator and epoch not in initial_epochs
+            for coordinator, epoch in roles[len(initial_roles):]):
         app.processEvents(QEventLoop.AllEvents, 10)
         time.sleep(.005)
-    print(json.dumps({"roles": roles}), flush=True)
+    print(json.dumps({"new_roles": roles[len(initial_roles):]}), flush=True)
 session.stop()
 '''
     env = dict(os.environ, QT_QPA_PLATFORM="offscreen", PYTHONPATH=os.getcwd())
@@ -418,16 +982,40 @@ session.stop()
         [sys.executable, "-c", script, name, "slot-b", str(tmp_path), "hold"],
         stdout=subprocess.PIPE, text=True, env=env,
     )
-    first_info = json.loads(first.stdout.readline())
-    second_info = json.loads(second.stdout.readline())
-    assert first_info["frames"] == second_info["frames"] == 1000
-    coordinator = first if any(role[0] for role in first_info["roles"]) else second
-    survivor = second if coordinator is first else first
-    coordinator.terminate()
-    assert coordinator.wait(timeout=5) is not None
-    survivor_info = json.loads(survivor.stdout.readline())
-    assert any(role[0] for role in survivor_info["roles"])
-    assert survivor.wait(timeout=5) == 0
+    try:
+        first_info = json.loads(first.stdout.readline())
+        second_info = json.loads(second.stdout.readline())
+        assert first_info["frames_sent"] == second_info["frames_sent"] == 1000
+        assert first_info["snapshot_count"] > 0
+        assert second_info["snapshot_count"] > 0
+        assert first_info["max_members"] >= 2
+        assert second_info["max_members"] >= 2
+
+        coordinator = first if any(role[0] for role in first_info["roles"]) else second
+        survivor = second if coordinator is first else first
+        initial_epochs = {
+            epoch
+            for info in (first_info, second_info)
+            for _, epoch in info["roles"]
+            if epoch
+        }
+        assert len(initial_epochs) == 1
+
+        coordinator.terminate()
+        assert coordinator.wait(timeout=5) is not None
+        survivor_info = json.loads(survivor.stdout.readline())
+        new_coordinator_epochs = {
+            epoch for is_coordinator, epoch in survivor_info["new_roles"]
+            if is_coordinator and epoch
+        }
+        assert len(new_coordinator_epochs) == 1
+        assert new_coordinator_epochs.isdisjoint(initial_epochs)
+        assert survivor.wait(timeout=5) == 0
+    finally:
+        for process in (first, second):
+            if process.poll() is None:
+                process.terminate()
+                process.wait(timeout=5)
 
 
 def test_submit_leave_removes_member_immediately(tmp_path):
@@ -460,11 +1048,25 @@ def test_submit_leave_removes_member_immediately(tmp_path):
         assert client_session.runtime_id in coord_worker.members
 
         # 发送 leave：成员即时移除（3s stale 移除阈值远未到）
+        snapshots = []
+        client_session.snapshot_ready.connect(snapshots.append)
+        stable_epoch = client_session._worker.epoch
         client_session.submit_leave()
         deadline = time.monotonic() + 2.0
         while time.monotonic() < deadline and client_session.runtime_id in coord_worker.members:
             _pump(0.05)
         assert client_session.runtime_id not in coord_worker.members
+
+        # 即使成员表已空，snapshot 仍是连接 watchdog 的控制心跳；客户端
+        # 必须收到空权威表，并在超过 1.5s 后继续连接到同一 epoch。
+        deadline = time.monotonic() + 1.0
+        while time.monotonic() < deadline and not any(
+                not (item.get("members") or ()) for item in snapshots):
+            _pump(0.05)
+        assert any(not (item.get("members") or ()) for item in snapshots)
+        _pump(1.7)
+        assert client_session._worker.socket is not None
+        assert client_session._worker.epoch == stable_epoch
     finally:
         coordinator.stop()
         client.stop()
@@ -477,7 +1079,10 @@ def test_update_policy_live_applies_to_worker(tmp_path):
     session = CollisionIpcSession(Config(tmp_path, instance_id="slot-p"), server_name=name)
     session.start()
     try:
-        _pump(0.5)
+        deadline = time.monotonic() + 3.0
+        while time.monotonic() < deadline and session._worker.server is None:
+            _pump(0.05)
+        assert session._worker.server is not None
         session.update_policy({"collision_enabled": True, "collision_restitution": 0.5,
                                "collision_friction": 0.15, "collision_mass_scale": 1.5,
                                "collision_impulse_cap": 6000.0})

--- a/tests/test_collision_window.py
+++ b/tests/test_collision_window.py
@@ -166,10 +166,12 @@ def test_collision_squash_is_not_restarted_within_250ms(tmp_path, app):
     app.processEvents()
     assert win._squash_active is True
 
-    win._squash_progress = 0.4
+    first_started_at = win._last_collision_squash_at
     session.impulse_ready.emit(msg)
     app.processEvents()
-    assert win._squash_progress == pytest.approx(0.4)
+    # progress 是由真实 elapsed timer 派生的，不能手工设值后做精确比较；
+    # 开始时间戳不变才是“第二次冲量没有重启动画”的直接证据。
+    assert win._last_collision_squash_at == first_started_at
 
     win.close()
 
@@ -437,6 +439,7 @@ def test_collision_disabled_does_not_report_receive_and_detaches(tmp_path, app):
     win.cfg.set("collision_enabled", False)
     win.refresh_pet_settings()
     assert win._collision_session is None
+    assert session.policy_updates[-1]["collision_enabled"] is False
 
     win.close()
 
@@ -469,15 +472,27 @@ def test_lock_position_window_is_knockable(tmp_path, app):
     win.close()
 
 
-def test_detach_collision_session_sends_leave(tmp_path, app):
+def test_detach_collision_session_sends_leave_after_stopping_state_production(
+    tmp_path, app, monkeypatch
+):
     """detach_collision_session 时向会话发 leave：协调者即时移除成员（不等 stale 超时）。"""
     win, session = _make_pet_window(tmp_path, "pet_a")
     assert win._collision_session is session
     assert session.leave_calls == 0
+    state_at_leave = []
+
+    def record_leave():
+        state_at_leave.append((win._collision_session, win._collision_timer.isActive()))
+        session.leave_calls += 1
+
+    monkeypatch.setattr(session, "submit_leave", record_leave)
+    win.cfg.set("collision_enabled", False)
 
     win.detach_collision_session()
     assert win._collision_session is None
     assert session.leave_calls == 1
+    assert state_at_leave == [(None, False)]
+    assert session.policy_updates[-1]["collision_enabled"] is False
 
     # 再次 detach（已无会话）不发 leave
     win.detach_collision_session()
@@ -528,6 +543,8 @@ def test_window_deduplicates_same_epoch_pair_tick(tmp_path, app):
     session.impulse_ready.emit(msg)
     app.processEvents()
     first_velocity = list(win._phys_vel)
+    # 隔离碰撞冲量去重：物理定时器会独立施加重力并改变 Y 速度。
+    win._physics_timer.stop()
     session.impulse_ready.emit(msg)
     app.processEvents()
     assert win._phys_vel == first_velocity
@@ -557,10 +574,13 @@ def test_predicted_bounce_reports_contact_geometry(tmp_path, app):
     win.close()
 
 
-def test_move_event_submits_throttled_not_forced(tmp_path, app):
+def test_move_event_submits_throttled_not_forced(tmp_path, app, monkeypatch):
     """moveEvent 非 force 节流提交：60Hz 连续移动不超标（上限 20Hz）。"""
+    import pet.window as window_mod
+
     win, session = _make_pet_window(tmp_path, "pet_a")
     win._collision_timer.stop()  # 排除定时器 force 兜底对计数的干扰
+    monkeypatch.setattr(window_mod.time, "monotonic", lambda: 100.0)
     session.submitted_states.clear()
     win._collision_last_submit_at = 0.0  # 保证首个 move 放行
     start = win.pos()
@@ -674,10 +694,11 @@ def _prediction_peer(win, runtime_id="pet_b", vx=0.0, flags=None):
     }
 
 
-def test_collision_snapshot_stores_epoch_and_clears_stale_members(tmp_path, app):
+def test_collision_snapshot_accepts_new_epoch_after_coordinator_failover(tmp_path, app):
     win, session = _make_pet_window(tmp_path, "pet_a")
     session.snapshot_ready.emit({"epoch": "epoch-1", "members": [_prediction_peer(win)]})
     app.processEvents()
+    assert win._collision_epoch == "epoch-1"
     assert "pet_b" in win._collision_peer_snapshots
     assert win._collision_peer_snapshots["pet_b"]["_received_at"] > 0
 
@@ -685,9 +706,16 @@ def test_collision_snapshot_stores_epoch_and_clears_stale_members(tmp_path, app)
     win._prune_collision_prediction_state(time.monotonic())
     assert win._collision_peer_snapshots == {}
 
+    win._pending_predicted_bounce = (10.0, 20.0)
+    win._pending_predicted_contact = (30.0, 40.0, [])
+    win._predicted_bounces = {"pet_a|pet_b": time.monotonic()}
     session.snapshot_ready.emit({"epoch": "epoch-2", "members": [_prediction_peer(win)]})
     app.processEvents()
-    assert win._collision_peer_snapshots == {}
+    assert win._collision_epoch == "epoch-2"
+    assert "pet_b" in win._collision_peer_snapshots
+    assert win._predicted_bounces == {}
+    assert win._pending_predicted_bounce is None
+    assert win._pending_predicted_contact is None
     win.close()
 
 
@@ -774,24 +802,6 @@ def test_authoritative_impulse_applies_after_prediction_window(tmp_path, app):
                                 "dvx_a": 400.0, "dvy_a": 0.0})
     app.processEvents()
     assert win._phys_vel[0] > 0.0
-    win.close()
-
-
-def test_move_event_submits_throttled_not_forced(tmp_path, app):
-    """moveEvent 非 force 节流提交：60Hz 连续移动不超标（上限 20Hz）。"""
-    win, session = _make_pet_window(tmp_path, "pet_a")
-    session.submitted_states.clear()
-    win._collision_last_submit_at = 0.0  # 保证首个 move 放行
-    start = win.pos()
-
-    # 模拟 60Hz 抛掷：极短时间内连续 20 次移动，全部落在 50ms 限流窗口内
-    for i in range(1, 21):
-        win.move(start.x() + i, start.y())
-    app.processEvents()
-
-    # moveEvent 路径只放行首个提交，其余被节流（运动期由 _collision_timer 兜底）
-    assert len(session.submitted_states) == 1
-
     win.close()
 
 

--- a/tests/test_slot_and_memory.py
+++ b/tests/test_slot_and_memory.py
@@ -154,6 +154,94 @@ else:
     assert lock_file.read_bytes().strip() != b""
 
 
+def test_public_acquire_is_safe_when_two_processes_observe_stale_zero_size(tmp_path):
+    """强制两个进程都在初始化前读到 size=0，后到者不能重复追加 16 字节。"""
+    config_dir = tmp_path / APP_DIR_NAME
+    config_dir.mkdir(parents=True, exist_ok=True)
+    sync_dir = tmp_path / "stale-size-sync"
+    sync_dir.mkdir()
+    initialized = sync_dir / "first-initialized"
+
+    def worker_code(role: str) -> str:
+        return f"""
+from pathlib import Path
+import time
+from pet import slot_manager as sm
+role = {role!r}
+sync_dir = Path({str(sync_dir)!r})
+initialized = Path({str(initialized)!r})
+real_fstat = sm.os.fstat
+def synchronized_fstat(fd):
+    observed = real_fstat(fd)
+    (sync_dir / f"ready-{{role}}").write_text("ready", encoding="ascii")
+    deadline = time.monotonic() + 5
+    while len(list(sync_dir.glob("ready-*"))) < 2:
+        if time.monotonic() >= deadline:
+            raise TimeoutError("peer did not reach fstat barrier")
+        time.sleep(0.001)
+    if role == "second":
+        while not initialized.exists():
+            if time.monotonic() >= deadline:
+                raise TimeoutError("first process did not initialize lock")
+            time.sleep(0.001)
+    return observed
+sm.os.fstat = synchronized_fstat
+try:
+    slot, handle = sm.acquire_pet_slot({str(config_dir)!r}, preferred_slot=0)
+except Exception as exc:
+    print(type(exc).__name__, flush=True)
+else:
+    if role == "first":
+        initialized.write_text("done", encoding="ascii")
+    print(f"LOCKED:{{slot}}", flush=True)
+    time.sleep(1)
+"""
+
+    first = _run_slot_worker_code(config_dir, worker_code("first"))
+    second = _run_slot_worker_code(config_dir, worker_code("second"))
+    assert first.stdout.readline().strip() == "LOCKED:0"
+    assert second.stdout.readline().strip() == "SlotLockError"
+    assert first.wait(timeout=5) == 0
+    assert second.wait(timeout=5) == 0
+    lock_file = sm.get_slot_lock_path(config_dir, 0)
+    assert lock_file.stat().st_size == sm.PID_RECORD_LEN
+
+
+def test_lock_initialization_is_idempotent_when_size_observation_is_stale(
+    tmp_path, monkeypatch
+):
+    """并发打开者都观察到旧 size=0 时，初始化也不能重复追加记录。"""
+    lock_file = sm.get_slot_lock_path(tmp_path / APP_DIR_NAME, 0)
+    lock_file.parent.mkdir(parents=True, exist_ok=True)
+
+    class StaleStat:
+        st_size = 0
+
+    monkeypatch.setattr(sm.os, "fstat", lambda _fd: StaleStat())
+    first = sm._open_lock_file(lock_file)
+    first.close()
+    second = sm._open_lock_file(lock_file)
+    second.close()
+
+    assert lock_file.stat().st_size == sm.PID_RECORD_LEN
+
+
+def test_lock_acquisition_repairs_an_oversized_pid_record(tmp_path):
+    """旧竞态留下的 32 字节锁文件在下一次成功持锁后恢复为定长格式。"""
+    lock_file = sm.get_slot_lock_path(tmp_path / APP_DIR_NAME, 0)
+    lock_file.parent.mkdir(parents=True, exist_ok=True)
+    lock_file.write_bytes(b" " * (sm.PID_RECORD_LEN * 2))
+
+    handle = sm.acquire_file_lock(lock_file)
+    assert handle is not None
+    try:
+        assert os.fstat(handle.fileno()).st_size == sm.PID_RECORD_LEN
+        handle.seek(0)
+        assert handle.read(sm.PID_RECORD_LEN).startswith(str(os.getpid()).encode("ascii"))
+    finally:
+        sm.release_file_lock(handle)
+
+
 def test_slot_reclaimed_after_process_killed_and_keeps_memory(tmp_path):
     """场景 2：子进程持有 slot-1 后被终止；新子进程重新加锁 slot-1，读取原个体配置和 sessions，且未删 lock 文件。"""
     config_dir = tmp_path / APP_DIR_NAME


### PR DESCRIPTION
## 概述

修复 #42 暴露的 POSIX/macOS 碰撞 IPC 协议边界与生命周期竞态，使协调者选举、成员同步、退出和接管使用一致的权威状态。

## 主要变更

- 拆分协议预算：协调者下行 256 KiB、客户端 state 上行 4 KiB；限制成员数和单成员公开载荷，并对入站状态进行有界归一化。
- 加固 POSIX 残留端点恢复、锁文件初始化与协调者交接，确保关闭时在释放锁前清理自有端点。
- 统一 solver、welcome 与 snapshot 的成员 freshness，补齐禁用、单成员、同 epoch welcome 和权威快照语义。
- 修正 leave、failover 与窗口 detach 时序，epoch 切换时清理预测和 solver 历史。
- 补充真实 QLocal IPC、锁竞争和跨进程 failover 回归测试。

## 本地验证

聚焦碰撞、IPC、窗口和锁套件：

    QT_QPA_PLATFORM=offscreen PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q tests/test_collision.py tests/test_collision_ipc.py tests/test_collision_window.py tests/test_slot_and_memory.py

结果：121 passed。

精确提交快照 3bd7cec 全量测试：

    QT_QPA_PLATFORM=offscreen PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q

结果：690 passed, 9 skipped。

## CI

上游 Linux、macOS、Windows workflow 当前只由 workflow_dispatch 或 v* tag push 触发，普通 PR 不会自动运行。合并前仍需维护者手动触发三平台验证。

Closes #42