### PR TITLE
fix: 点击音效 pair 每次按下重置，避免解析失败复用旧音效

### DIFF
--- a/pet/window.py
+++ b/pet/window.py
@@ -2451,9 +2451,9 @@ class PetWindow(QWidget):
                 return  # 左右留白区域不参与点击/拖拽
             if self.click_sound_enabled:
                 pair = resolve_click_sound_pair(self.cfg.get("click_sound_pack"), data_dir=self.cfg.dir)
-                if pair is not None:
-                    self._press_sound_pair = pair
-                    # 拖动不应触发点击音效：按下阶段不发声，确认是点击后再播放完整 press+release
+                # 每次按下都重置：解析失败/切换音效包时不能复用上一次的旧 pair
+                self._press_sound_pair = pair
+                # 拖动不应触发点击音效：按下阶段不发声，确认是点击后再播放完整 press+release
             if self.lock_position:
                 # 锁定位置：不记录按下，拖拽不会开始；松手时仍按点击处理
                 return

--- a/tests/test_pet_interaction_locks.py
+++ b/tests/test_pet_interaction_locks.py
@@ -392,3 +392,38 @@ def test_drag_does_not_play_click_sound_but_click_does(app, tmp_path, monkeypatc
 
     win.close()
     app.processEvents()
+
+def test_click_sound_pair_is_cleared_when_resolution_fails(app, tmp_path, monkeypatch):
+    from pathlib import Path
+    win = _make_win(app, tmp_path)
+    press_calls = []
+    release_calls = []
+    pair_a = (Path("press-a.wav"), Path("release-a.wav"))
+    current_pair = [pair_a]
+    monkeypatch.setattr("pet.window.resolve_click_sound_pair", lambda pack, data_dir=None: current_pair[0])
+    monkeypatch.setattr("pet.window.play_press_sound", lambda pair, volume: press_calls.append(pair))
+    monkeypatch.setattr("pet.window.play_release_sound", lambda pair, volume: release_calls.append(pair))
+
+    # 第一次点击：解析成功，播放 pair_a
+    win.mousePressEvent(_press(QPointF(10, 10), QPointF(200, 200)))
+    win.mouseReleaseEvent(_release(QPointF(10, 10), QPointF(200, 200)))
+    assert press_calls == [pair_a]
+    assert release_calls == [pair_a]
+
+    # 解析失败（如切换音效包后文件缺失）：不应复用旧 pair
+    current_pair[0] = None
+    win.mousePressEvent(_press(QPointF(10, 10), QPointF(300, 300)))
+    win.mouseReleaseEvent(_release(QPointF(10, 10), QPointF(300, 300)))
+    assert press_calls == [pair_a], "解析失败时不应播放旧按下音"
+    assert release_calls == [pair_a], "解析失败时不应播放旧释放音"
+
+    # 再次解析成功且换成 pair_b：应播放新 pair
+    pair_b = (Path("press-b.wav"), Path("release-b.wav"))
+    current_pair[0] = pair_b
+    win.mousePressEvent(_press(QPointF(10, 10), QPointF(400, 400)))
+    win.mouseReleaseEvent(_release(QPointF(10, 10), QPointF(400, 400)))
+    assert press_calls == [pair_a, pair_b]
+    assert release_calls == [pair_a, pair_b]
+
+    win.close()
+    app.processEvents()


### PR DESCRIPTION
# 修复 Copilot 评论：点击音效 pair 残留复用

## 问题

`_press_sound_pair` 只在 `resolve_click_sound_pair(...)` 返回 pair 时更新。如果用户切换音效包或解析失败，旧 pair 不会清空，松手时会播放上一次的旧音效。

## 修复

每次按下左键时都重置：

```python
pair = resolve_click_sound_pair(...)
# 每次按下都重置：解析失败/切换音效包时不能复用上一次的旧 pair
self._press_sound_pair = pair
```

- 解析成功 → 记录当前 pair，点击时播放当前音效；
- 解析失败/切换后缺失 → `_press_sound_pair = None`，松手不会播放旧音效。

## 测试

新增 `test_click_sound_pair_is_cleared_when_resolution_fails`：
1. 第一次解析成功播放 pair_a；
2. 解析失败（返回 None）后点击不播放任何音效；
3. 切换 pair_b 后播放新音效。

验证：`tests/test_pet_interaction_locks.py tests/test_click_sound.py` 27 passed。