### PR TITLE
fix: 拖动不触发点击音效 + API 请求头浏览器特征（Cloudflare 1010）

### DIFF
--- a/pet/balance.py
+++ b/pet/balance.py
@@ -60,7 +60,8 @@ def fetch_balance(base_url: str, api_key: str, timeout: float = 10.0,
     endpoint = str(base_url or '').strip().rstrip('/') + BALANCE_PATH
     if not api_key:
         raise BalanceError('未配置 API Key')
-    headers = {'Authorization': f'Bearer {api_key}', 'Accept': 'application/json'}
+    from .chat.providers import build_browser_headers  # 延迟导入：无 Chat 变体排除 pet.chat
+    headers = build_browser_headers({'Authorization': f'Bearer {api_key}', 'Accept': 'application/json'})
     req = urllib.request.Request(endpoint, headers=headers)
     try:
         with urllib.request.urlopen(req, timeout=timeout,

--- a/pet/chat/providers.py
+++ b/pet/chat/providers.py
@@ -29,13 +29,32 @@ def _is_cert_verify_error(reason) -> bool:
 
 _CERT_HINT = '；如为代理/梯子拦截或自签名证书，可在 AI 设置中勾选"跳过 SSL 证书验证"后重试'
 
+
+def build_browser_headers(extra: dict | None = None) -> dict[str, str]:
+    """构造带浏览器特征的请求头，降低 Cloudflare 等 WAF 的机器人误判。
+
+    urllib 默认 User-Agent 是 Python-urllib/3.x，容易被识别为脚本机器人
+    （如 Cloudflare error 1010）。这里提供常见浏览器头，业务头经 extra 覆盖。
+    """
+    headers = {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
+        'Accept': 'application/json, text/plain, */*',
+        'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8',
+        'Cache-Control': 'no-cache',
+        'Pragma': 'no-cache',
+    }
+    if extra:
+        headers.update(extra)
+    return headers
+
+
 def test_connection(config, timeout: float = 10.0):
     """发送一个最小的非流式请求验证端点连通性（含 TLS 校验）。
     返回 (ok: bool, message: str)，供设置界面"测试连接"使用，不写入任何状态。"""
     try:
         endpoint = normalize_chat_endpoint(config.base_url, config.chat_path)
         payload = {'model': config.model, 'messages': [{'role': 'user', 'content': 'ping'}], 'max_tokens': 1, 'stream': False}
-        headers = {'Content-Type': 'application/json'}
+        headers = build_browser_headers({'Content-Type': 'application/json'})
         if config.api_key: headers['Authorization'] = f'Bearer {config.api_key}'
         req = urllib.request.Request(endpoint, data=json.dumps(payload, ensure_ascii=False).encode('utf-8'), headers=headers, method='POST')
         with urllib.request.urlopen(req, timeout=timeout, context=_make_ssl_context(config.verify_ssl)) as resp:
@@ -93,7 +112,7 @@ class OpenAICompatibleProvider:
     def stream(self,messages:list[dict[str,Any]],config:ProviderConfig,cancel_event:threading.Event,response_holder:list|None=None)->Iterator[str]:
         endpoint=normalize_chat_endpoint(config.base_url,config.chat_path)
         payload:dict[str,Any]={'model':config.model,'messages':messages,'stream':True,'temperature':config.temperature,'max_tokens':config.max_tokens}
-        headers={'Content-Type':'application/json','Accept':'text/event-stream'}
+        headers=build_browser_headers({'Content-Type':'application/json','Accept':'text/event-stream'})
         if config.api_key: headers['Authorization']=f'Bearer {config.api_key}'
         req=urllib.request.Request(endpoint,data=json.dumps(payload,ensure_ascii=False).encode('utf-8'),headers=headers,method='POST')
         try: response=urllib.request.urlopen(req,timeout=config.timeout,context=_make_ssl_context(config.verify_ssl))

--- a/pet/vision.py
+++ b/pet/vision.py
@@ -303,7 +303,7 @@ def _post_vision_request(
     次数消耗每日预算，避免一次触发多次重试却只记一次）。返回 False 表示预算
     已耗尽，函数直接抛出 VisionError 停止后续重试。"""
     # 延迟导入：无 Chat 变体（pet.chat 被排除）下本函数不会被调用
-    from .chat.providers import _make_ssl_context, normalize_chat_endpoint
+    from .chat.providers import _make_ssl_context, normalize_chat_endpoint, build_browser_headers
     # 视觉独立端点仅在「不同聊天模型」时生效；同聊天模型时强制跟随聊天配置，
     # 否则残留的 GLM 地址会配上 ds 的模型名发出（modelCode 不存在）
     base_url = p.base_url if p.vision_same_as_chat else (p.vision_base_url or p.base_url)
@@ -338,7 +338,7 @@ def _post_vision_request(
     if model_name.lower().startswith('deepseek') and 'deepseek' in base_url.lower():
         # ds 视觉模型默认开推理（思考十几秒才说话），关掉后 1~2 秒直答
         payload['thinking'] = {'type': 'disabled'}
-    headers = {'Content-Type': 'application/json'}
+    headers = build_browser_headers({'Content-Type': 'application/json'})
     # 安全（高优先）：独立视觉端点（vision_same_as_chat=False）绝不能把聊天 Key
     # 一起发过去。只有与聊天同模型时才允许复用聊天 Key；独立端点只认视觉自己的
     # Key（含钥匙串解析），缺失时直接报错，绝不回退到聊天 Key。

--- a/pet/window.py
+++ b/pet/window.py
@@ -2449,7 +2449,7 @@ class PetWindow(QWidget):
                 if pair is not None:
                     self._press_sound_pair = pair
                     self._press_sound_started_at = time.monotonic()
-                    play_press_sound(pair, float(self.cfg.get("click_sound_volume", 0.70)))
+                    # 拖动不应触发点击音效：按下阶段不发声，确认是点击后再播放完整 press+release
             if self.lock_position:
                 # 锁定位置：不记录按下，拖拽不会开始；松手时仍按点击处理
                 return
@@ -2574,11 +2574,9 @@ class PetWindow(QWidget):
                 self._switch(self._pick(self.idles))  # 回待机缓冲
         elif dist < catalog.DRAG_THRESHOLD * self.scale:
             if self._press_sound_pair is not None and self.click_sound_enabled:
-                play_release_sound(
-                    self._press_sound_pair,
-                    float(self.cfg.get("click_sound_volume", 0.70)),
-                    self._press_sound_started_at,
-                )
+                volume = float(self.cfg.get("click_sound_volume", 0.70))
+                play_press_sound(self._press_sound_pair, volume)
+                play_release_sound(self._press_sound_pair, volume)
             if not self._try_open_quick_chat_from_bubble(g):
                 self._on_click()
         self._dragging = False

--- a/tests/test_balance.py
+++ b/tests/test_balance.py
@@ -42,6 +42,8 @@ def test_fetch_balance_parses_response(monkeypatch):
         # 校验端点与认证头
         assert req.full_url.endswith("/user/balance")
         assert req.get_header("Authorization") == "Bearer sk-test"
+        assert req.get_header("User-agent", "").startswith("Mozilla/")
+        assert req.get_header("Accept-language", "") != ""
         return io.BytesIO(body)
 
     monkeypatch.setattr(balance.urllib.request, "urlopen", fake_urlopen)

--- a/tests/test_pet_interaction_locks.py
+++ b/tests/test_pet_interaction_locks.py
@@ -365,3 +365,30 @@ def test_tray_menu_syncs_mouse_through_from_config(tmp_path):
     assert config.get("mouse_through") is False
     tray.hide()
     app.processEvents()
+
+def test_drag_does_not_play_click_sound_but_click_does(app, tmp_path, monkeypatch):
+    from pathlib import Path
+    win = _make_win(app, tmp_path)
+    press_calls = []
+    release_calls = []
+    monkeypatch.setattr("pet.window.resolve_click_sound_pair", lambda pack, data_dir=None: (Path("press.wav"), Path("release.wav")))
+    monkeypatch.setattr("pet.window.play_press_sound", lambda pair, volume: press_calls.append((pair, volume)))
+    monkeypatch.setattr("pet.window.play_release_sound", lambda pair, volume: release_calls.append((pair, volume)))
+
+    # 拖动：按下 -> 超过阈值移动 -> 松手，不应触发任何点击音效
+    start = win.pos()
+    win.mousePressEvent(_press(QPointF(10, 10), QPointF(100, 100)))
+    win.mouseMoveEvent(_move(QPointF(60, 60), QPointF(400, 300)))
+    win.mouseReleaseEvent(_release(QPointF(60, 60), QPointF(400, 300)))
+    assert win.pos() != start
+    assert press_calls == []
+    assert release_calls == []
+
+    # 点击：按下 -> 原位松手，应播放完整 press+release
+    win.mousePressEvent(_press(QPointF(10, 10), QPointF(200, 200)))
+    win.mouseReleaseEvent(_release(QPointF(10, 10), QPointF(200, 200)))
+    assert len(press_calls) == 1
+    assert len(release_calls) == 1
+
+    win.close()
+    app.processEvents()

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -150,6 +150,7 @@ def test_independent_vision_prefers_own_key_over_chat_key(monkeypatch):
     assert reply == "好呀"
     assert called_with["url"] == "https://open.bigmodel.cn/api/paas/v4/chat/completions"
     auth = called_with["headers"].get("Authorization")
+    assert called_with["headers"].get("User-agent", "").startswith("Mozilla/")
     assert auth == "Bearer sk-vision-secret"
     assert "sk-chat-secret" not in str(auth)
 


### PR DESCRIPTION
# 修复两个问题

## 1. 拖动也会触发一次点击音效

原因：`PetWindow.mousePressEvent` 在按下左键时立即播放 press 音效，即使后续进入拖动也会响。

修复：
- 按下阶段只记录音效 pair，不再播放；
- 松手确认是点击（未超过拖动阈值）时才播放完整 `press + release`；
- 拖动全程不再触发任何点击音效。

## 2. opencode go 套餐认证失败 HTTP 403 / Cloudflare error 1010

原因：urllib 默认 `User-Agent: Python-urllib/3.x` 缺少浏览器特征，容易被 Cloudflare 识别为脚本机器人。

修复：
- 新增 `build_browser_headers()`，统一提供浏览器风格请求头（User-Agent / Accept / Accept-Language / Cache-Control / Pragma）；
- 应用到聊天流式请求、连接测试、余额查询、视觉请求；
- 业务头（Authorization / Content-Type / Accept）继续通过 `extra` 覆盖，不影响原有语义。

## 验证
- Windows 全量：`669 passed, 5 skipped`
- 新增回归：拖动不播点击音效、点击播完整音效
- 请求头断言：余额/视觉请求带浏览器 User-Agent