### PR TITLE
feat(settings): 增加 API/Provider 列表以快速切换模型服务

### DIFF
--- a/pet/chat/settings_dialog.py
+++ b/pet/chat/settings_dialog.py
@@ -13,6 +13,10 @@ from .themes import theme_names
 class ChatSettingsDialog(QDialog):
     """AI 对话设置对话框。
 
+    支持多 Provider / API 列表：可以在一个对话框里维护多套模型服务配置，
+    通过下拉框快速切换当前要使用/编辑的 API；保存后 active_provider 会切到
+    下拉框当前选中的那一项。
+
     测试连接在 Python daemon 线程中执行真实请求，通过本对象的 Signal
     排队回主线程更新界面——不用 QThread，避免线程对象被提前销毁导致的
     "Destroyed while thread is still running" 崩溃（多次连续测试时偶发）。
@@ -24,8 +28,32 @@ class ChatSettingsDialog(QDialog):
         self.settings = config.chat_settings()
         p = self.settings.active_config
         self._test_thread = None
+        self._provider_drafts: dict[str, dict] = {}
+        self._deleted_provider_ids: set[str] = set()
+        self._loading_provider = False
         self._test_done.connect(self._on_test_done)
         self.setWindowTitle('AI 对话设置')
+
+        # API 列表：管理多套 Provider，快速切换当前 API
+        self.provider_combo = QComboBox()
+        self.provider_combo.setMinimumWidth(220)
+        for pid, provider in self.settings.providers.items():
+            self.provider_combo.addItem(self._provider_label(provider), pid)
+        idx = self.provider_combo.findData(self.settings.active_provider)
+        if idx >= 0:
+            self.provider_combo.setCurrentIndex(idx)
+        self.add_provider_btn = QPushButton('添加')
+        self.add_provider_btn.setToolTip('复制当前 API 配置为一份新配置，便于填不同的地址/模型/Key')
+        self.delete_provider_btn = QPushButton('删除')
+        self.delete_provider_btn.setToolTip('删除当前选中的 API 配置；至少保留一个')
+        provider_row = QWidget()
+        provider_lay = QHBoxLayout(provider_row)
+        provider_lay.setContentsMargins(0, 0, 0, 0)
+        provider_lay.setSpacing(6)
+        provider_lay.addWidget(self.provider_combo, 1)
+        provider_lay.addWidget(self.add_provider_btn)
+        provider_lay.addWidget(self.delete_provider_btn)
+
         form = QFormLayout()
         self.name = QLineEdit(p.name)
         self.url = QLineEdit(p.base_url)
@@ -91,6 +119,8 @@ class ChatSettingsDialog(QDialog):
         self.bg_mode.currentIndexChanged.connect(lambda i: bg_row.setVisible(i == len(self._bg_keys) + 1))
         self.skip_ssl = QCheckBox('跳过 SSL 证书验证（开着代理/梯子、本地网关或自签名证书时勾选）')
         self.skip_ssl.setChecked(not p.verify_ssl)
+
+        form.insertRow(0, 'API 列表', provider_row)
         for label, w in [('Provider 名称', self.name), ('API 地址', self.url),
                          ('模型', self.model), ('', self.vsame), ('视觉模型', self.vmodel), ('视觉 API 地址', self.vurl), ('视觉 API Key', self.vkey),
                          ('API Key', self.key), ('', self.key_hint), ('System Prompt', self.prompt),
@@ -114,6 +144,145 @@ class ChatSettingsDialog(QDialog):
         layout.addWidget(self.result)
         layout.addLayout(buttons)
 
+        self.provider_combo.currentIndexChanged.connect(self._on_provider_changed)
+        self.add_provider_btn.clicked.connect(self._add_provider)
+        self.delete_provider_btn.clicked.connect(self._delete_provider)
+        self._update_provider_buttons()
+
+    # ---------------------------------------------------------------- provider 列表
+    @staticmethod
+    def _provider_label(p) -> str:
+        name = str(p.name or p.provider_id)
+        model = str(p.model or '').strip()
+        return f'{name} · {model}' if model else name
+
+    def _capture_current_draft(self) -> None:
+        """把当前表单的非提交态保存到草稿，切换 API 时不会丢编辑。"""
+        pid = self.settings.active_provider
+        if not pid or pid not in self.settings.providers:
+            return
+        self._provider_drafts[pid] = {
+            'name': self.name.text().strip(),
+            'base_url': self.url.text().strip(),
+            'model': self.model.text().strip(),
+            'key': self.key.text(),
+            'timeout': float(self.timeout.value()),
+            'temperature': float(self.temp.value()),
+            'max_tokens': int(self.tokens.value()),
+            'vision_model': self.vmodel.text().strip(),
+            'vision_same_as_chat': self.vsame.isChecked(),
+            'vision_base_url': self.vurl.text().strip(),
+            'vision_key': self.vkey.text(),
+            'verify_ssl': not self.skip_ssl.isChecked(),
+        }
+
+    def _load_provider_ui(self, provider_id: str) -> None:
+        p = self.settings.providers.get(provider_id)
+        if p is None:
+            return
+        draft = self._provider_drafts.get(provider_id, {})
+        self.settings.active_provider = provider_id
+        self.name.setText(draft.get('name') if draft.get('name') is not None else p.name)
+        self.url.setText(draft.get('base_url') if draft.get('base_url') is not None else p.base_url)
+        self.model.setText(draft.get('model') if draft.get('model') is not None else p.model)
+        self.key.clear()
+        self.key_hint.setText(self._key_status(p))
+        self.timeout.setValue(int(draft.get('timeout', p.timeout)))
+        self.temp.setValue(float(draft.get('temperature', p.temperature)))
+        self.tokens.setValue(int(draft.get('max_tokens', p.max_tokens)))
+        self.vmodel.setText(draft.get('vision_model', p.vision_model))
+        self.vsame.setChecked(bool(draft.get('vision_same_as_chat', p.vision_same_as_chat)))
+        self.vurl.setText(draft.get('vision_base_url', p.vision_base_url))
+        self.vkey.clear()
+        self.skip_ssl.setChecked(not bool(draft.get('verify_ssl', p.verify_ssl)))
+        self._update_provider_buttons()
+
+    def _on_provider_changed(self, _index: int) -> None:
+        if self._loading_provider:
+            return
+        self._capture_current_draft()
+        pid = self.provider_combo.currentData()
+        if pid and pid in self.settings.providers:
+            self._load_provider_ui(pid)
+
+    def _new_provider_id(self) -> str:
+        used = set(self.settings.providers)
+        i = len(self.settings.providers) + 1
+        while f'api-{i}' in used:
+            i += 1
+        return f'api-{i}'
+
+    def _add_provider(self) -> None:
+        self._capture_current_draft()
+        base = self.settings.active_config
+        new_id = self._new_provider_id()
+        new = ProviderConfig(
+            new_id,
+            name=f'{base.name} 副本',
+            base_url=base.base_url,
+            chat_path=base.chat_path,
+            model=base.model,
+            api_key_ref=f'provider/{new_id}',
+            timeout=base.timeout,
+            temperature=base.temperature,
+            max_tokens=base.max_tokens,
+            vision_model=base.vision_model,
+            vision_same_as_chat=base.vision_same_as_chat,
+            vision_base_url=base.vision_base_url,
+            vision_api_key_ref=f'provider/{new_id}/vision',
+            verify_ssl=base.verify_ssl,
+        )
+        self.settings.providers[new_id] = new
+        # 复制当前草稿（不含 Key），方便基于同一份参数快速修改
+        self._provider_drafts[new_id] = {
+            'name': new.name,
+            'base_url': new.base_url,
+            'model': new.model,
+            'key': '',
+            'timeout': new.timeout,
+            'temperature': new.temperature,
+            'max_tokens': new.max_tokens,
+            'vision_model': new.vision_model,
+            'vision_same_as_chat': new.vision_same_as_chat,
+            'vision_base_url': new.vision_base_url,
+            'vision_key': '',
+            'verify_ssl': new.verify_ssl,
+        }
+        self.provider_combo.addItem(self._provider_label(new), new_id)
+        self.provider_combo.setCurrentIndex(self.provider_combo.count() - 1)
+        # setCurrentIndex 会触发 _on_provider_changed，但 active_provider 已在
+        # _capture_current_draft 后仍为旧值；这里显式切换并加载新配置。
+        self._capture_current_draft()
+        self.settings.active_provider = new_id
+        self._load_provider_ui(new_id)
+        self._update_provider_buttons()
+
+    def _delete_provider(self) -> None:
+        if len(self.settings.providers) <= 1:
+            return
+        pid = self.provider_combo.currentData()
+        if not pid or pid not in self.settings.providers:
+            return
+        self.settings.providers.pop(pid, None)
+        self._provider_drafts.pop(pid, None)
+        self._deleted_provider_ids.add(pid)
+        index = self.provider_combo.currentIndex()
+        self._loading_provider = True
+        try:
+            self.provider_combo.removeItem(index)
+            new_pid = next(iter(self.settings.providers))
+            new_index = self.provider_combo.findData(new_pid)
+            if new_index >= 0:
+                self.provider_combo.setCurrentIndex(new_index)
+        finally:
+            self._loading_provider = False
+        self.settings.active_provider = next(iter(self.settings.providers))
+        self._load_provider_ui(self.settings.active_provider)
+
+    def _update_provider_buttons(self) -> None:
+        self.delete_provider_btn.setEnabled(len(self.settings.providers) > 1)
+
+    # ---------------------------------------------------------------- 保存与测试
     def _pick_bg(self):
         path, _ = QFileDialog.getOpenFileName(self, '选择聊天背景图', '', '图片文件 (*.png *.jpg *.jpeg *.webp *.bmp)')
         if path:
@@ -196,38 +365,60 @@ class ChatSettingsDialog(QDialog):
         self.result.setStyleSheet('color: #16a34a;' if ok else 'color: #dc2626;')
         self._test_thread = None
 
-    def save(self):
-        # 保存前基于磁盘最新配置重取快照，避免覆盖另一设置窗口在本窗口
-        # 打开期间写入的结构性改动（详见现代设置页 ai_page.save 同源注释）。
-        self.config._load()
-        self.settings = self.config.chat_settings()
-        p = self.settings.active_config
-        p.name = self.name.text().strip() or p.name
-        p.base_url = self.url.text().strip()
-        p.model = self.model.text().strip()
-        p.timeout = float(self.timeout.value())
-        p.temperature = float(self.temp.value())
-        p.max_tokens = int(self.tokens.value())
-        p.vision_model = self.vmodel.text().strip()
-        p.vision_same_as_chat = self.vsame.isChecked()
-        p.vision_base_url = self.vurl.text().strip()
-        vkey = self.vkey.text()
-        if vkey:
-            p.vision_api_key_ref = f'provider/{p.provider_id}/vision'
-            if not SecretStore().set(p.vision_api_key_ref, vkey):
-                p.vision_api_key = vkey
-                QMessageBox.warning(self, '安全存储不可用', '无法使用系统安全存储，Key 仅本次运行保留，重启需重输。')
-        p.verify_ssl = not self.skip_ssl.isChecked()
-        key = self.key.text()
+    def _apply_draft_to_provider(self, provider_id: str) -> None:
+        p = self.settings.providers.get(provider_id)
+        draft = self._provider_drafts.get(provider_id)
+        if p is None or not draft:
+            return
+        if draft.get('name'):
+            p.name = draft['name']
+        p.base_url = draft.get('base_url') or p.base_url
+        p.model = draft.get('model') or p.model
+        p.timeout = float(draft.get('timeout', p.timeout))
+        p.temperature = float(draft.get('temperature', p.temperature))
+        p.max_tokens = int(draft.get('max_tokens', p.max_tokens))
+        p.vision_model = draft.get('vision_model', p.vision_model)
+        p.vision_same_as_chat = bool(draft.get('vision_same_as_chat', p.vision_same_as_chat))
+        p.vision_base_url = draft.get('vision_base_url', p.vision_base_url)
+        p.verify_ssl = bool(draft.get('verify_ssl', p.verify_ssl))
+        key = str(draft.get('key') or '')
         if key:
-            p.api_key_ref = p.api_key_ref or f'provider/{p.provider_id}'
+            p.api_key_ref = p.api_key_ref or f'provider/{provider_id}'
             if not SecretStore().set(p.api_key_ref, key):
                 p.api_key = key
                 QMessageBox.warning(self, '安全存储不可用', '无法使用系统安全存储，Key 仅本次运行保留，重启需重输。')
+        vkey = str(draft.get('vision_key') or '')
+        if vkey:
+            p.vision_api_key_ref = p.vision_api_key_ref or f'provider/{provider_id}/vision'
+            if not SecretStore().set(p.vision_api_key_ref, vkey):
+                p.vision_api_key = vkey
+                QMessageBox.warning(self, '安全存储不可用', '无法使用系统安全存储，Key 仅本次运行保留，重启需重输。')
+
+    def save(self):
+        # 保存前基于磁盘最新配置重取快照：另一个设置窗口可能在本窗口打开期间
+        # 写入结构性改动。先保留本窗口的 provider 草稿/新增/删除，再与磁盘快照合并。
+        old_settings = self.settings
+        self.config._load()
+        self._capture_current_draft()
+        self.settings = self.config.chat_settings()
+        # 合并 provider 结构：保留磁盘中其它窗口新增的项，应用本窗口删除/新增的项。
+        for pid in list(self.settings.providers):
+            if pid in self._deleted_provider_ids:
+                self.settings.providers.pop(pid, None)
+        for pid, provider in old_settings.providers.items():
+            if pid not in self.settings.providers and pid not in self._deleted_provider_ids:
+                self.settings.providers[pid] = provider
+        active_pid = self.provider_combo.currentData()
+        if active_pid in self.settings.providers:
+            self.settings.active_provider = active_pid
+        elif self.settings.providers:
+            self.settings.active_provider = next(iter(self.settings.providers))
+        for pid in list(self.settings.providers):
+            self._apply_draft_to_provider(pid)
+        self.settings.default_system_prompt = self.prompt.toPlainText().strip()
         i = self.bg_mode.currentIndex()
         bg_val = '' if i == 0 else ('builtin:' + self._bg_keys[i - 1] if i <= len(self._bg_keys) else self.bg.text().strip())
         self.config.set('chat_background', bg_val)
-        self.settings.default_system_prompt = self.prompt.toPlainText().strip()
         self.config.set_chat_settings(self.settings)
         if not self.config.save():
             QMessageBox.warning(self, '保存失败', '配置未能写入磁盘，改动可能在重启后丢失。\n\n配置路径：' + str(self.config.path))

--- a/pet/chat/settings_dialog.py
+++ b/pet/chat/settings_dialog.py
@@ -161,18 +161,23 @@ class ChatSettingsDialog(QDialog):
         pid = self.settings.active_provider
         if not pid or pid not in self.settings.providers:
             return
+        existing = self._provider_drafts.get(pid, {})
+        key_text = self.key.text()
+        vkey_text = self.vkey.text()
         self._provider_drafts[pid] = {
             'name': self.name.text().strip(),
             'base_url': self.url.text().strip(),
             'model': self.model.text().strip(),
-            'key': self.key.text(),
+            # 输入框为空表示“不修改/不覆盖”，保留草稿里已录入但尚未保存的 Key；
+            # 否则 _load_provider_ui() 清空输入框后会把草稿 Key 覆盖成空。
+            'key': key_text if key_text else existing.get('key', ''),
             'timeout': float(self.timeout.value()),
             'temperature': float(self.temp.value()),
             'max_tokens': int(self.tokens.value()),
             'vision_model': self.vmodel.text().strip(),
             'vision_same_as_chat': self.vsame.isChecked(),
             'vision_base_url': self.vurl.text().strip(),
-            'vision_key': self.vkey.text(),
+            'vision_key': vkey_text if vkey_text else existing.get('vision_key', ''),
             'verify_ssl': not self.skip_ssl.isChecked(),
         }
 
@@ -206,7 +211,8 @@ class ChatSettingsDialog(QDialog):
             self._load_provider_ui(pid)
 
     def _new_provider_id(self) -> str:
-        used = set(self.settings.providers)
+        # 避免复用已删除的 provider_id：否则保存合并时新建项会被删除集合过滤掉。
+        used = set(self.settings.providers) | set(self._deleted_provider_ids)
         i = len(self.settings.providers) + 1
         while f'api-{i}' in used:
             i += 1

--- a/pet/modern_settings_dialog.py
+++ b/pet/modern_settings_dialog.py
@@ -993,18 +993,23 @@ class _AiSettingsPage(QWidget):
         pid = self.settings.active_provider
         if not pid or pid not in self.settings.providers:
             return
+        existing = self._provider_drafts.get(pid, {})
+        key_text = self.key.text()
+        vkey_text = self.vision_key.text()
         self._provider_drafts[pid] = {
             "name": self.name.text().strip(),
             "base_url": self.url.text().strip(),
             "model": self.model.text().strip(),
-            "key": self.key.text(),
+            # 输入框为空表示“不修改/不覆盖”，保留草稿里已录入但尚未保存的 Key；
+            # 否则 _load_provider_ui() 清空输入框后会把草稿 Key 覆盖成空。
+            "key": key_text if key_text else existing.get("key", ""),
             "timeout": float(self.timeout.value()),
             "temperature": float(self.temperature.value()),
             "max_tokens": int(self.tokens.value()),
             "vision_model": self.vision_model.text().strip(),
             "vision_same_as_chat": self.vision_same.isChecked(),
             "vision_base_url": self.vision_url.text().strip(),
-            "vision_key": self.vision_key.text(),
+            "vision_key": vkey_text if vkey_text else existing.get("vision_key", ""),
             "verify_ssl": not self.skip_ssl.isChecked(),
         }
 
@@ -1037,7 +1042,8 @@ class _AiSettingsPage(QWidget):
             self._load_provider_ui(pid)
 
     def _new_provider_id(self) -> str:
-        used = set(self.settings.providers)
+        # 避免复用已删除的 provider_id：否则保存合并时新建项会被删除集合过滤掉。
+        used = set(self.settings.providers) | set(self._deleted_provider_ids)
         i = len(self.settings.providers) + 1
         while f"api-{i}" in used:
             i += 1

--- a/pet/modern_settings_dialog.py
+++ b/pet/modern_settings_dialog.py
@@ -761,7 +761,17 @@ class _AiSettingsPage(QWidget):
         self.settings = config.chat_settings()
         provider = self.settings.active_config
         self._test_thread = None
+        self._provider_drafts: dict[str, dict] = {}
+        self._deleted_provider_ids: set[str] = set()
+        self._loading_provider = False
         self.test_done.connect(self._on_test_done)
+
+        self.provider_combo = ModernSelect(self, width=230)
+        self.add_provider_btn = QPushButton("添加", self)
+        self.delete_provider_btn = QPushButton("删除", self)
+        for pid, provider_item in self.settings.providers.items():
+            self.provider_combo.addItem(self._provider_label(provider_item), pid)
+        self.provider_combo.setCurrentData(self.settings.active_provider)
 
         self.name = _line_edit(provider.name)
         self.url = _line_edit(provider.base_url)
@@ -837,6 +847,20 @@ class _AiSettingsPage(QWidget):
         root = QVBoxLayout(self)
         root.setContentsMargins(0, 0, 0, 0)
         root.setSpacing(18)
+        provider_row = QWidget()
+        provider_lay = QHBoxLayout(provider_row)
+        provider_lay.setContentsMargins(0, 0, 0, 0)
+        provider_lay.setSpacing(6)
+        provider_lay.addWidget(self.provider_combo, 1)
+        provider_lay.addWidget(self.add_provider_btn)
+        provider_lay.addWidget(self.delete_provider_btn)
+        root.addWidget(SettingsSection("API 列表", [
+            SettingRow(
+                "provider_list", "API 列表",
+                "选择要编辑/切换的模型服务；保存后当前选中项会作为 active_provider 生效。",
+                provider_row,
+            ),
+        ], self))
         root.addWidget(SettingsSection("模型与连接", [
             SettingRow("provider_name", "Provider 名称", "用于区分当前使用的模型服务。", self.name),
             SettingRow("api_url", "API 地址", "OpenAI Chat Completions 兼容服务地址。", self.url),
@@ -864,6 +888,10 @@ class _AiSettingsPage(QWidget):
             SettingRow("max_tokens", "最大输出 Token", "限制模型单次回复的最大长度。", self.tokens),
             SettingRow("skip_ssl", "跳过 SSL 证书验证", "仅用于本地网关或自签名证书。", self.skip_ssl),
         ], self))
+        self.provider_combo.currentIndexChanged.connect(self._on_provider_changed)
+        self.add_provider_btn.clicked.connect(self._add_provider)
+        self.delete_provider_btn.clicked.connect(self._delete_provider)
+        self._update_provider_buttons()
         root.addStretch(1)
 
     def appearance_rows(self) -> list[SettingRow]:
@@ -954,6 +982,166 @@ class _AiSettingsPage(QWidget):
         if card_opacity_row is not None:
             card_opacity_row.setVisible(self._background_style == "modern")
 
+    # ------------------------------------------------------------ API 列表管理
+    @staticmethod
+    def _provider_label(p) -> str:
+        name = str(p.name or p.provider_id)
+        model = str(p.model or '').strip()
+        return f"{name} · {model}" if model else name
+
+    def _capture_current_draft(self) -> None:
+        pid = self.settings.active_provider
+        if not pid or pid not in self.settings.providers:
+            return
+        self._provider_drafts[pid] = {
+            "name": self.name.text().strip(),
+            "base_url": self.url.text().strip(),
+            "model": self.model.text().strip(),
+            "key": self.key.text(),
+            "timeout": float(self.timeout.value()),
+            "temperature": float(self.temperature.value()),
+            "max_tokens": int(self.tokens.value()),
+            "vision_model": self.vision_model.text().strip(),
+            "vision_same_as_chat": self.vision_same.isChecked(),
+            "vision_base_url": self.vision_url.text().strip(),
+            "vision_key": self.vision_key.text(),
+            "verify_ssl": not self.skip_ssl.isChecked(),
+        }
+
+    def _load_provider_ui(self, provider_id: str) -> None:
+        p = self.settings.providers.get(provider_id)
+        if p is None:
+            return
+        draft = self._provider_drafts.get(provider_id, {})
+        self.settings.active_provider = provider_id
+        self.name.setText(draft.get("name") if draft.get("name") is not None else p.name)
+        self.url.setText(draft.get("base_url") if draft.get("base_url") is not None else p.base_url)
+        self.model.setText(draft.get("model") if draft.get("model") is not None else p.model)
+        self.key.clear()
+        self.timeout.setValue(int(draft.get("timeout", p.timeout)))
+        self.temperature.setValue(float(draft.get("temperature", p.temperature)))
+        self.tokens.setValue(int(draft.get("max_tokens", p.max_tokens)))
+        self.vision_model.setText(draft.get("vision_model", p.vision_model))
+        self.vision_same.setChecked(bool(draft.get("vision_same_as_chat", p.vision_same_as_chat)))
+        self.vision_url.setText(draft.get("vision_base_url", p.vision_base_url))
+        self.vision_key.clear()
+        self.skip_ssl.setChecked(not bool(draft.get("verify_ssl", p.verify_ssl)))
+        self._update_provider_buttons()
+
+    def _on_provider_changed(self, _index: int = -1) -> None:
+        if self._loading_provider:
+            return
+        self._capture_current_draft()
+        pid = self.provider_combo.currentData()
+        if pid and pid in self.settings.providers:
+            self._load_provider_ui(pid)
+
+    def _new_provider_id(self) -> str:
+        used = set(self.settings.providers)
+        i = len(self.settings.providers) + 1
+        while f"api-{i}" in used:
+            i += 1
+        return f"api-{i}"
+
+    def _add_provider(self) -> None:
+        self._capture_current_draft()
+        base = self.settings.active_config
+        new_id = self._new_provider_id()
+        new = self._provider_config_type(
+            new_id,
+            name=f"{base.name} 副本",
+            base_url=base.base_url,
+            chat_path=base.chat_path,
+            model=base.model,
+            api_key_ref=f"provider/{new_id}",
+            timeout=base.timeout,
+            temperature=base.temperature,
+            max_tokens=base.max_tokens,
+            vision_model=base.vision_model,
+            vision_same_as_chat=base.vision_same_as_chat,
+            vision_base_url=base.vision_base_url,
+            vision_api_key_ref=f"provider/{new_id}/vision",
+            verify_ssl=base.verify_ssl,
+        )
+        self.settings.providers[new_id] = new
+        self._provider_drafts[new_id] = {
+            "name": new.name,
+            "base_url": new.base_url,
+            "model": new.model,
+            "key": "",
+            "timeout": new.timeout,
+            "temperature": new.temperature,
+            "max_tokens": new.max_tokens,
+            "vision_model": new.vision_model,
+            "vision_same_as_chat": new.vision_same_as_chat,
+            "vision_base_url": new.vision_base_url,
+            "vision_key": "",
+            "verify_ssl": new.verify_ssl,
+        }
+        self._loading_provider = True
+        try:
+            self.provider_combo.addItem(self._provider_label(new), new_id)
+            self.provider_combo.setCurrentIndex(self.provider_combo.count() - 1)
+        finally:
+            self._loading_provider = False
+        self.settings.active_provider = new_id
+        self._load_provider_ui(new_id)
+        self._update_provider_buttons()
+
+    def _delete_provider(self) -> None:
+        if len(self.settings.providers) <= 1:
+            return
+        pid = self.provider_combo.currentData()
+        if not pid or pid not in self.settings.providers:
+            return
+        self.settings.providers.pop(pid, None)
+        self._provider_drafts.pop(pid, None)
+        self._deleted_provider_ids.add(pid)
+        index = self.provider_combo.currentIndex()
+        self._loading_provider = True
+        try:
+            self.provider_combo.clear()
+            for p in self.settings.providers.values():
+                self.provider_combo.addItem(self._provider_label(p), p.provider_id)
+            self.settings.active_provider = next(iter(self.settings.providers))
+            self.provider_combo.setCurrentData(self.settings.active_provider)
+        finally:
+            self._loading_provider = False
+        self._load_provider_ui(self.settings.active_provider)
+        self._update_provider_buttons()
+
+    def _update_provider_buttons(self) -> None:
+        self.delete_provider_btn.setEnabled(len(self.settings.providers) > 1)
+
+    def _apply_draft_to_provider(self, provider_id: str) -> None:
+        p = self.settings.providers.get(provider_id)
+        draft = self._provider_drafts.get(provider_id)
+        if p is None or not draft:
+            return
+        if draft.get("name"):
+            p.name = draft["name"]
+        p.base_url = draft.get("base_url") or p.base_url
+        p.model = draft.get("model") or p.model
+        p.timeout = float(draft.get("timeout", p.timeout))
+        p.temperature = float(draft.get("temperature", p.temperature))
+        p.max_tokens = int(draft.get("max_tokens", p.max_tokens))
+        p.vision_model = draft.get("vision_model", p.vision_model)
+        p.vision_same_as_chat = bool(draft.get("vision_same_as_chat", p.vision_same_as_chat))
+        p.vision_base_url = draft.get("vision_base_url", p.vision_base_url)
+        p.verify_ssl = bool(draft.get("verify_ssl", p.verify_ssl))
+        key = str(draft.get("key") or "")
+        if key:
+            p.api_key_ref = p.api_key_ref or f"provider/{provider_id}"
+            if not self._secret_store_type().set(p.api_key_ref, key):
+                p.api_key = key
+                QMessageBox.warning(self, "安全存储不可用", "无法使用系统安全存储，Key 仅本次运行保留，重启需重输。")
+        vkey = str(draft.get("vision_key") or "")
+        if vkey:
+            p.vision_api_key_ref = p.vision_api_key_ref or f"provider/{provider_id}/vision"
+            if not self._secret_store_type().set(p.vision_api_key_ref, vkey):
+                p.vision_api_key = vkey
+                QMessageBox.warning(self, "安全存储不可用", "无法使用系统安全存储，Key 仅本次运行保留，重启需重输。")
+
     def provisional_config(self):
         provider = self.settings.active_config
         return self._provider_config_type(
@@ -997,32 +1185,24 @@ class _AiSettingsPage(QWidget):
 
     def save(self) -> None:
         # 保存前基于磁盘最新配置重取快照：另一个设置窗口（AI 设置/桌宠设置 AI 页）
-        # 可能在本窗口打开期间改过 Provider 结构；UI 字段随后覆盖到新鲜快照上，
-        # 未暴露/结构性的改动（新增 provider、切换 active_provider）不被旧快照吞掉。
+        # 可能在本窗口打开期间改过 Provider 结构；先保留本窗口的 provider 草稿/
+        # 新增/删除，再与磁盘快照合并，避免覆盖其它窗口新增的结构。
+        old_settings = self.settings
+        self._capture_current_draft()
         self.settings = self.config.chat_settings()
-        provider = self.settings.active_config
-        provider.name = self.name.text().strip() or provider.name
-        provider.base_url = self.url.text().strip()
-        provider.model = self.model.text().strip()
-        provider.timeout = float(self.timeout.value())
-        provider.temperature = float(self.temperature.value())
-        provider.max_tokens = int(self.tokens.value())
-        provider.verify_ssl = not self.skip_ssl.isChecked()
-        provider.vision_same_as_chat = self.vision_same.isChecked()
-        provider.vision_model = self.vision_model.text().strip()
-        provider.vision_base_url = self.vision_url.text().strip()
-        vision_key = self.vision_key.text()
-        if vision_key:
-            provider.vision_api_key_ref = provider.vision_api_key_ref or f"provider/{provider.provider_id}/vision"
-            if not self._secret_store_type().set(provider.vision_api_key_ref, vision_key):
-                provider.vision_api_key = vision_key
-                QMessageBox.warning(self, "安全存储不可用", "无法使用系统安全存储，Key 仅本次运行保留，重启需重输。")
-        key = self.key.text()
-        if key:
-            provider.api_key_ref = provider.api_key_ref or f"provider/{provider.provider_id}"
-            if not self._secret_store_type().set(provider.api_key_ref, key):
-                provider.api_key = key
-                QMessageBox.warning(self, "安全存储不可用", "无法使用系统安全存储，Key 仅本次运行保留，重启需重输。")
+        for pid in list(self.settings.providers):
+            if pid in self._deleted_provider_ids:
+                self.settings.providers.pop(pid, None)
+        for pid, provider in old_settings.providers.items():
+            if pid not in self.settings.providers and pid not in self._deleted_provider_ids:
+                self.settings.providers[pid] = provider
+        active_pid = self.provider_combo.currentData()
+        if active_pid in self.settings.providers:
+            self.settings.active_provider = active_pid
+        elif self.settings.providers:
+            self.settings.active_provider = next(iter(self.settings.providers))
+        for pid in list(self.settings.providers):
+            self._apply_draft_to_provider(pid)
         self.settings.default_system_prompt = self.prompt.toPlainText().strip()
         self.config.set("chat_ui_style", self.chat_ui_style.currentData())
         self._capture_background_value()

--- a/tests/test_api_provider_list.py
+++ b/tests/test_api_provider_list.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+"""API/Provider 列表：设置页可添加、切换、删除多套 API 配置。"""
+from __future__ import annotations
+
+from PySide6.QtWidgets import QApplication
+
+from pet.config import Config
+
+
+def _app():
+    return QApplication.instance() or QApplication([])
+
+
+def test_chat_settings_provider_list_add_switch_delete(tmp_path):
+    """AI 设置对话框：API 列表添加后能切换并保留编辑，删除后回到默认项。"""
+    from pet.chat.settings_dialog import ChatSettingsDialog
+
+    _app()
+    cfg = Config(tmp_path)
+    dlg = ChatSettingsDialog(cfg)
+    try:
+        assert dlg.provider_combo.count() == 1
+        assert dlg.settings.active_provider == "openai-main"
+
+        dlg._add_provider()
+        new_pid = dlg.settings.active_provider
+        assert dlg.provider_combo.count() == 2
+        assert new_pid != "openai-main"
+        assert new_pid in dlg.settings.providers
+
+        # 修改新 API 后切到默认项再切回，草稿应保留
+        dlg.name.setText("Second API")
+        dlg.provider_combo.setCurrentIndex(dlg.provider_combo.findData("openai-main"))
+        assert dlg.settings.active_provider == "openai-main"
+        dlg.provider_combo.setCurrentIndex(dlg.provider_combo.findData(new_pid))
+        assert dlg.name.text() == "Second API"
+
+        # 删除新 API 后回到唯一默认项
+        dlg._delete_provider()
+        assert dlg.provider_combo.count() == 1
+        assert dlg.settings.active_provider == "openai-main"
+        assert dlg.settings.providers.keys() == {"openai-main"}
+    finally:
+        dlg.close()
+        _app().processEvents()
+
+
+def test_chat_settings_provider_list_save_persists_active_provider(tmp_path):
+    """保存后 active_provider 与新增 Provider 应写入配置。"""
+    from pet.chat.settings_dialog import ChatSettingsDialog
+
+    _app()
+    cfg = Config(tmp_path)
+    dlg = ChatSettingsDialog(cfg)
+    try:
+        dlg._add_provider()
+        new_pid = dlg.settings.active_provider
+        dlg.name.setText("Second API")
+        dlg.save()
+
+        reloaded = cfg.chat_settings()
+        assert reloaded.active_provider == new_pid
+        assert new_pid in reloaded.providers
+        assert reloaded.providers[new_pid].name == "Second API"
+    finally:
+        dlg.close()
+        _app().processEvents()
+
+
+def test_modern_ai_page_provider_list_add_switch_delete(tmp_path, monkeypatch):
+    """现代设置 AI 页：API 列表同样支持添加/切换/删除。"""
+    import pet.modern_settings_dialog as settings_mod
+
+    monkeypatch.setattr(settings_mod.autostart_mod, "is_enabled", lambda: False)
+    _app()
+    cfg = Config(tmp_path)
+    dlg = settings_mod.ModernSettingsDialog(cfg, include_ai=True)
+    try:
+        page = dlg.ai_page
+        assert page.provider_combo.count() == 1
+        assert page.settings.active_provider == "openai-main"
+
+        page._add_provider()
+        new_pid = page.settings.active_provider
+        assert page.provider_combo.count() == 2
+        assert new_pid != "openai-main"
+
+        page.name.setText("Second API")
+        page.provider_combo.setCurrentData("openai-main")
+        assert page.settings.active_provider == "openai-main"
+        page.provider_combo.setCurrentData(new_pid)
+        assert page.name.text() == "Second API"
+
+        page._delete_provider()
+        assert page.provider_combo.count() == 1
+        assert page.settings.providers.keys() == {"openai-main"}
+    finally:
+        dlg.close()
+        _app().processEvents()

--- a/tests/test_api_provider_list.py
+++ b/tests/test_api_provider_list.py
@@ -45,6 +45,50 @@ def test_chat_settings_provider_list_add_switch_delete(tmp_path):
         _app().processEvents()
 
 
+def test_chat_settings_provider_id_not_reused_after_delete(tmp_path):
+    """删除后再次添加不能复用已删除 provider_id，避免保存合并误过滤。"""
+    from pet.chat.settings_dialog import ChatSettingsDialog
+
+    _app()
+    cfg = Config(tmp_path)
+    dlg = ChatSettingsDialog(cfg)
+    try:
+        dlg._add_provider()
+        first_pid = dlg.settings.active_provider
+        dlg._delete_provider()
+        dlg._add_provider()
+        second_pid = dlg.settings.active_provider
+        assert second_pid != first_pid
+        assert first_pid not in dlg.settings.providers
+        assert second_pid in dlg.settings.providers
+    finally:
+        dlg.close()
+        _app().processEvents()
+
+
+def test_chat_settings_provider_switch_keeps_key_draft(tmp_path):
+    """切走再切回后，已录入但未保存的 API Key 不应被空输入框覆盖丢失。"""
+    from pet.chat.settings_dialog import ChatSettingsDialog
+
+    _app()
+    cfg = Config(tmp_path)
+    dlg = ChatSettingsDialog(cfg)
+    try:
+        dlg._add_provider()
+        new_pid = dlg.settings.active_provider
+        dlg.key.setText("sk-draft")
+
+        # 切到默认项再切回：_load_provider_ui 会清空 Key 输入框
+        dlg.provider_combo.setCurrentIndex(dlg.provider_combo.findData("openai-main"))
+        assert dlg.settings.active_provider == "openai-main"
+        dlg.provider_combo.setCurrentIndex(dlg.provider_combo.findData(new_pid))
+        assert dlg.key.text() == ""
+        assert dlg._provider_drafts[new_pid]["key"] == "sk-draft"
+    finally:
+        dlg.close()
+        _app().processEvents()
+
+
 def test_chat_settings_provider_list_save_persists_active_provider(tmp_path):
     """保存后 active_provider 与新增 Provider 应写入配置。"""
     from pet.chat.settings_dialog import ChatSettingsDialog


### PR DESCRIPTION
## 概述

解决 #58：在 AI 设置里增加 API 列表，方便维护多套模型服务并快速切换当前使用的 API。

## 改动

- AI 设置对话框（ChatSettingsDialog）顶部新增 \API 列表\ 下拉框；
- 现代设置 AI 页同步增加相同能力；
- 支持：
  - 下拉切换当前要编辑/使用的 API；
  - 添加（复制当前配置生成新 API）；
  - 删除（至少保留一个）；
  - 切换时保留未保存的草稿编辑；
- 保存后 \ctive_provider\ 跟随当前选中项，并正确合并新增/删除到配置。

## 测试

- 新增 \	ests/test_api_provider_list.py\
- 相关设置/聊天测试已通过：
  - \	ests/test_chat_subsystem.py\
  - \	ests/test_requested_regressions.py\
  - \	ests/test_desktop_pet_features.py\
  - \	ests/test_settings_and_resources.py\
  - \	ests/test_settings_subslot_autostart.py\
  - \	ests/test_collision_settings.py\

Closes #58