### PR TITLE
[AI 修改] 修复 Linux Fcitx 中文输入与设置页游离开关

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -23,11 +23,11 @@ jobs:
         uses: actions/checkout@v4
 
       # PySide6 在 Linux 上 import 需要系统 EGL/GL 等库（裸 runner 没有）；
-      # 这组库与 README「Linux 使用」给用户的运行时依赖一致。
+      # 构建 Fcitx 插件还需要 CMake、ECM 和 Qt6 私有开发头文件。
       - name: Install system libraries (PySide6)
         run: |
           sudo apt-get update
-          sudo apt-get install -y libegl1 libgl1 libxkbcommon-x11-0 libxcb-cursor0 libfontconfig1 libdbus-1-3 fonts-noto-cjk
+          sudo apt-get install -y libegl1 libgl1 libxkbcommon-x11-0 libxcb-cursor0 libfontconfig1 libdbus-1-3 fonts-noto-cjk cmake extra-cmake-modules qt6-base-private-dev libxkbcommon-dev libxcb1-dev libx11-dev
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -70,6 +70,12 @@ jobs:
               echo "::error::$APP 未打包 integrations/dsh-pet-bridge，DSH 桥接一键安装必然失败"; exit 1
             fi
             echo "$APP 桥接插件资源已打包"
+            # Fcitx 插件必须与 PySide6 Qt 一起分发，Linux Fcitx 用户才能输入中文。
+            IME_PLUGIN="dist/$APP/_internal/PySide6/Qt/plugins/platforminputcontexts/libfcitx5platforminputcontextplugin.so"
+            if [ ! -f "$IME_PLUGIN" ]; then
+              echo "::error::$APP 未打包 Fcitx5 输入法插件，中文输入必然失败"; exit 1
+            fi
+            echo "$APP Fcitx5 输入法插件已打包"
           done
 
       - name: Package as zip

--- a/pet/app.py
+++ b/pet/app.py
@@ -917,8 +917,21 @@ def _default_xcb_platform_on_wayland() -> None:
         os.environ["QT_QPA_PLATFORM"] = "xcb"
 
 
+def _configure_linux_fcitx_input_method() -> None:
+    """为 PySide6 冻结版选择与内置 Qt ABI 兼容的 Fcitx 输入法前端。"""
+    # Linux 成品随包携带按 PySide6 Qt ABI 编译的 Fcitx 插件；未指定时默认选中 fcitx 上下文。
+    if not sys.platform.startswith("linux"):
+        return
+    if os.environ.get("XMODIFIERS", "").strip() != "@im=fcitx":
+        return
+    if not os.environ.get("QT_IM_MODULE", "").strip():
+        os.environ["QT_IM_MODULE"] = "fcitx"
+
+
 def main(argv: list[str] | None = None, enable_chat: bool = True) -> int:
     _default_xcb_platform_on_wayland()
+    # 必须在 QApplication 构造前设置，Qt 才会按随包 Fcitx 插件创建输入法上下文。
+    _configure_linux_fcitx_input_method()
     argv = list(argv if argv is not None else sys.argv)
     preferred_slot = None
 

--- a/pet/modern_settings_dialog.py
+++ b/pet/modern_settings_dialog.py
@@ -1344,8 +1344,11 @@ class ModernSettingsDialog(QDialog):
         self.no_move_check.setChecked(bool(self.config.get("no_move", False)))
         self.mouse_through_check = ToggleSwitch(self)
         self.mouse_through_check.setChecked(bool(self.config.get("mouse_through", False)))
