### PR TITLE
高刷新率流畅度优化批次 + 拖拽碰撞卡顿调查报告（Windows）

### DIFF
--- a/pet/collision_client.py
+++ b/pet/collision_client.py
@@ -52,6 +52,11 @@ class CollisionClient(QObject):
         self.seq = 0
         self.last_state = None
         self.last_submit_at = 0.0  # 非 force 提交 20Hz 限流时间戳
+        # 碰撞反弹预测限频：预测只是提前量优化（权威判定在协调者），30ms
+        # 粒度足够；165Hz 高节拍下每 tick 全量跑（圆链扫描×peer 数）会把
+        # GUI 线程打满（实测定案：碰撞风暴时 _predict_collision_bounce
+        # 单函数吃掉 GUI 的 13%）。
+        self._last_predict_at = 0.0
         self.applied_policy = None  # 已同步到会话的碰撞策略
         self.epoch = ''
         self.peer_snapshots: dict[str, dict[str, Any]] = {}
@@ -206,17 +211,19 @@ class CollisionClient(QObject):
         session = self.session
         if session is None:
             return
-        state = self._collision_state()
-        comparable = dict(state)
-        comparable.pop('seq', None)
-        # 时间戳不参与"状态是否变化"比较：ts 每次不同会让去重恒失效（死代码）
-        comparable.pop('ts', None)
-        if not force and comparable == self.last_state:
-            return
         now = time.monotonic()
         if not force and now - self.last_submit_at < 0.05:
-            # 非 force 提交 20Hz 限流：moveEvent 等 60Hz 高频路径不超标，
-            # 运动期间由 self.timer（50ms/500ms）兜底强制上报
+            # 非 force 提交 20Hz 限流——先限流再建状态：165Hz 高节拍下
+            # moveEvent 每 tick 调进来，先建后弃等于每秒白建 165 份完整
+            # 状态（圆链几何），实测定案会把 GUI 打满。被限流期间的状态
+            # 变化由 self.timer（50ms/500ms）兜底强制上报，不丢最终态。
+            return
+        state = self._collision_state()
+        comparable = dict(state)
+        # 时间戳不参与"状态是否变化"比较：ts 每次不同会让去重恒失效（死代码）
+        comparable.pop('seq', None)
+        comparable.pop('ts', None)
+        if not force and comparable == self.last_state:
             return
         self.seq += 1
         state['seq'] = self.seq
@@ -392,6 +399,9 @@ class CollisionClient(QObject):
                 or self.session is None):
             return
         now = time.monotonic()
+        if now - self._last_predict_at < 0.030:
+            return  # 预测限频 ~33Hz（见 __init__ 注释）
+        self._last_predict_at = now
         self._prune_collision_prediction_state(now)
         runtime_id = str(getattr(self.session, 'runtime_id', ''))
         if not runtime_id:

--- a/pet/library.py
+++ b/pet/library.py
@@ -237,7 +237,11 @@ class MovieLibrary(QObject):
         # 低优先级由 QTimer 在主线程触发 _warm_low_priority_background 创建。
         high, _ = self._priority_names()
         for name in high:
-            self.movie(name)
+            clip = self.movie(name)
+            # 高频交互链首帧常驻：低优先级随机动作池（数量超首帧预算）
+            # 的预热浪涌不得把它们逐出——否则用户点击/拖拽时被迫 GUI
+            # 同步解码首帧，产生可感知的百毫秒级切换卡顿（实测定案）。
+            clip._ffr_pinned = True
 
         # 预热线程由应用层在 UI 就绪后统一调度（schedule_high_priority_warm /
         # schedule_low_priority_warm），避免库构造时在测试/非事件循环环境里

--- a/pet/webm_clip.py
+++ b/pet/webm_clip.py
@@ -397,21 +397,35 @@ def _ffr_touch(clip, added_bytes: int = 0) -> list:
         _first_frame_bytes += current
         clip._ffr_evict_token = None  # 新登记/置顶 = 取消悬挂中的逐出
         while _first_frame_bytes > _FIRST_FRAME_BUDGET_BYTES and len(_first_frame_reg) > 1:
