### PR TITLE
feat(chat): 增加系统通知，对话完成/生成失败/需要授权时跳回处理

### DIFF
--- a/pet/app.py
+++ b/pet/app.py
@@ -178,6 +178,7 @@ class PetApp:
         self.slot_id = slot_id
         self.win: PetWindow | None = None
         self.tray: QSystemTrayIcon | None = None
+        self._notification_click_callback = None
         self.chat_window = None
         self.legacy_chat_window = None
         self.modern_chat_window = None
@@ -622,7 +623,13 @@ class PetApp:
             return
         from .chat.legacy_widgets import ChatWindow
         if self.legacy_chat_window is None:
-            self.legacy_chat_window = ChatWindow(self.config, str(self.config.get('character', catalog.DEFAULT_CHARACTER)), pet_window=self.win)
+            self.legacy_chat_window = ChatWindow(
+                self.config,
+                str(self.config.get('character', catalog.DEFAULT_CHARACTER)),
+                pet_window=self.win,
+                notifier=self.system_notify,
+                auth_callback=self.open_chat_settings,
+            )
         else:
             self.legacy_chat_window.set_pet_window(self.win)
         self.chat_window = self.legacy_chat_window
@@ -635,7 +642,13 @@ class PetApp:
             return
         from .chat.widgets import ChatWindow
         if self.modern_chat_window is None:
-            self.modern_chat_window = ChatWindow(self.config, str(self.config.get('character', catalog.DEFAULT_CHARACTER)), pet_window=self.win)
+            self.modern_chat_window = ChatWindow(
+                self.config,
+                str(self.config.get('character', catalog.DEFAULT_CHARACTER)),
+                pet_window=self.win,
+                notifier=self.system_notify,
+                auth_callback=self.open_chat_settings,
+            )
         else:
             self.modern_chat_window.set_pet_window(self.win)
         self.chat_window = self.modern_chat_window
@@ -783,6 +796,27 @@ class PetApp:
             4000,
         )
 
+    def system_notify(self, title: str, message: str, *, on_click=None, duration_ms: int = 5000) -> None:
+        """Show a desktop tray notification; clicking routes to on_click."""
+        if self.tray is None:
+            return
+        self._notification_click_callback = on_click
+        self.tray.showMessage(
+            str(title),
+            str(message),
+            QSystemTrayIcon.MessageIcon.Information,
+            int(duration_ms),
+        )
+
+    def _on_tray_message_clicked(self) -> None:
+        callback = self._notification_click_callback
+        self._notification_click_callback = None
+        if callable(callback):
+            try:
+                callback()
+            except Exception:
+                logging.exception("系统通知点击回调执行失败")
+
     def _build_tray(self, win: PetWindow) -> QSystemTrayIcon:
         tray = QSystemTrayIcon(QIcon(win.icon_pixmap()))
 
@@ -861,6 +895,7 @@ class PetApp:
 
         tray.setContextMenu(menu)
         tray.setToolTip('dsh-pet 独立桌宠')
