### PR TITLE
fix: dsh 启动链路静默化——探测窗口隐藏 + --no-open 探测落盘缓存

### DIFF
--- a/pet/agent_link.py
+++ b/pet/agent_link.py
@@ -62,6 +62,12 @@ log = logging.getLogger("dsh-pet-standalone")
 DSH_PLUGIN_NAME = "@dsh-pet/bridge"
 DSH_PROFILE_HOME = Path(os.environ.get("DSH_HOME", str(Path.home() / ".dsh")))
 
+# Windows 探测/安装子进程隐藏窗口（与 harness_launcher 同款）：桌宠是无控制台
+# 的 GUI 进程，node/cmd 子进程不隐藏会弹出可见终端窗口。
+_HIDDEN_KWARGS: dict = (
+    {"creationflags": subprocess.CREATE_NO_WINDOW} if os.name == "nt" else {}
+)
+
 
 def _real_profiles() -> list[Path]:
     """真实存在的 dsh profile：profiles 目录下含 package.json 的子目录。
@@ -149,6 +155,7 @@ def _run_pnpm(profile_dir: Path, *args: str) -> tuple[int, str]:
             [node, cli, *args], capture_output=True, text=True,
             timeout=300, shell=False, cwd=str(profile_dir),
             env={**os.environ, "PATH": _augmented_path()},
+            **_HIDDEN_KWARGS,
         )
         return proc.returncode, (proc.stdout or "") + (proc.stderr or "")
     except Exception as exc:

--- a/pet/harness_launcher.py
+++ b/pet/harness_launcher.py
@@ -79,12 +79,22 @@ def _wrap_cmd(command: list[str]) -> list[str]:
 # 按基础命令缓存 `web --help` 是否包含 --no-open，避免每次点击菜单都探测
 _NO_OPEN_CACHE: dict[tuple[str, ...], bool] = {}
 
+# Windows 探测子进程必须隐藏窗口：桌宠是无控制台的 GUI 进程，console 类子进程
+# （cmd/node）不隐藏就会弹出可见终端窗口（开机自启场景实测复现：空终端窗口
+# 挂十几秒后消失）。
+_HIDDEN_KWARGS: dict = (
+    {"creationflags": subprocess.CREATE_NO_WINDOW} if os.name == "nt" else {}
+)
+
 
 def _supports_no_open(base_command: list[str]) -> bool:
     """探测 `web --help` 是否支持 --no-open。
 
     旧版 dsh（如 0.1.0-rc.3）没有该选项，强行传参会启动失败；探测失败/
     超时默认 False，宁可少传参数也不能让启动命令报 unknown option。
+    注意 dsh web --help 要初始化插件栈，热机也要 ~9s，超时给 30s
+    （开机等高负载场景 15s 会被打爆，误判为不支持 → 不带 --no-open →
+    dsh 自己弹浏览器，实测复现）。
     """
     key = tuple(str(part) for part in base_command)
     if key in _NO_OPEN_CACHE:
@@ -94,9 +104,10 @@ def _supports_no_open(base_command: list[str]) -> bool:
             [*base_command, "web", "--help"],
             capture_output=True,
             text=True,
-            timeout=15,
+            timeout=30,
             cwd=str(Path.home()),
             env={**os.environ, "PATH": _augmented_path()},
+            **_HIDDEN_KWARGS,
         )
         supported = "--no-open" in (result.stdout or "") or "--no-open" in (result.stderr or "")
     except Exception:
@@ -121,6 +132,7 @@ def _npm_global_roots() -> list[Path]:
             result = subprocess.run(
                 [npm, "root", "-g"], capture_output=True, text=True, timeout=15,
                 env={**os.environ, "PATH": _augmented_path()},
+                **_HIDDEN_KWARGS,
             )
             if result.returncode == 0 and result.stdout.strip():
                 roots.append(Path(result.stdout.strip()))

--- a/pet/harness_launcher.py
+++ b/pet/harness_launcher.py
@@ -16,6 +16,7 @@ nvm、volta、bun、pnpm 等常见安装目录后回退 npx；需要机器装有
 """
 from __future__ import annotations
 