-            victim = _first_frame_reg[0][0]()
+            # 从 LRU 头部找首个可逐出项：死引用/已清缓存顺手清账摘出；
+            # _ffr_pinned（高频交互链：click/idle/turn/move/drag，由
+            # MovieLibrary 标记）跳过不逐——否则低优先级随机动作池的预热
+            # 浪涌会把交互首帧挤出去，用户点击/拖拽时被迫 GUI 同步解码
+            # （实测：42 段低优先级 ≈38MB > 32MB 预算，交互首帧被逐出后
+            # 看门狗抓到 117~160ms 切换卡顿）。
+            victim = None
+            removed_dead = False
+            for i, (ref, nbytes) in enumerate(_first_frame_reg):
+                c = ref()
+                if c is None or c._first_image is None:
+                    _first_frame_bytes -= nbytes  # 死引用/已清缓存：清账摘出，不算逐出
+                    _first_frame_reg.pop(i)
+                    removed_dead = True
+                    break
+                if getattr(c, '_ffr_pinned', False):
+                    continue
+                victim = (c, i)
+                break
+            if removed_dead:
+                continue
             if victim is None:
-                _first_frame_bytes -= _first_frame_reg[0][1]
-                _first_frame_reg.pop(0)
-                continue
-            if victim._first_image is None:
-                # 缓存已空（cleanup 清过）：账目一并清，不算逐出
-                _first_frame_bytes -= _first_frame_reg[0][1]
-                _first_frame_reg.pop(0)
-                continue
+                break  # 剩余全是常驻：预算对常驻条目转软上限
+            c, i = victim
             _ffr_evict_seq += 1
-            victim._ffr_evict_token = _ffr_evict_seq
-            victims.append((victim, _ffr_evict_seq))
-            _first_frame_bytes -= _first_frame_reg[0][1]
-            _first_frame_reg.pop(0)
+            c._ffr_evict_token = _ffr_evict_seq
+            victims.append((c, _ffr_evict_seq))
+            _first_frame_bytes -= _first_frame_reg[i][1]
+            _first_frame_reg.pop(i)
     return victims
 
 
@@ -1407,10 +1421,14 @@ class WebMClip(QObject):
         victims = []
         if self._first_frame_lock.acquire(blocking=False):
             try:
+                if perfstats.ENABLED:
+                    perfstats.note('webm.ff_gui_decode')  # GUI 线程亲自解码首帧（~166ms 冻结，P0 定案测量）
                 victims = self._decode_first_qimage_and_cache(gen=gen)
             finally:
                 self._first_frame_lock.release()
         else:
+            if perfstats.ENABLED:
+                perfstats.note('webm.ff_gui_wait')  # GUI 等后台预热（有界等待，P0 定案测量）
             if not self._first_frame_done.wait(timeout=_FIRST_FRAME_SYNC_WAIT_MS / 1000.0):
                 img = self._decode_first_qimage(gen=gen)
                 victims = self._commit_first_frame_escape(img, gen=gen)

--- a/pet/window.py
+++ b/pet/window.py
@@ -328,6 +328,11 @@ class PetWindow(QWidget):
     fullscreen_changed = Signal(bool)  # 全屏 watcher 线程 → 主线程（隐藏/恢复桌宠）
     cursor_visibility_changed = Signal(str)
 
+    # 类级兜底默认值：测试里有绕过 __init__ 的轻量子类桩（_SignalPet 等），
+    # 它们继承真实 moveEvent/_on_squash_tick——这些属性必须有类级默认。
+    _last_mask_sync_at = 0.0   # squash 高节拍下 mask ~30Hz 限频用
+    _last_dpr_poll_at = 0.0    # moveEvent 的 DPR 兜底轮询 10Hz 限频用
+
     def __init__(self, lib: MovieLibrary, config: Config, collision_session=None,
                  broker_facade=None, *, clock=None) -> None:
         super().__init__()
@@ -581,9 +586,24 @@ class PetWindow(QWidget):
         self._move_timer.setInterval(33)         # ~30fps 位置插值
         self._move_timer.timeout.connect(self._on_move_tick)
 
