### PR TITLE
fix(config): 加载时把磁盘明文 API Key 迁移进 keyring，修复老版本升级后聊天 401 静默失效

### DIFF
--- a/pet/config.py
+++ b/pet/config.py
@@ -694,6 +694,42 @@ class Config:
             self.data["agent_link"] = _merge_agent_link_data(raw["agent_link"])
         self._migrate_click_sound_config(raw)
         self.data["version"] = 4
+        self._migrate_plaintext_keys_to_keyring()
+
+    def _migrate_plaintext_keys_to_keyring(self) -> None:
+        """加载时把磁盘遗留的明文 API Key 迁移进 keyring。
+
+        v4.0.4/4.0.5 起 _redacted_data() 写盘时剔除 chat.providers 下的明文
+        api_key/vision_api_key，但 SecretStore.set 只在设置对话框保存时调用——
+        老版本（≤v4.0.0）磁盘上的明文 key 从未进过 keyring，升级后首次写盘即被剔除，
+        重启后 resolve_api_key 拿不到任何值，聊天/视觉 401 静默失效。
+        此处补迁移：keyring 已有值不覆盖（与 resolve_api_key 的 keyring 优先序一致），
+        仅丢弃明文；set 失败（keyring 不可用）保留内存明文，维持原兜底行为。
+        幂等：迁移成功后内存/磁盘均无明文，重复 _load 无副作用；不主动 save()，
+        写盘剔除交给下次正常保存。
+        """
+        chat = self.data.get("chat")
+        providers = chat.get("providers") if isinstance(chat, dict) else None
+        if not isinstance(providers, dict):
+            return
+        from .chat.models import SecretStore  # 惰性导入，且只实例化一次
+        store = SecretStore()
+        for provider_id, provider in providers.items():
+            if not isinstance(provider, dict):
+                continue
+            for key_field, ref_field, default_ref in (
+                ("api_key", "api_key_ref", f"provider/{provider_id}"),
+                ("vision_api_key", "vision_api_key_ref", f"provider/{provider_id}/vision"),
+            ):
+                plaintext = str(provider.get(key_field) or "")
+                if not plaintext.strip():
+                    continue
+                ref = str(provider.get(ref_field) or "").strip()
+                if not ref:
+                    ref = default_ref
+                    provider[ref_field] = ref
+                if store.get(ref) or store.set(ref, plaintext):
+                    provider.pop(key_field, None)
 
     def _migrate_click_sound_config(self, raw: dict) -> None:
         """旧版 click_sound_path 迁移为 click_sound_pack。"""

--- a/tests/test_chat_subsystem.py
+++ b/tests/test_chat_subsystem.py
@@ -97,8 +97,22 @@ def test_provider_error_is_safe():
     assert "401" in str(error)
     assert "api_key" not in str(error).lower()
 
-def test_config_v4_migrates_legacy_chat_fields(tmp_path: Path):
+def test_config_v4_migrates_legacy_chat_fields(tmp_path: Path, monkeypatch):
     from pet.config import Config
+
+    # 内存假 keyring：加载时明文迁移（_migrate_plaintext_keys_to_keyring）会把
+    # legacy chat_api_key 搬进去，不碰真实系统钥匙串。
+    class _FakeStore:
+        shared = {}
+        def __init__(self, *args, **kwargs):
+            pass
+        def get(self, ref):
+            return self.shared.get(ref, "") if ref else ""
+        def set(self, ref, value):
+            self.shared[ref] = value
+            return True
+    _FakeStore.shared = {}
+    monkeypatch.setattr("pet.chat.models.SecretStore", _FakeStore)
     root = tmp_path / "appdata"
     cfg_dir = root / "dsh-pet-standalone"
     cfg_dir.mkdir(parents=True)
@@ -115,7 +129,10 @@ def test_config_v4_migrates_legacy_chat_fields(tmp_path: Path):
     assert settings.default_system_prompt == "legacy prompt"
     assert settings.active_config.base_url == "https://deepseek.example/v1/"
     assert settings.active_config.model == "deepseek-chat"
-    assert settings.active_config.api_key == "secret-value"
+    # 明文 key 已迁移进 keyring：内存 api_key 置空，经 keyring 优先序仍可解析
+    assert settings.active_config.api_key == ""
+    assert _FakeStore.shared["provider/openai-main"] == "secret-value"
+    assert cfg.resolve_api_key(settings.active_config) == "secret-value"
     cfg.save()
     assert json.loads((cfg_dir / "config.json").read_text(encoding="utf-8"))["version"] == 4
 

--- a/tests/test_config_instance.py
+++ b/tests/test_config_instance.py
@@ -74,13 +74,25 @@ def test_save_returns_false_on_write_failure(tmp_path):
     assert config.save() is False
 
 