-        self.cursor_hidden_passthrough_check = ToggleSwitch(self)
-        self.cursor_hidden_passthrough_check.setChecked(bool(self.config.get("cursor_hidden_passthrough", True)))
+        # Windows 专属的光标隐藏穿透仅在 Windows 创建，避免非 Windows 未入布局时游离到窗口左上角。
+        self.cursor_hidden_passthrough_check = None
+        if sys.platform == "win32":
+            self.cursor_hidden_passthrough_check = ToggleSwitch(self)
+            self.cursor_hidden_passthrough_check.setChecked(bool(self.config.get("cursor_hidden_passthrough", True)))
         self.drag_physics_check = ToggleSwitch(self)
         self.drag_physics_check.setChecked(bool(self.config.get("drag_physics", False)))
 

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -36,6 +36,12 @@ fi
 
 mkdir -p "$DIST_DIR" "$WORK_DIR"
 
+# 按当前 PySide6 Qt 精确版本构建 Fcitx 插件，避免系统 Qt6 插件的私有 ABI 不匹配。
+FCITX5_PLUGIN_DIR="$(mktemp -d /tmp/dsh-pet-fcitx-package.XXXXXX)"
+trap 'rm -rf "$FCITX5_PLUGIN_DIR"' EXIT
+FCITX5_PLUGIN="$FCITX5_PLUGIN_DIR/libfcitx5platforminputcontextplugin.so"
+"$ROOT/scripts/build_pyside6_fcitx_plugin.sh" "$PYTHON_BIN" "$FCITX5_PLUGIN"
+
 IFS=',' read -ra variant_list <<< "$VARIANTS"
 for variant in "${variant_list[@]}"; do
     case "$variant" in
@@ -59,6 +65,7 @@ for variant in "${variant_list[@]}"; do
         --collect-all imageio_ffmpeg
         --collect-all certifi
         --collect-all PySide6.QtMultimedia
+        --add-binary "$FCITX5_PLUGIN:PySide6/Qt/plugins/platforminputcontexts"
         --add-data "$assets:$assets"
         --add-data "assets/sounds:assets/sounds"
         --add-data "assets/chat:assets/chat"