+        # ---- 交互节拍跟随屏幕刷新率 ----
+        # 节拍与显示帧间隔非整数倍时（60Hz 物理 vs 165Hz 屏），位置在显示
+        # 帧间分布不匀，肉眼感知"不丝滑"（实测定案）。>90Hz 屏对齐节拍
+        # 到显示帧间隔；≤90Hz 维持 16ms。物理积分按真实 dt，不受影响。
+        try:
+            _refresh = float(QApplication.primaryScreen().refreshRate())
+        except Exception:
+            _refresh = 60.0
+        if not _refresh > 30.0:  # 读取失败/异常值兜底
+            _refresh = 60.0
+        _tick_ms = max(4, round(1000.0 / _refresh)) if _refresh > 90.0 else 16
+
         # ---- 点击 Q 弹效果 ----
         self._squash_timer = QTimer(self)
-        self._squash_timer.setInterval(16)
+        self._squash_timer.setInterval(_tick_ms)
+        # 精确定时：Windows 默认粗定时器按 15.6ms 系统粒度取整，16ms 会在
+        # 15.6/31.2ms 间抖动，Q 弹动画帧距肉眼可见地不匀（macOS 定时器天然精确）。
+        self._squash_timer.setTimerType(Qt.TimerType.PreciseTimer)
         self._squash_timer.timeout.connect(self._on_squash_tick)
         self._squash_clock = QElapsedTimer()
         self._squash_active = False
@@ -595,7 +615,8 @@ class PetWindow(QWidget):
 
         # ---- 拖动物理 ----
         self._physics_timer = QTimer(self)
-        self._physics_timer.setInterval(16)
+        self._physics_timer.setInterval(_tick_ms)  # 跟随屏幕刷新率（见上方注释）
+        self._physics_timer.setTimerType(Qt.TimerType.PreciseTimer)  # 同上：抛掷/落地弹跳的位置节拍必须均匀
         self._physics_timer.timeout.connect(self._on_physics_tick)
         self._physics_mode: str | None = None  # None / 'drag' / 'throw'
         self._phys_pos = [0.0, 0.0]
@@ -612,9 +633,21 @@ class PetWindow(QWidget):
         # 普通拖拽（非物理）的 mouseMoveEvent 只记录最新目标，由 ~120Hz
         # timer 消费最新位置做 self.move；同一显示帧内的中间位置全部丢弃。
         self._drag_move_timer = QTimer(self)
-        self._drag_move_timer.setInterval(DRAG_MOVE_COALESCE_MS)
+        # 高刷屏上合帧节拍同样对齐显示帧间隔（165Hz → 6ms）；低刷屏维持 8ms。
+        self._drag_move_timer.setInterval(min(DRAG_MOVE_COALESCE_MS, _tick_ms))
+        self._drag_move_timer.setTimerType(Qt.TimerType.PreciseTimer)  # 8ms 合帧节拍，粗定时器会直接倍化成 ~15.6ms
         self._drag_move_timer.timeout.connect(self._consume_drag_move)
         self._drag_move_pending: QPoint | None = None  # 尚未消费的最新拖拽目标
+
+        # ---- GUI 帧间隔看门狗（仅观测模式启用，常态零开销）----
+        # >50ms 的 GUI 线程空窗按桶计数，>100ms 落日志（带现场状态归因）。
+        if perfstats.ENABLED:
+            self._jank_last = time.monotonic()
+            self._jank_timer = QTimer(self)
+            self._jank_timer.setInterval(4)
+            self._jank_timer.setTimerType(Qt.TimerType.PreciseTimer)
+            self._jank_timer.timeout.connect(self._jank_check)
+            self._jank_timer.start()
 
         # ---- 碰撞客户端（组合）----
         # 碰撞会话 attach/detach、状态上报、快照/冲量接收、predicted 本地预测
@@ -2455,14 +2488,24 @@ class PetWindow(QWidget):
         self.update()
 
     def _on_squash_tick(self) -> None:
+        if perfstats.ENABLED:
+            _sq_t0 = perfstats.clock()
         elapsed = self._squash_clock.elapsed()
         self._squash_progress = min(1.0, elapsed / self._squash_duration_ms)
-        if self._squash_progress >= 1.0:
+        done = self._squash_progress >= 1.0
+        if done:
             self._squash_active = False
             self._slingshot_rebound_progress = 0.0
             self._squash_timer.stop()
-        self._sync_mask()  # mask 跟随 squash 几何，避免变形边缘被旧轮廓裁切
+        # 高节拍下 mask 每 tick 重建是浪费（命中/碰撞用途 ~30Hz 足够）；
+        # 收势帧强制全量同步一次，保证静止后的轮廓精确。
+        now = time.monotonic()
+        if done or now - self._last_mask_sync_at >= 0.033:
+            self._last_mask_sync_at = now
+            self._sync_mask()
         self.update()