-def test_reload_preserves_memory_api_key_when_keyring_unavailable(tmp_path):
+def test_reload_preserves_memory_api_key_when_keyring_unavailable(tmp_path, monkeypatch):
     """keyring 不可用时 key 只存内存：磁盘重载（config._load()）不得冲掉内存 key。
 
     回归背景：设置对话框保存前会调用 config._load() 从磁盘重读以吸收外部改动，
     而 _redacted_data() 写盘时剔除了明文 api_key/vision_api_key —— 磁盘文件里没有
     key，_load() 于是把内存中的 key 覆盖成空，用户没重启就丢了 key。
     """
+    # 模拟 keyring 不可用：set 恒失败、get 恒空；否则加载时明文迁移会把内存 key
+    # 搬进真实 keyring（见 Config._migrate_plaintext_keys_to_keyring），本测试
+    # 要固定的正是「不可用兜底」这条路径。
+    class _UnavailableStore:
+        def __init__(self, *args, **kwargs):
+            pass
+        def get(self, ref):
+            return ""
+        def set(self, ref, value):
+            return False
+    monkeypatch.setattr("pet.chat.models.SecretStore", _UnavailableStore)
+
     config = Config(base=tmp_path)
     settings = config.chat_settings()
     provider = settings.active_config

--- a/tests/test_config_key_migration.py
+++ b/tests/test_config_key_migration.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+"""加载时把磁盘明文 API Key 迁移进 keyring 的回归测试。
+
+回归背景：v4.0.4/4.0.5 起 _redacted_data() 写盘时剔除 chat.providers 下的明文
+api_key/vision_api_key，但 SecretStore.set 只在设置对话框保存时调用——老版本
+(≤v4.0.0) 用户磁盘上的明文 key 从未进过 keyring，升级后首次写盘即被剔除，
+重启后 resolve_api_key 拿不到任何值，聊天/视觉 401 静默失效。
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import pet.chat.models as chat_models
+from pet.config import APP_DIR_NAME, Config
+
+
+class FakeStore:
+    """模拟 SecretStore：实例共享一个 dict；set 可控成败。"""
+
+    shared: dict = {}
+    set_ok: bool = True
+
+    def __init__(self, service_name="dsh-pet-standalone"):
+        self.service_name = service_name
+
+    @property
+    def available(self):
+        return True
+
+    def get(self, ref):
+        if not ref:
+            return ""
+        return self.shared.get(ref, "")
+
+    def set(self, ref, value):
+        if not self.set_ok or not ref:
+            return False
+        self.shared[ref] = value
+        return True
+
+
+@pytest.fixture(autouse=True)
+def _fake_secret_store(monkeypatch):
+    FakeStore.shared = {}
+    FakeStore.set_ok = True
+    monkeypatch.setattr(chat_models, "SecretStore", FakeStore)
+
+
+def _write_disk_config(tmp_path, providers):
+    config_dir = tmp_path / APP_DIR_NAME
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "config.json").write_text(
+        json.dumps({"version": 4, "chat": {"providers": providers}}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+def test_plaintext_api_key_migrated_to_keyring_on_load(tmp_path):
+    """磁盘 config.json 含明文 api_key：加载后迁移进 keyring，内存/磁盘均无明文。"""
+    _write_disk_config(tmp_path, {
+        "openai-main": {"name": "DeepSeek", "api_key": "sk-legacy-plaintext"},
+    })
+
+    config = Config(base=tmp_path)
+
+    # keyring 收到默认 ref 的 key
+    assert FakeStore.shared["provider/openai-main"] == "sk-legacy-plaintext"
+    # 内存中明文已被移除
+    provider = config.data["chat"]["providers"]["openai-main"]
+    assert not provider.get("api_key")
+    # 幂等：重复 _load 无副作用
+    config._load()
+    assert FakeStore.shared["provider/openai-main"] == "sk-legacy-plaintext"
+    # save() 后磁盘也无明文
+    assert config.save() is True
+    raw = json.loads(config.path.read_text(encoding="utf-8"))
+    disk_provider = raw["chat"]["providers"]["openai-main"]
+    assert "api_key" not in disk_provider
+
+
+def test_plaintext_kept_in_memory_when_keyring_unavailable(tmp_path):
+    """keyring 不可用（set 返回 False）→ 内存保留明文，维持原兜底行为。"""
+    _write_disk_config(tmp_path, {
+        "openai-main": {"name": "DeepSeek", "api_key": "sk-legacy-plaintext"},
+    })
+    FakeStore.set_ok = False
+
+    config = Config(base=tmp_path)
+
+    assert FakeStore.shared == {}
+    provider = config.data["chat"]["providers"]["openai-main"]
+    assert provider["api_key"] == "sk-legacy-plaintext"
+
+
+def test_existing_keyring_value_not_overwritten(tmp_path):
+    """keyring 已有该 ref 的值 → 不覆盖，仅丢弃明文。"""
+    _write_disk_config(tmp_path, {
+        "openai-main": {"name": "DeepSeek", "api_key": "sk-legacy-plaintext"},
+    })
+    FakeStore.shared["provider/openai-main"] = "sk-already-in-keyring"
+
+    config = Config(base=tmp_path)
+
+    assert FakeStore.shared["provider/openai-main"] == "sk-already-in-keyring"
+    provider = config.data["chat"]["providers"]["openai-main"]
+    assert not provider.get("api_key")
+
+
+def test_vision_api_key_migrated_with_default_ref(tmp_path):
+    """vision_api_key 迁移：ref 为空时用默认 ref provider/<pid>/vision 并回填。"""
+    _write_disk_config(tmp_path, {
+        "openai-main": {"name": "DeepSeek", "vision_api_key": "vk-legacy-plaintext"},
+    })
+
+    config = Config(base=tmp_path)
+
+    assert FakeStore.shared["provider/openai-main/vision"] == "vk-legacy-plaintext"
+    provider = config.data["chat"]["providers"]["openai-main"]
+    assert not provider.get("vision_api_key")
+    assert provider["vision_api_key_ref"] == "provider/openai-main/vision"


### PR DESCRIPTION
## 问题

在 issue #23 / #24 修复测试期间发现：老版本（≤v4.0.0）用户升级后，聊天/视觉功能 401 静默失效。

## 根因

v4.0.4/4.0.5 引入 keyring 安全存储：`Config._redacted_data()`（pet/config.py）写盘时会剔除 `chat.providers` 下的明文 `api_key` / `vision_api_key`；但全仓库没有任何「加载时把磁盘明文 key 迁移进 keyring」的代码——`SecretStore.set` 只在两个设置对话框保存时调用。

于是老用户升级后的链路是：

1. 磁盘 config.json 里有明文 key（老版本写入）；
2. 升级后首次写盘，`_redacted_data()` 把明文剔除；
3. keyring 从头到尾没被写入过；
4. 重启后 `resolve_api_key()` 先查 keyring（空）再回退内存/磁盘明文（已被剔除），返回空 → 401。

## 真机取证时间线

- issue #23/#24 修复测试期间，真机观察到升级后聊天请求 401；
- 检查 config.json：无 `api_key` 字段（已被写盘剔除）；检查系统钥匙串：对应 ref 无条目；
- 用 ≤v4.0.0 的 config.json（含明文 `api_key`）在新版本上完整复现：首次保存后明文消失、keyring 为空、重启后 key 丢失，证据链闭合。

## 复现步骤

1. 用 v4.0.0 或更早版本配置好 API Key（明文存入 config.json）；
2. 升级到 v4.0.4+，打开任意设置触发一次 `save()`（或等自动保存）；
3. 重启应用，发起聊天 → 401（key 已丢）。

## 修复方案

`Config._load()` 末尾新增 `_migrate_plaintext_keys_to_keyring()`：

- 遍历 `chat.providers` 每个 provider 的两个字段对：`(api_key, api_key_ref)` 与 `(vision_api_key, vision_api_key_ref)`；
- 明文为空跳过；ref 为空用默认 ref（`provider/<pid>` / `provider/<pid>/vision`，与设置对话框约定一致）并回填；
- keyring 已有该 ref 的值 → 不覆盖，仅丢弃明文（与 `resolve_api_key` 的 keyring 优先序一致）；
- `set` 成功 → 从内存移除明文；`set` 失败（keyring 不可用）→ 保留内存明文，维持原兜底行为；
- 幂等：重复 `_load()` 无副作用；不主动 `save()`，写盘剔除交给下次正常保存。

## 测试

先红后绿，全量通过：

- **红**：新增 `tests/test_config_key_migration.py`（FakeStore 模拟 keyring get/set，set 可控成败），未改代码时 3 红 1 绿（「keyring 不可用保留内存明文」的兜底语义在修复前后都成立）；
- **绿**：实现后 4 条全绿，覆盖——明文迁移进 keyring 且内存/磁盘均无明文、keyring 不可用保留内存明文、keyring 已有值不覆盖仅丢明文、vision key 迁移默认 ref `provider/<pid>/vision`；
- 两条受影响的既有断言改为与真实 keyring 隔离（monkeypatch 内存 FakeStore）：`test_reload_preserves_memory_api_key_when_keyring_unavailable` 固定其名称所示的「不可用兜底」语义；`test_config_v4_migrates_legacy_chat_fields` 改为断言 legacy key 经 keyring 优先序仍可解析；
- 相关文件 `tests/test_config_key_migration.py` + `tests/test_config_instance.py` + `tests/test_chat_subsystem.py`：100 passed, 1 skipped；
- 全量 `python -m pytest -q`（QT_QPA_PLATFORM=offscreen）：**710 passed, 6 skipped**，无失败。