--- a/scripts/build_pyside6_fcitx_plugin.sh
+++ b/scripts/build_pyside6_fcitx_plugin.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# 为 PySide6 自带 Qt 构建 ABI 匹配的 Fcitx5 Qt6 输入法插件。
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+    echo "用法: $0 <python-bin> <output-plugin-path>" >&2
+    exit 2
+fi
+
+PYTHON_BIN="$1"
+OUTPUT_PLUGIN="$2"
+FCITX5_QT_TAG="5.1.14"
+
+# 仅依赖构建环境提供的工具与 Qt6 私有开发头文件，缺失时给出可执行的错误信息。
+for required in cmake git perl; do
+    if ! command -v "$required" >/dev/null; then
+        echo "缺少构建工具: $required" >&2
+        exit 1
+    fi
+done
+SYSTEM_INPUT_CONTEXT_HEADER="$(find /usr/include -type f -path '*/QtGui/*/QtGui/qpa/qplatforminputcontext.h' -print -quit)"
+if [[ -z "$SYSTEM_INPUT_CONTEXT_HEADER" ]]; then
+    echo "缺少 qt6-base-private-dev；无法构建 PySide6 Fcitx 插件。" >&2
+    exit 1
+fi
+
+# 从实际 PySide6 运行库读取 Qt 精确版本，插件的私有 QPA 头文件必须与它一一对应。
+PYSIDE_QT_VERSION="$($PYTHON_BIN -c 'from PySide6.QtCore import qVersion; print(qVersion())')"
+PYSIDE_QT_LIB="$($PYTHON_BIN -c 'from pathlib import Path; import PySide6; print(Path(PySide6.__file__).resolve().parent / "Qt" / "lib")')"
+if [[ ! "$PYSIDE_QT_VERSION" =~ ^6\.[0-9]+\.[0-9]+$ ]] || [[ ! -f "$PYSIDE_QT_LIB/libQt6Gui.so.6" ]]; then
+    echo "无法识别 PySide6 Qt 运行库版本或路径。" >&2
+    exit 1
+fi
+
+# 所有源码、覆盖头文件和对象文件都在临时目录；只把最终插件复制到调用方指定位置。
+WORK_DIR="$(mktemp -d /tmp/dsh-pet-fcitx-plugin.XXXXXX)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+QTBASE_SOURCE="$WORK_DIR/qtbase"
+FCITX_SOURCE="$WORK_DIR/fcitx5-qt"
+HEADER_OVERLAY="$WORK_DIR/header-overlay/qpa"
+BUILD_DIR="$WORK_DIR/build"
+mkdir -p "$HEADER_OVERLAY"
+
+git clone --depth 1 --branch "v$PYSIDE_QT_VERSION" https://code.qt.io/qt/qtbase.git "$QTBASE_SOURCE"
+git clone --depth 1 --branch "$FCITX5_QT_TAG" https://github.com/fcitx/fcitx5-qt.git "$FCITX_SOURCE"
+
+# 覆盖平台输入上下文实际使用的 QPA 私有头文件，修正 Qt 6.4 开发包与 PySide6 Qt 的布局差异。
+for header in qplatformcursor.h qplatforminputcontext.h qplatforminputcontextplugin_p.h qplatformnativeinterface.h qplatformscreen.h qwindowsysteminterface.h; do
+    cp "$QTBASE_SOURCE/src/gui/kernel/$header" "$HEADER_OVERLAY/$header"
+done
+
+cmake -S "$FCITX_SOURCE" -B "$BUILD_DIR" \
+    -DBUILD_ONLY_PLUGIN=ON \
+    -DENABLE_QT4=OFF \
+    -DENABLE_QT5=OFF \
+    -DENABLE_QT6=ON \
+    -DENABLE_QT6_WAYLAND_WORKAROUND=OFF \
+    "-DCMAKE_CXX_FLAGS=-I$WORK_DIR/header-overlay"
+
+# CMake 用系统 Qt6 头文件完成目标配置；先编译对象，最终链接改为 PySide6 自带 Qt 运行库。
+set +e
+cmake --build "$BUILD_DIR" --target fcitx5platforminputcontextplugin-qt6 -j2 >"$WORK_DIR/compile.log" 2>&1
+set -e
+LINK_FILE="$BUILD_DIR/qt6/platforminputcontext/CMakeFiles/fcitx5platforminputcontextplugin-qt6.dir/link.txt"
+if [[ ! -f "$LINK_FILE" ]]; then
+    cat "$WORK_DIR/compile.log" >&2
+    exit 1
+fi
+perl -pi -e "s#/usr/lib/[^ ]*/libQt6Widgets\\.so[^ ]*#$PYSIDE_QT_LIB/libQt6Widgets.so.6#g; s#/usr/lib/[^ ]*/libQt6Gui\\.so[^ ]*#$PYSIDE_QT_LIB/libQt6Gui.so.6#g; s#/usr/lib/[^ ]*/libQt6DBus\\.so[^ ]*#$PYSIDE_QT_LIB/libQt6DBus.so.6#g; s#/usr/lib/[^ ]*/libQt6Core\\.so[^ ]*#$PYSIDE_QT_LIB/libQt6Core.so.6#g" "$LINK_FILE"
+(
+    cd "$BUILD_DIR/qt6/platforminputcontext"
+    /bin/sh "$LINK_FILE"
+)
+
+# 构建产物必须存在且引用 PySide6 Qt 版本的扩展按键接口，避免回退到系统 Qt 6.4 ABI。
+BUILT_PLUGIN="$BUILD_DIR/qt6/platforminputcontext/libfcitx5platforminputcontextplugin.so"
+if [[ ! -f "$BUILT_PLUGIN" ]] || ! nm -D --demangle "$BUILT_PLUGIN" | grep -q 'handleExtendedKeyEvent'; then
+    echo "Fcitx5 Qt6 插件构建不完整。" >&2
+    exit 1
+fi
+mkdir -p "$(dirname "$OUTPUT_PLUGIN")"
+cp "$BUILT_PLUGIN" "$OUTPUT_PLUGIN"