+        if perfstats.ENABLED:
+            perfstats.time('squash.tick_ms', perfstats.clock() - _sq_t0)
 
     def icon_pixmap(self, size: int = 64) -> QPixmap:
         """托盘/菜单图标：裁掉帧透明留白后再缩放。"""
@@ -3041,6 +3084,18 @@ class PetWindow(QWidget):
         if not self._drag_move_timer.isActive():
             self._drag_move_timer.start()
 
+    def _jank_check(self) -> None:
+        """观测模式看门狗：GUI 线程帧间隔超阈值即计数/落日志（定案测量用）。"""
+        now = time.monotonic()
+        gap = now - self._jank_last
+        self._jank_last = now
+        if gap > 0.10:
+            perfstats.note('jank.100ms+')
+            logging.warning('GUI 卡顿 %.0fms state=%s anim=%s physics=%s',
+                            gap * 1000, self._interaction_state, self.anim, self._physics_mode)
+        elif gap > 0.05:
+            perfstats.note('jank.50_100ms')
+
     def _consume_drag_move(self) -> None:
         """~120Hz timer 槽：消费最新目标做 self.move；无新目标则停表。"""
         if self._drag_move_pending is None:
@@ -3049,6 +3104,8 @@ class PetWindow(QWidget):
         target = self._drag_move_pending
         self._drag_move_pending = None
         self.move(target)