+import json
 import os
 import socket
 import subprocess
@@ -87,18 +88,73 @@ _HIDDEN_KWARGS: dict = (
 )
 
 
-def _supports_no_open(base_command: list[str]) -> bool:
-    """探测 `web --help` 是否支持 --no-open。
+def _probe_cache_path() -> Path:
+    """--no-open 探测结果的落盘缓存路径（桌宠数据目录下）。"""
+    try:
+        from . import config as _config_mod
+        app_dir = str(getattr(_config_mod, "APP_DIR_NAME", "dsh-pet-standalone"))
+    except Exception:
+        app_dir = "dsh-pet-standalone"
+    if os.name == "nt":
+        base = Path(os.environ.get("APPDATA", str(Path.home() / "AppData" / "Roaming")))
+    else:
+        base = Path(os.environ.get("XDG_CONFIG_HOME", str(Path.home() / ".config")))
+    return base / app_dir / "harness_probe_cache.json"
 
-    旧版 dsh（如 0.1.0-rc.3）没有该选项，强行传参会启动失败；探测失败/
-    超时默认 False，宁可少传参数也不能让启动命令报 unknown option。
-    注意 dsh web --help 要初始化插件栈，热机也要 ~9s，超时给 30s
-    （开机等高负载场景 15s 会被打爆，误判为不支持 → 不带 --no-open →
-    dsh 自己弹浏览器，实测复现）。
+
+def _dsh_version(base_command: list[str]) -> str | None:
+    """快速取 dsh 版本（--version 不加载插件栈，秒回；失败返回 None）。"""
+    try:
+        result = subprocess.run(
+            [*base_command, "--version"],
+            capture_output=True, text=True, timeout=8,
+            cwd=str(Path.home()),
+            env={**os.environ, "PATH": _augmented_path()},
+            **_HIDDEN_KWARGS,
+        )
+        return (result.stdout or "").strip() or (result.stderr or "").strip() or None
+    except Exception:
+        return None
+
+
+def _no_open_disk_cache_read(base_command: list[str], *, allow_stale: bool = False) -> bool | None:
+    """读落盘缓存：默认仅当缓存的命令行与当前 dsh 版本都匹配才命中；
+    allow_stale=True 时跳过版本校验（仅作探测失败时的兜底）；否则 None。"""
+    try:
+        cache = json.loads(_probe_cache_path().read_text(encoding="utf-8"))
+        if cache.get("cmd") != [str(part) for part in base_command]:
+            return None
+        if not allow_stale:
+            version = _dsh_version(base_command)
+            if version is None or version != cache.get("version"):
+                return None
+        return bool(cache.get("no_open"))
+    except Exception:
+        return None
+
+
+def _no_open_disk_cache_write(base_command: list[str], supported: bool) -> None:
+    """慢探测成功后写落盘缓存（失败探测不写，避免把超时误判固化）。"""
+    try:
+        version = _dsh_version(base_command)
+        if version is None:
+            return
+        path = _probe_cache_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({
+            "cmd": [str(part) for part in base_command],
+            "version": version,
+            "no_open": bool(supported),
+        }), encoding="utf-8")
+    except Exception:
+        pass
+
+
+def _probe_no_open(base_command: list[str]) -> tuple[bool, bool]:
+    """慢探测 `web --help`：返回 (supported, probe_ok)。
+
+    超时/异常时 probe_ok=False——这是「不知道」，不是「不支持」，不得写缓存。
     """
-    key = tuple(str(part) for part in base_command)
-    if key in _NO_OPEN_CACHE:
-        return _NO_OPEN_CACHE[key]
     try:
         result = subprocess.run(
             [*base_command, "web", "--help"],
@@ -110,8 +166,33 @@ def _supports_no_open(base_command: list[str]) -> bool:
             **_HIDDEN_KWARGS,
         )
         supported = "--no-open" in (result.stdout or "") or "--no-open" in (result.stderr or "")
+        return supported, True
     except Exception:
-        supported = False
+        return False, False
+
+
+def _supports_no_open(base_command: list[str]) -> bool:
+    """探测 `web --help` 是否支持 --no-open。
+
+    三级缓存：进程内 dict → 落盘缓存（按 `dsh --version` 匹配——慢探测要初始
+    化插件栈，热机 ~9s，开机高负载 30s 也会超时；缓存使命中后零探测）→
+    慢探测。旧版 dsh（如 0.1.0-rc.3）没有该选项，强行传参会启动失败；探测
+    失败/超时默认 False，宁可少传参数也不能让启动命令报 unknown option。
+    """
+    key = tuple(str(part) for part in base_command)
+    if key in _NO_OPEN_CACHE:
+        return _NO_OPEN_CACHE[key]
+    supported = _no_open_disk_cache_read(base_command)
+    if supported is None:
+        supported, probe_ok = _probe_no_open(base_command)
+        if probe_ok:
+            _no_open_disk_cache_write(base_command, supported)
+        else:
+            # 慢探测失败（开机高负载超时）：用旧版本缓存兜底——命令行匹配说明
+            # 是同一个 dsh 安装，dsh 跨版本移除 CLI 参数的概率远低于探测超时
+            stale = _no_open_disk_cache_read(base_command, allow_stale=True)
+            if stale is not None:
+                supported = stale
     _NO_OPEN_CACHE[key] = supported
     return supported
 

--- a/tests/test_harness_launcher.py
+++ b/tests/test_harness_launcher.py
@@ -56,10 +56,11 @@ def test_find_launch_command_fallback_without_dsh(monkeypatch):
     assert os.path.basename(command[0]).lower() in allowed
 
 
-def test_supports_no_open_probes_help(monkeypatch):
+def test_supports_no_open_probes_help(monkeypatch, tmp_path):
     from pet import harness_launcher as hl
 
     hl._NO_OPEN_CACHE.clear()
+    monkeypatch.setattr(hl, "_probe_cache_path", lambda: tmp_path / "nope.json")
 
     def fake_run(*args, **kwargs):
         return SimpleNamespace(returncode=0, stdout="--no-open  Do not open browser", stderr="")
@@ -75,16 +76,56 @@ def test_supports_no_open_probes_help(monkeypatch):
     assert hl._supports_no_open(["dsh"]) is False
 
 
-def test_supports_no_open_probe_failure_defaults_false(monkeypatch):
+def test_supports_no_open_probe_failure_defaults_false(monkeypatch, tmp_path):
     from pet import harness_launcher as hl
 
     hl._NO_OPEN_CACHE.clear()
+    monkeypatch.setattr(hl, "_probe_cache_path", lambda: tmp_path / "nope.json")
 
     def fake_run_fail(*args, **kwargs):
         raise TimeoutError("probe timeout")
 
     monkeypatch.setattr(hl.subprocess, "run", fake_run_fail)
     assert hl._supports_no_open(["dsh"]) is False
+
+
+def test_supports_no_open_disk_cache(monkeypatch, tmp_path):
+    """落盘缓存：版本匹配时直接用缓存零探测；版本变了才重新慢探测。"""
+    import json as _json
+    from pet import harness_launcher as hl
+
+    cache_file = tmp_path / "cache.json"
+    monkeypatch.setattr(hl, "_probe_cache_path", lambda: cache_file)
+    monkeypatch.setattr(hl, "_dsh_version", lambda cmd: "0.1.1-rc.2")
+    hl._NO_OPEN_CACHE.clear()
+
+    def _explode(*args, **kwargs):
+        raise AssertionError("缓存命中时不应再跑慢探测")
+
+    # 缓存命中：probe 爆炸也不应被调用
+    cache_file.write_text(_json.dumps(
+        {"cmd": ["dsh"], "version": "0.1.1-rc.2", "no_open": True}), encoding="utf-8")
+    monkeypatch.setattr(hl, "_probe_no_open", _explode)
+    assert hl._supports_no_open(["dsh"]) is True
+
+    # 版本变了：缓存失效，回落到慢探测
+    monkeypatch.setattr(hl, "_dsh_version", lambda cmd: "0.1.2")
+    hl._NO_OPEN_CACHE.clear()
+    monkeypatch.setattr(hl, "_probe_no_open", lambda cmd: (False, True))
+    assert hl._supports_no_open(["dsh"]) is False
+
+    # 探测失败（probe_ok=False）不写缓存，避免把超时误判固化
+    hl._NO_OPEN_CACHE.clear()
+    monkeypatch.setattr(hl, "_probe_no_open", lambda cmd: (False, False))
+    assert hl._supports_no_open(["dsh"]) is False
+    # 缓存应保持第二段写入的 0.1.2 版本内容，未被失败探测覆盖
+    assert _json.loads(cache_file.read_text(encoding="utf-8"))["version"] == "0.1.2"
+
+    # 探测失败 + 版本不匹配的旧缓存 → 兜底沿用旧答案（开机超时不再误判）
+    cache_file.write_text(_json.dumps(
+        {"cmd": ["dsh"], "version": "9.9.9", "no_open": True}), encoding="utf-8")
+    hl._NO_OPEN_CACHE.clear()
+    assert hl._supports_no_open(["dsh"]) is True
 
 
 def test_launch_harness_reuses_existing_instance_on_alt_port(monkeypatch):


### PR DESCRIPTION
## 问题

「启动 DeepSeek Harness」/「随桌宠启动 dsh 服务」在 Windows 开机高负载场景下的两个实测问题：

1. **弹出一个空的可见终端窗口**（挂十几秒后消失）：`_supports_no_open`（`web --help` 探测）与 `_npm_global_roots`（`npm root -g` 探测）的探测子进程未隐藏窗口——桌宠是无控制台的 GUI 进程，console 类子进程会被分配可见终端
2. **dsh 启动后自己弹开浏览器**：`--no-open` 探测超时——`dsh web --help` 需初始化插件栈，热机实测约 9s，原 15s 超时在开机负载下必被打爆，探测失败按「不支持」处理导致启动命令不带 `--no-open`，dsh 按自身默认 openBrowser=true 打开浏览器

issue #10（双开浏览器）同根因：探测失败时 `--no-open` 缺失所致。

## 修法

- 所有探测/安装子进程（`_supports_no_open`、`_npm_global_roots`、`agent_link._run_pnpm`）加 `CREATE_NO_WINDOW` 隐藏窗口
- `--no-open` 探测超时 15s → 30s
- 探测结果三级缓存：进程内 dict → 落盘缓存（数据目录 `harness_probe_cache.json`，按 `dsh --version` 匹配，版本变了才重探）→ 慢探测。命中缓存后开机零探测
- 两个防误判护栏：探测失败（超时/异常）不写缓存，避免固化误判；版本不匹配且重探失败时沿用旧版本缓存答案兜底（同一安装跨版本移除 CLI 参数的概率远低于开机探测超时）

## 验证

- 新增磁盘缓存命中/版本失效重探/失败不写缓存/旧版本兜底 4 个用例，harness 相关测试 15/15 通过；全量 1372 passed / 7 skipped（另有 3 个本机环境既有失败与本次无关）
- 实机验证（Windows 11，dsh 0.1.1-rc.2）：开启「随桌宠启动 dsh 服务」后两次重启——无可见终端窗口、浏览器不再自动打开、dsh 服务静默就绪；缓存命中时从桌宠启动到 dsh 就绪约 10 秒