--- a/tests/test_bundle_encoding_check.py
+++ b/tests/test_bundle_encoding_check.py
@@ -143,3 +143,16 @@ class TestBundleChecks:
         asset.parent.joinpath("吃Token").mkdir()
         errors = checker.check_bundle(root)
         assert any("吃Token" in error for error in errors)
+
+
+# Linux 回归：Fcitx 会话必须保留 fcitx 输入法上下文，供随包的匹配 Qt 插件加载。
+def test_linux_fcitx_session_preserves_fcitx_input_context(monkeypatch):
+    from pet import app as app_mod
+
+    monkeypatch.setattr(app_mod.sys, "platform", "linux")
+    monkeypatch.setenv("XMODIFIERS", "@im=fcitx")
+    monkeypatch.setenv("QT_IM_MODULE", "fcitx")
+
+    app_mod._configure_linux_fcitx_input_method()
+
+    assert app_mod.os.environ["QT_IM_MODULE"] == "fcitx"

--- a/tests/test_requested_regressions.py
+++ b/tests/test_requested_regressions.py
@@ -597,6 +597,28 @@ def test_windows_settings_has_no_orphan_macos_dock_toggle(tmp_path, monkeypatch)
     app.processEvents()
 
 
+# Linux 回归：Windows 专属开关不得在非 Windows 平台创建后游离到设置窗左上角。
+def test_linux_settings_has_no_orphan_windows_cursor_passthrough_toggle(tmp_path, monkeypatch):
+    from PySide6.QtWidgets import QApplication
+
+    import pet.modern_settings_dialog as settings_mod
+    from pet.config import Config
+
+    app = QApplication.instance() or QApplication([])
+    monkeypatch.setattr(settings_mod.sys, "platform", "linux")
+    monkeypatch.setattr(settings_mod.autostart_mod, "is_enabled", lambda: False)
+    dialog = settings_mod.ModernSettingsDialog(Config(tmp_path), include_ai=False)
+
+    assert dialog.cursor_hidden_passthrough_check is None
+    assert not any(
+        isinstance(child, settings_mod.ToggleSwitch)
+        for child in dialog.children()
+    ), "所有开关都必须被设置行接管，不能游离在窗口左上角"
+
+    dialog.close()
+    app.processEvents()
+
+
 def test_hide_pet_notifies_and_dock_click_restores(tmp_path, monkeypatch):
     """用户主动隐藏：弹托盘提示 + macOS 点击 Dock 图标恢复桌宠。"""
     import sys


### PR DESCRIPTION
## AI 修改

本 PR 由 AI 协助实现和验证。

## 有什么问题

- PySide6 内置 Qt 与系统 Fcitx5 Qt6 插件的私有 ABI 不兼容，导致 Linux 下所有文本控件无法用 Fcitx/Rime 输入中文。
- Linux 设置页错误创建未进入布局的 Windows 专属「光标隐藏自动穿透」开关，使其显示在窗口左上角。

## 修复了什么

- 新增构建脚本：按当前 PySide6 Qt 的精确版本临时构建 ABI 匹配的 Fcitx5 Qt6 输入法插件，并在 Linux 打包时放入标准 Qt 插件目录。
- Linux Fcitx 会话保留或默认选择 `QT_IM_MODULE=fcitx`，并在 `QApplication` 创建前完成配置。
- 仅在 Windows 创建光标隐藏自动穿透开关，避免非 Windows 平台出现游离控件。
- Linux CI 安装插件构建依赖，并验证最终产物包含 Fcitx 插件。

## 验证

- 真实 Fcitx/Rime 探针：`nihao` 加空格上屏为 `你好`。
- 冻结 Linux 成功加载随包 Fcitx 插件。
- `XDG_DATA_HOME=/tmp/dsh-pet-pytest-data QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest -q`：`665 passed, 10 skipped`。