### PR TITLE
docs(README): 补充 v4.0.5 后修复与构建/CI 失败经验

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ DeepSeek 余额显示（气泡/小部件思路）参考了 [MeteorNOX/DeepSeek-B
 
 ## 当前状态
 
-- **开发版（v4.0.5 之后）**：多开碰撞、灵动岛、快速对话气泡、自定义 Agent 联动通道、POSIX IPC 重选修复、右键菜单 LTR、碰撞协议加固、拖动不触发点击音效、Cloudflare 请求头优化等（PR #36/#39/#40/#41/#44/#46/#47/#49/#50）。
+- **开发版（v4.0.5 之后）**：多开碰撞、灵动岛、快速对话气泡、自定义 Agent 联动通道、POSIX IPC 重选修复、右键菜单 LTR、碰撞协议加固、拖动不触发点击音效、点击音效切换修复、Cloudflare 请求头优化、CI 稳定性加固等（PR #36/#39/#40/#41/#44/#46/#47/#49/#50/#52/#53/#54）。
 - **v4.0.5**：功能版——音效体系升级（点击音效包/Agent 联动音效）、甩出力度档位、弹弓弹射、光标隐藏自动穿透、点击 Q 弹卡顿修复、自启变体独立（PR #33/#34/#35）。
 - **v4.0.4**：功能版——余额分档动画、DeepSeek 峰谷提示（可自定义文案与颜色）、后台音乐自动唱歌、点击音效打断、移动动画调整、位置记忆修复、自启残留清理、thinking 专属气泡文案等（PR #29/#30/#31/#32）。
 - **v4.0.3**：紧急修复版——修复 Windows 透明像素点击穿透、DSH 桥接插件自动安装 pnpm，以及 Windows 官方包中文乱码（PR #27/#28）。
@@ -943,6 +943,19 @@ python scripts/cleanup_mei_cache.py --delete
 - **碰撞协议与协调者生命周期加固（PR #49）**：协议预算（协调者下行 256 KiB / 客户端上行 4 KiB）、成员数/载荷限制、残留端点恢复、锁文件初始化、成员 freshness 统一、leave/failover/epoch 切换时序修正。
 - **拖动不再触发点击音效（PR #50）**：按下阶段不再播放 press 音效，确认是点击后才播放完整 press+release。
 - **Cloudflare 1010 请求头优化（PR #50）**：urllib 请求统一增加浏览器特征头（Mozilla User-Agent / Accept-Language 等），规避 opencode go 等网关的 Cloudflare 浏览器签名拦截。
+- **点击音效切换/解析失败修复（PR #52）**：每次按下都重置当前音效 pair，切换音效包或解析失败后不会复用上一次的旧音效。
+
+### 构建 / CI 失败经验（v4.0.5 之后）
+
+- **POSIX 碰撞 IPC 测试失败（issue #42）**：Linux/macOS 上协调者被强杀后 `QLocalServer` 的 Unix socket 文件残留，幸存者 `listen()` 报 `AddressInUseError` 导致重选死循环；`submit_leave` 成员表为空属于同批时序问题。处理：先探测活监听者、确认无人应答再清理残留并重试；补 `bytesAvailable()` 兜底读取；测试服务名缩短规避 macOS socket 路径长度上限（PR #46/#49）。
+- **WebM 线程回收偶发失败**：`test_rapid_start_stop_no_leaked_running_threads` 在 Linux/macOS 偶发断言残留 reader/LogCatcher 线程。处理：线程退出是异步的，断言前给 5s 宽限等待；若仍偶发可重跑定位是否负载相关。
+- **macOS 右键菜单动画时序失败**：`test_context_menu_transitions_smoothly_to_safe_target` 原先固定 `qWait(50)` 采样动画中间位置，macOS offscreen 子进程定时器调度延迟时会采样到尚未推进的帧（`middle.x == 40`）。处理：改为轮询等待菜单位置首次变化（上限 2s）后再采样，并等待 `duration + margin` 验证最终位置；恢复严格下界断言（PR #53/#54）。
+- **经验总结**：
+  - 本地 Windows 全量通过 ≠ 三平台通过；QLocalServer、子进程、UI 动画等平台敏感测试必须跑真实 Linux/macOS。
+  - 固定短等待采样 UI 中间态是 flaky 主要来源，应轮询“状态变化”而非假设固定帧率/调度。
+  - `workflow_dispatch` 手动触发 CI 只测试+构建+上传 artifact，不创建/修改 Release，适合合并前/后验证。
+  - 遇到平台相关 flaky 先定位根因，不要简单放宽断言到“永远通过”。
+  - 更完整记录见 `docs/BUILD-CI-FAILURE-NOTES-2026-08.md`。
 
 ### v4.0.5（功能版）
 


### PR DESCRIPTION
# README 补充 v4.0.5 后修复与构建/CI 失败经验

## 改动

- 当前状态中的开发版描述补充：
  - 点击音效切换/解析失败修复（PR #52）
  - CI 稳定性加固（PR #53/#54）
- 「最近修复」的 v4.0.5 之后章节新增 PR #52 条目。
- 新增「构建 / CI 失败经验（v4.0.5 之后）」小节，记录：
  - POSIX 碰撞 IPC 测试失败（issue #42）根因与处理
  - WebM 线程回收偶发失败与 5s 宽限
  - macOS 右键菜单动画时序失败与轮询采样修复
  - 经验总结（本地通过 ≠ 三平台通过、避免固定短等待、workflow_dispatch 不发布等）

纯文档改动。