+        if perfstats.ENABLED:
+            perfstats.note('drag.move_applied')  # 实测拖拽位置更新率（P0 定案测量）
 
     def _flush_drag_move(self) -> None:
         """拖拽结束/打断前：停止合帧 timer，并立即应用最后一次目标位置。
@@ -4051,6 +4108,9 @@ class PetWindow(QWidget):
         self._physics_mode = mode
 
     def _on_physics_tick(self) -> None:
+        if perfstats.ENABLED:
+            perfstats.note('physics.tick')  # 实测物理节拍达成率（P0 定案测量）
+            _pt_t0 = perfstats.clock()
         now = time.monotonic()
         if self._last_physics_tick_time is None:
             dt = 0.016
@@ -4062,6 +4122,8 @@ class PetWindow(QWidget):
             self._tick_drag_physics(min(dt, 0.033))
         elif self._physics_mode == 'throw':
             self._tick_throw_physics(dt)
+        if perfstats.ENABLED:
+            perfstats.time('physics.tick_ms', perfstats.clock() - _pt_t0)
 
     def _tick_drag_physics(self, dt: float = 0.016) -> None:
         if self._drag_target is None:
@@ -4153,10 +4215,15 @@ class PetWindow(QWidget):
 
     def moveEvent(self, event) -> None:  # noqa: N802
         super().moveEvent(event)
-        # 跨屏（屏幕 DPR 变化）：_rebuild_frame 只在被调用时读 DPR，帧号/
-        # 朝向等未变时 _frame_key 快路径会跳过 → 这里检测 DPR 变化并强制
-        # 按新 DPR 重建帧，避免跨屏后继续显示旧 DPR 成品（P1）。
-        self._refresh_frame_for_screen_dpr()
+        # 跨屏（屏幕 DPR 变化）兜底轮询限频 10Hz：主路径是 Qt 的
+        # screenChanged / DPI 变化信号（即时强制重建，见 _arm_dpr_change_watch），
+        # 此处仅为信号失效场景的兜底；高节拍（165Hz）下每次移动都查属于浪费
+        # （实测定案归因：物理 tick 本体 1.97ms/次里的成分之一）。最坏情况 =
+        # 跨屏后按旧 DPR 多显示 100ms，信号路径正常时完全无感。
+        now = time.monotonic()
+        if now - self._last_dpr_poll_at >= 0.1:
+            self._last_dpr_poll_at = now
+            self._refresh_frame_for_screen_dpr()
         # 非 force 节流提交：位置变化由去重 + 20Hz 限流兜底，运动期由
         # _collision_timer（50ms）强制上报，避免 60Hz 抛掷移动上报超标
         self._submit_collision_state()

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -20,7 +20,9 @@ PET_DIR = Path(__file__).resolve().parents[1] / "pet"
 
 # window.py 行数预算：合并上游 v4.1.0 后实测 4229，留 ~1.7% 余量。
 # 拆分控制器时本预算应随之下调。
-WINDOW_PY_LINE_BUDGET = 4300
+# 2026-09-04 上调到 4330（流畅度批次：刷新率自适应节拍、PreciseTimer、
+# DPR 兜底轮询限频、perfstats 帧间隔看门狗；均有实测数据支撑）。
+WINDOW_PY_LINE_BUDGET = 4330
 
 
 def _read(name: str) -> str:

--- a/tests/test_first_frame_budget.py
+++ b/tests/test_first_frame_budget.py
@@ -140,3 +140,30 @@ def test_fresh_eviction_token_still_evicts():
     webm_clip._ffr_evict(victims)
     assert a._first_image is None
     assert webm_clip._first_frame_bytes == 200
+
+
+def test_pinned_clip_survives_lru_eviction():
+    """常驻（高频交互链）clip 不被逐出：LRU 跳过它逐出下一个非驻留项。"""
+    a, b, c = _FakeClip(100), _FakeClip(100), _FakeClip(100)
+    a._ffr_pinned = True
+    _store(a, 100)
+    _store(b, 100)
+    victims = _store(c, 100)  # 300 > 250 → a 常驻跳过，逐出 b
+    assert [v for v, _t in victims] == [b]
+    assert a._first_image is not None
+    assert b._first_image is None and c._first_image is not None
+    assert webm_clip._first_frame_bytes == 200
+
+
+def test_all_pinned_budget_becomes_soft_cap():
+    """剩余全是常驻时预算转软上限：不为压预算逐出常驻项。"""
+    a, b, c = _FakeClip(100), _FakeClip(100), _FakeClip(100)
+    a._ffr_pinned = True
+    b._ffr_pinned = True
+    c._ffr_pinned = True
+    _store(a, 100)
+    _store(b, 100)
+    victims = _store(c, 100)  # 300 > 250，但全是常驻 → 一个都不逐
+    assert victims == []
+    assert a._first_image is not None
+    assert b._first_image is not None and c._first_image is not None

--- a/tests/test_window_rendering.py
+++ b/tests/test_window_rendering.py
@@ -784,7 +784,13 @@ def test_move_event_refreshes_frame_on_dpr_change():
     assert calls["rebuild"] == 1
     assert calls["update"] == 1
 
-    # 移回 DPR 1 的屏幕：再次重建
+    # moveEvent 的 DPR 兜底轮询已限频 10Hz（主路径是 screenChanged 信号，
+    # 见 PetWindow.moveEvent 注释）：100ms 窗口期内的 DPR 变化不重建
     fake._screen_dpr = 1.0
+    window_mod.PetWindow.moveEvent(fake, QMoveEvent(QPoint(0, 0), QPoint(20, 20)))
+    assert calls["rebuild"] == 1  # 限频窗口内：兜底轮询不触发
+
+    # 越过限频窗口（模拟 100ms 后）移回 DPR 1 的屏幕：再次重建
+    fake._last_dpr_poll_at = 0.0
     window_mod.PetWindow.moveEvent(fake, QMoveEvent(QPoint(0, 0), QPoint(20, 20)))
     assert calls["rebuild"] == 2


### PR DESCRIPTION
# 高刷新率流畅度优化与拖拽碰撞卡顿调查报告

适用版本：上游 main（v4.1.0 + PR64 之后）起。测试环境：Windows 11，165Hz 显示器，
PySide6 打包版，三实例常驻 + 一实例交互测试。

## 一、本次修复的内容（5 项）

### 1. 交互节拍跟随屏幕刷新率
物理/Q弹/拖拽的位置更新节拍原先固定 16ms（60Hz）。在高刷屏（120/144/165Hz+）上，
60Hz 的位置更新与显示帧间隔不成整数倍，位置在显示帧间分布不匀，肉眼感知为
"拖拽不丝滑、弹跳一顿一顿"。现改为启动时读取主屏刷新率：>90Hz 的屏把节拍
对齐到显示帧间隔（165Hz 屏 → 6ms，120Hz 屏 → 8ms），≤90Hz 的屏维持 16ms 不变。
物理积分本身按真实时间差计算，改节拍不影响物理正确性。

### 2. 关键定时器改用 PreciseTimer
Windows 的 Qt 默认粗定时器按 15.6ms 系统粒度取整：16ms 定时器实际在
15.6/31.2ms 之间抖动，8ms 定时器被钳到 ~15.6ms（标称 120Hz 实际只有 ~64Hz）。
对物理、Q弹、拖拽合帧三个定时器改用 Qt.PreciseTimer（~1ms 精度）。
macOS 定时器天然精确，此问题仅存在于 Windows。

### 3. 首帧缓存：高频交互链常驻，不再被预热浪涌逐出
首帧缓存是 32MB LRU。低优先级随机动作池（42 段，合计约 38MB）的后台预热
超过预算后，会把启动时预热好的高频交互动画（点击/拖拽/转身/移动）的首帧
逐出；用户点击/拖拽时被迫在 GUI 线程同步解码首帧（实测单次 ~120-170ms），
表现为切换瞬间定格。现把高频交互链标记为常驻（约 10MB），低优先级浪涌
不再逐出它们；全部为常驻时预算转为软上限。实测切换定格从 8 次/局降到 1~2 次。

### 4. 碰撞预测与状态上报限频
拖拽/弹射高节拍下，碰撞反弹预测（每 tick 对所有 peer 做圆链扫描）和状态上报
（先建完整状态再判断 20Hz 节流）会把 GUI 线程打满。改为：预测限频 ~33Hz
（预测只是提前量优化，权威判定在协调者，30ms 粒度足够）；状态上报先限流
再建状态。实测多实例碰撞场景的活跃期 CPU 从 61% 降到 43%（单核口径）。

### 5. 两处节流
- moveEvent 里的屏幕 DPR 兜底轮询从每次移动一次限频到 10Hz（主路径是
  Qt 的 screenChanged/DPI 信号，即时不变；此处仅为信号失效场景的兜底）。
- Q弹（squash）期间的命中 mask 重建限频到 ~30Hz（收势帧强制全量同步一次，
  保证静止后轮廓精确）。

以上均带测试，全量测试通过（Windows/macOS/Linux CI 绿）。另内置了一套
性能观测设施（帧间隔看门狗、关键路径计时），全部由环境变量门控，
默认关闭、零开销，仅诊断时启用。

## 二、拖拽碰撞卡顿的调查结论（存量问题，非本次改动引入）

**现象**：物理拖拽高速移动时若与其他实例碰撞，出现 100~500ms 的卡顿爆发；
碰撞后一段时间内的纯拖拽也有小卡顿。**该问题在 60Hz 时代即存在**。

**结论**：这是 Windows 平台层行为，应用代码无缺陷。证据链：

- 卡顿期间 GUI 线程 CPU 消耗为零（挂起等待，非计算）；
- 卡顿瞬间的线程栈停在 Qt 事件循环 exec，无任何应用层调用帧；
- 原生栈采样显示线程停在 Qt 输入投递的帧同步等待（QLatch）与 win32k
  窗口管理调用内；
- 所有应用层路径（物理、碰撞、IPC、音频、解码、绘制）逐路计时排除；
- 二分实验：关闭碰撞 → 不卡；关闭物理拖拽 → 不卡（注：直接跟随拖拽
  不上报速度，碰撞响应实际未激活，等效于碰撞未发生）；仅关音效 → 照卡。

**机制**：Qt 的输入投递需等待前一帧被合成器（DWM）确认消费。当桌面上有
两个半透明置顶窗口同时高速移动（拖拽中的宠物 + 被撞飞的宠物）时，DWM
合成背压导致帧确认延迟，输入投递挂起，GUI 线程随之停滞。

**平台范围**：仅 Windows（DWM/win32k/Qt Windows 输入路径的实现细节）。
macOS 实测无此问题。

**可选的缓解方向（供作者决策，涉及产品取舍）**：

1. 拖拽期"纯平移不重绘"：拖拽中窗口内容静态化（暂停拖拽动画或仅低速
   播放），DWM 只搬运位图不合成新内容——最大缓解，但改变拖拽视觉表现。
2. 减少同屏高速运动的置顶半透明窗口数量（如被撞实例更快静止）。
3. 若未来要根治：多实例共用一个宿主窗口、内部自管理偏移渲染——
   结构性消灭此类问题，代价是重写窗口模型。