+        tray.messageClicked.connect(self._on_tray_message_clicked)
         tray.activated.connect(
             lambda reason: toggle_visible()
             if reason == QSystemTrayIcon.ActivationReason.DoubleClick

--- a/pet/app.py
+++ b/pet/app.py
@@ -31,6 +31,7 @@ from . import slot_manager as slot_manager_mod
 from . import updater
 from .click_sound import warm_click_sound_effects
 from .config import APP_DIR_NAME, Config, _default_base
+from .context_menus.shared import open_deepseek_web
 from .harness_launcher import launch_harness_gui
 from .instance_launcher import launch_new_pet
 from .library import MovieLibrary
@@ -889,8 +890,11 @@ class PetApp:
         menu.addSeparator()
         if self.enable_chat:
             menu.addAction('DeepSeek 余额', lambda: self.show_balance(win))
+            menu.addAction('启动 DeepSeek Harness', lambda: launch_harness_gui(win))
+        else:
+            # 纯桌宠版本不提供本地 DSH 启动入口，只保留网页版入口
+            menu.addAction('打开网页版 DeepSeek', open_deepseek_web)
         menu.addAction('检查更新', lambda: self.check_update(win))
-        menu.addAction('启动 DeepSeek Harness', lambda: launch_harness_gui(win))
         menu.addAction('退出', self.app.quit)
 
         tray.setContextMenu(menu)

--- a/pet/chat/legacy_widgets.py
+++ b/pet/chat/legacy_widgets.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
 from datetime import datetime
 from pathlib import Path
@@ -258,10 +259,12 @@ class ChatComposer(QFrame):
 
 
 class ChatWindow(QDialog):
-    def __init__(self, config, character_id: str, parent=None, pet_window=None):
+    def __init__(self, config, character_id: str, parent=None, pet_window=None, notifier=None, auth_callback=None):
         super().__init__(parent)
         self.config = config
         self.character_id = str(character_id)
+        self._system_notifier = notifier
+        self._auth_callback = auth_callback
         self.setObjectName("chat-window")
         self.setWindowTitle("AI 对话")
         # 窗口级图标主题：浅色表面用深灰轮廓图标（rename 按钮等），
@@ -957,6 +960,42 @@ class ChatWindow(QDialog):
         self._active_request_id = self.service.send(messages, config)
         self._bottom()
 
+    def _focus_chat(self) -> None:
+        """把聊天窗口带回前台，供系统通知点击后跳回页面处理。"""
+        if self.isMinimized():
+            self.showNormal()
+        self.show()
+        self.raise_()
+        self.activateWindow()
+
+    def _focus_auth_settings(self) -> None:
+        if callable(self._auth_callback):
+            self._auth_callback()
+        else:
+            self._focus_chat()
+
+    def _show_system_notice(self, title: str, message: str, *, on_click=None) -> None:
+        """仅在聊天窗口不是当前活动窗口时弹系统通知；点击默认跳回本窗口。"""
+        if self._system_notifier is None or self.isActiveWindow():
+            return
+        try:
+            self._system_notifier(title, message, on_click=on_click or self._focus_chat)
+        except Exception:
+            logging.getLogger(__name__).exception("系统通知发送失败")
+
+    @staticmethod
+    def _looks_like_authorization_error(text: str) -> bool:
+        lowered = str(text or "").lower()
+        return any(
+            token in lowered
+            for token in ("401", "403", "unauthorized", "authentication", "api key",
+                          "认证失败", "未授权", "授权")
+        )
+
+    def notify_authorization_required(self, message: str = "有一条需要授权或确认的请求，点击查看。") -> None:
+        """供“需要授权/审批”类事件调用：切走窗口时弹系统通知并跳回聊天页。"""
+        self._show_system_notice("需要授权", message)
+
     def _started(self, request_id: str) -> None:
         if request_id != self._active_request_id:
             return
@@ -993,6 +1032,7 @@ class ChatWindow(QDialog):
         self._refresh_sessions()
         self._reset()
         self.pet_link.success()
+        self._show_system_notice("对话完成", "AI 已回复完成，点击查看。")
         if follow_output:
             self._bottom()
 
@@ -1004,6 +1044,14 @@ class ChatWindow(QDialog):
             self._bubble.set_state("error")
         self._reset()
         self.pet_link.error(text)
+        if self._looks_like_authorization_error(text):
+            self._show_system_notice(
+                "需要授权",
+                "模型服务返回认证失败，点击打开 AI 设置检查 API Key。",
+                on_click=self._focus_auth_settings,
+            )
+        else:
+            self._show_system_notice("生成失败", f"对话生成失败：{str(text)[:100]}")
         self._bottom()
 
     def _stopped(self, request_id: str) -> None:

--- a/pet/chat/widgets.py
+++ b/pet/chat/widgets.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import json
+import logging
 import mimetypes
 import re
 from datetime import datetime, timedelta
@@ -783,10 +784,12 @@ class SidebarScrim(QFrame):
 
 
 class ChatWindow(QDialog):
-    def __init__(self, config, character_id: str, parent=None, pet_window=None):
+    def __init__(self, config, character_id: str, parent=None, pet_window=None, notifier=None, auth_callback=None):
         super().__init__(parent)
         self.config = config
         self.character_id = str(character_id)
+        self._system_notifier = notifier
+        self._auth_callback = auth_callback
         self.setObjectName("chat-window")
         self.setWindowTitle("AI 对话")
         # 窗口级图标主题：QSS 表面为浅色，深色系统 palette 前景是白色，
@@ -1890,6 +1893,42 @@ class ChatWindow(QDialog):
         self._active_request_id = self.service.send(messages, config)
         self._bottom()
 
+    def _focus_chat(self) -> None:
+        """把聊天窗口带回前台，供系统通知点击后跳回页面处理。"""
+        if self.isMinimized():
+            self.showNormal()
+        self.show()
+        self.raise_()
+        self.activateWindow()
+
+    def _focus_auth_settings(self) -> None:
+        if callable(self._auth_callback):
+            self._auth_callback()
+        else:
+            self._focus_chat()
+
+    def _show_system_notice(self, title: str, message: str, *, on_click=None) -> None:
+        """仅在聊天窗口不是当前活动窗口时弹系统通知；点击默认跳回本窗口。"""
+        if self._system_notifier is None or self.isActiveWindow():
+            return
+        try:
+            self._system_notifier(title, message, on_click=on_click or self._focus_chat)
+        except Exception:
+            logging.getLogger(__name__).exception("系统通知发送失败")
+
+    @staticmethod
+    def _looks_like_authorization_error(text: str) -> bool:
+        lowered = str(text or "").lower()
+        return any(
+            token in lowered
+            for token in ("401", "403", "unauthorized", "authentication", "api key",
+                          "认证失败", "未授权", "授权")
+        )
+
+    def notify_authorization_required(self, message: str = "有一条需要授权或确认的请求，点击查看。") -> None:
+        """供“需要授权/审批”类事件调用：切走窗口时弹系统通知并跳回聊天页。"""
+        self._show_system_notice("需要授权", message)
+
     def _started(self, request_id: str) -> None:
         if request_id != self._active_request_id:
             return
@@ -1970,6 +2009,7 @@ class ChatWindow(QDialog):
         self._refresh_sessions()
         self._reset()
         self.pet_link.success()
+        self._show_system_notice("对话完成", "AI 已回复完成，点击查看。")
         if self._stream_follow_output:
             self._bottom()
 
@@ -1984,6 +2024,14 @@ class ChatWindow(QDialog):
             self._bubble.set_state("error")
         self._reset()
         self.pet_link.error(text)
+        if self._looks_like_authorization_error(text):
+            self._show_system_notice(
+                "需要授权",
+                "模型服务返回认证失败，点击打开 AI 设置检查 API Key。",
+                on_click=self._focus_auth_settings,
+            )
+        else:
+            self._show_system_notice("生成失败", f"对话生成失败：{str(text)[:100]}")
         self._bottom()
 
     def _stopped(self, request_id: str) -> None:

--- a/pet/context_menus/legacy.py
+++ b/pet/context_menus/legacy.py
@@ -58,7 +58,10 @@ def build_legacy_menu(menu: QMenu, pet, template: dict) -> None:
     build_size_menu(menu, pet, icons=False)
 
     menu.addSeparator()
-    add_harness(menu, pet, icons=False)
+    # 纯桌宠（无 Chat/DSH 联动）版本不再显示“启动 DeepSeek Harness”，
+    # 仅保留“打开网页版 DeepSeek”。
+    if getattr(pet, "on_open_chat", None) is not None:
+        add_harness(menu, pet, icons=False)
     add_deepseek_web(menu, icons=False)
     add_proactive_menu(menu, pet)
     add_agent_link_menu(menu, pet)

--- a/pet/context_menus/modern.py
+++ b/pet/context_menus/modern.py
@@ -76,7 +76,10 @@ def build_modern_menu(menu: QMenu, pet, template: dict) -> None:
     # 4. 工具：同样直接显示，避免为了两个动作增加一级导航。
     start_group()
     add_balance(menu, pet)
-    add_harness(menu, pet)
+    # 纯桌宠（无 Chat/DSH 联动）版本不再显示“启动 DeepSeek Harness”，
+    # 仅保留“打开网页版 DeepSeek”。
+    if getattr(pet, "on_open_chat", None) is not None:
+        add_harness(menu, pet)
     add_deepseek_web(menu)
     add_quick_launch_menu(menu, pet.cfg)
     add_update_help(menu, pet)

--- a/pet/dynamic_island.py
+++ b/pet/dynamic_island.py
@@ -102,6 +102,26 @@ class DynamicIsland(QWidget):
 
         return QTime.currentTime().toString("HH:mm")
 
+    def _info_color(self, fallback: QColor) -> QColor:
+        """余额峰谷信息槽跟随设置的峰谷提示颜色开关。
+
+        开启后高峰显示红色、低谷显示绿色；关闭或非余额峰谷模式使用普通次文字色。
+        """
+        if str(self._cfg.get("info_mode") or "time") != "balance_tier":
+            return fallback
+        if not bool(self.config.get("balance_tier_color_enabled", True)):
+            return fallback
+        try:
+            from . import balance as balance_mod
+            tier = balance_mod.deepseek_pricing_tier()
+        except Exception:
+            return fallback
+        if tier == "peak":
+            return QColor("#e5484d")
+        if tier == "idle":
+            return QColor("#30a46c")
+        return fallback
+
     def _character_name(self) -> str:
         character_id = str(self.config.get("character", catalog.DEFAULT_CHARACTER))
         return self.config.character_alias(character_id) or character_id
@@ -223,7 +243,7 @@ class DynamicIsland(QWidget):
 
         if info:
             info_text = self._info_text()
-            painter.setPen(secondary_color)
+            painter.setPen(self._info_color(secondary_color))
             painter.drawText(
                 QRectF(x, 0, self.fontMetrics().horizontalAdvance(info_text), self.height()),
                 Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignLeft,

--- a/tests/test_chat_subsystem.py
+++ b/tests/test_chat_subsystem.py
@@ -2178,3 +2178,58 @@ def test_chat_settings_dialog_warns_when_keyring_unavailable(tmp_path, monkeypat
     assert "系统安全存储" in str(warnings[0][2])
     assert dialog.settings.active_config.api_key == "sk-new"
     app.processEvents()
+
+
+def test_chat_window_system_notification_when_not_active(tmp_path):
+    """聊天窗口非活动时发送系统通知；点击回调可聚焦窗口。"""
+    from PySide6.QtWidgets import QApplication
+
+    from pet.chat.widgets import ChatWindow
+    from pet.config import Config
+
+    _app = QApplication.instance() or QApplication([])
+    calls = []
+    win = ChatWindow(
+        Config(tmp_path),
+        "shenshen",
+        notifier=lambda title, message, on_click=None: calls.append((title, message, on_click)),
+    )
+    try:
+        win._show_system_notice("对话完成", "AI 已回复完成，点击查看。")
+        assert len(calls) == 1
+        assert calls[0][0] == "对话完成"
+        assert calls[0][1] == "AI 已回复完成，点击查看。"
+        # 点击默认回调应把窗口带回前台（能调用不抛异常即可）
+        calls[0][2]()
+    finally:
+        win.close()
+        _app.processEvents()
+
+
+def test_chat_window_authorization_error_opens_settings(tmp_path):
+    """认证失败类系统通知的点击回调应打开 AI 设置。"""
+    from PySide6.QtWidgets import QApplication
+
+    from pet.chat.widgets import ChatWindow
+    from pet.config import Config
+
+    _app = QApplication.instance() or QApplication([])
+    settings_opened = []
+    notices = []
+    win = ChatWindow(
+        Config(tmp_path),
+        "shenshen",
+        notifier=lambda title, message, on_click=None: notices.append((title, on_click)),
+        auth_callback=lambda: settings_opened.append(1),
+    )
+    try:
+        assert win._looks_like_authorization_error("HTTP 401 Unauthorized")
+        assert win._looks_like_authorization_error("认证失败：invalid api key")
+        assert not win._looks_like_authorization_error("connection reset")
+        win._show_system_notice("需要授权", "请检查 API Key", on_click=win._focus_auth_settings)
+        assert len(notices) == 1
+        notices[0][1]()
+        assert settings_opened == [1]
+    finally:
+        win.close()
+        _app.processEvents()

--- a/tests/test_desktop_pet_features.py
+++ b/tests/test_desktop_pet_features.py
@@ -802,6 +802,44 @@ def test_modern_context_menu_has_compact_semantic_groups(monkeypatch):
     app.processEvents()
 
 
+def test_pure_pet_context_menu_keeps_web_but_hides_harness():
+    """纯桌宠（无 Chat/DSH 联动）右键菜单去掉 DeepSeek Harness，保留网页版。"""
+    from PySide6.QtWidgets import QApplication, QMenu
+
+    from pet.context_menu import populate_context_menu
+
+    class FakeConfig:
+        def get(self, key, default=None):
+            return {
+                "context_menu_template": "modern",
+                "character": "shenshen",
+                "context_menu_appearance": {"theme": "light"},
+            }.get(key, default)
+
+    class FakePet:
+        cfg = FakeConfig()
+        on_open_chat = None
+        on_open_chat_settings = None
+        on_open_legacy_settings = None
+        on_open_modern_settings = None
+        on_spawn_pet = None
+        idles = turns = moves = clicks = acts = []
+        playback_speed = scale = 1.0
+        drag_physics = no_move = False
+
+        def __getattr__(self, name):
+            return None
+
+    app = QApplication.instance() or QApplication([])
+    menu = QMenu()
+    populate_context_menu(menu, FakePet())
+    labels = [action.text() for action in menu.actions() if not action.isSeparator()]
+    assert "启动 DeepSeek Harness" not in labels
+    assert "打开网页版 DeepSeek" in labels
+    menu.close()
+    app.processEvents()
+
+
 def test_context_menu_dispatches_style_by_template(monkeypatch):
     from PySide6.QtWidgets import QApplication, QMenu, QStyle, QWidget
 

--- a/tests/test_first_batch_features.py
+++ b/tests/test_first_batch_features.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from PySide6.QtGui import QColor
 from PySide6.QtWidgets import QApplication
 
 from pet.config import Config
@@ -123,3 +124,38 @@ def test_dynamic_island_resizes_when_info_changes(tmp_path: Path):
     island.hide()
     island.deleteLater()
     app.processEvents()
+
+
+def test_dynamic_island_balance_tier_color_syncs_to_setting(tmp_path: Path, monkeypatch):
+    """灵动岛余额峰谷信息槽跟随设置的颜色开关显示高峰/低谷颜色。"""
+    import pet.balance as balance_mod
+    from pet.dynamic_island import DynamicIsland
+
+    app = QApplication.instance() or QApplication([])
+    monkeypatch.setattr(balance_mod, "deepseek_pricing_tier", lambda: "peak")
+    cfg = _config(tmp_path)
+    cfg.set("dynamic_island", {
+        "enabled": True,
+        "show_icon": True,
+        "show_name": True,
+        "show_info": True,
+        "info_mode": "balance_tier",
+        "custom_text": "",
+        "show_status": True,
+        "style": "dark",
+        "x": 100,
+        "y": 100,
+    })
+    cfg.set("balance_tier_color_enabled", True)
+    island = DynamicIsland(cfg)
+    try:
+        fallback = QColor(160, 170, 190)
+        assert island._info_color(fallback).name() == "#e5484d"
+
+        cfg.set("balance_tier_color_enabled", False)
+        island.refresh_from_config()
+        assert island._info_color(fallback) is fallback
+    finally:
+        island.hide()
+        island.deleteLater()
+        app.processEvents()


### PR DESCRIPTION
## 概述

新增桌面系统通知：AI 对话在后台完成、生成失败或遇到认证/授权问题时，即使用户已切走窗口，也会在桌面右下角弹通知；点击通知可直接跳回聊天窗口或 AI 设置处理。

## 改动

- 复用托盘 `QSystemTrayIcon` 发送系统通知，支持点击回调。
- 现代/经典聊天窗在非活动状态收到完成/失败事件时弹系统通知。
- 认证失败类错误单独提示“需要授权”，点击打开 AI 设置。
- 预留 `notify_authorization_required()` 供后续授权/审批事件接入。
- 新增单元测试覆盖通知触发、点击回调与认证错误识别。

## 测试

- `tests/test_chat_subsystem.py`：88 passed, 1 skipped