### PR TITLE
fix: 子肥鱼生命周期修复（生成继承/一键退出）+ 边缘探头撞飞修复与彩蛋

### DIFF
--- a/pet/app.py
+++ b/pet/app.py
@@ -1383,21 +1383,15 @@ class AppShell:
             _show_startup_error('生小肥鱼失败', str(exc))
 
     def clear_spawned_pets(self) -> None:
-        """右键菜单快捷入口：确认后退出所有小肥鱼（设置与数据保留）。"""
+        """右键菜单快捷入口：一键静默退出所有小肥鱼（设置与数据保留）。
+
+        批 I：按用户要求去掉确认框与结果框——操作本身不删数据、子肥鱼可
+        随时重新生成，无需确认；子肥鱼消失本身就是反馈，结果写日志。
+        """
         from .child_pet_cleanup import clear_spawned_pets as cleanup_slots
 
         if self._clear_spawned_pending:
             # 链式关闭进行中：重复点击直接忽略（同一任务会清干净，保持幂等）。
-            return
-        parent = self.win if self.win is not None and hasattr(self.win, "winId") else None
-        answer = QMessageBox.question(
-            parent,
-            "退出子肥鱼",
-            "将退出所有已生成的小肥鱼。\n\n它们的设置与数据会保留，下次生成时原样恢复。确定继续吗？",
-            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.Cancel,
-            QMessageBox.StandardButton.Cancel,
-        )
-        if answer != QMessageBox.StandardButton.Yes:
             return
         # 单进程模式前置：进程内「非主窗」小肥鱼（PID=主进程）会被文件级清理的
         # pid==os.getpid() 自我保护跳过而永远清不掉，先按进程内子窗登记表枚举。
@@ -1406,19 +1400,19 @@ class AppShell:
         # 阻塞秒级）挪到后台 reaper 线程（批 G，_on_window_exit_requested 的
         # defer_heavy_teardown 路径），UI 线程只留关窗/摘标记等毫秒级必做步骤。
         # 全部关完再走文件级清理杀多进程子进程（同样在后台线程跑，taskkill
-        # 不再冻 UI）并弹结果框。两条路径都幂等，清完不留 runtime 标记残留。
+        # 不再冻 UI）。两条路径都幂等，清完不留 runtime 标记残留。
         refs = [weakref.ref(inst) for inst in self._instances
                 if inst is not self.instance]
         # 进行中标记两条路径统一前置：链式与纯文件级清理都覆盖（批 G 起文件级
         # 清理改后台线程，执行期间重复点击同样忽略）。
         self._clear_spawned_pending = True
         if not refs:
-            self._finish_clear_spawned_pets(cleanup_slots, parent)
+            self._finish_clear_spawned_pets(cleanup_slots)
             return
         QTimer.singleShot(
-            0, lambda: self._clear_spawned_chain(refs, 0, cleanup_slots, parent))
+            0, lambda: self._clear_spawned_chain(refs, 0, cleanup_slots))
 
-    def _clear_spawned_chain(self, refs, index: int, cleanup_slots, parent) -> None:
+    def _clear_spawned_chain(self, refs, index: int, cleanup_slots) -> None:
         """逐只异步关闭进程内子窗（每只之间让出事件循环，UI 不冻结）。
 
         窗口已销毁（弱引用失效）或已被关闭（不在登记表）则跳过；链尾执行
@@ -1426,7 +1420,7 @@ class AppShell:
         保证进行中标记一定复位。
         """
         if index >= len(refs):
-            self._finish_clear_spawned_pets(cleanup_slots, parent)
+            self._finish_clear_spawned_pets(cleanup_slots)
             return
         inst = refs[index]()
         if inst is not None and inst in self._instances:
@@ -1439,15 +1433,14 @@ class AppShell:
                     "清除子肥鱼：关闭进程内小肥鱼失败 (slot=%s)",
                     getattr(inst, "slot_id", None))
         QTimer.singleShot(
-            0, lambda: self._clear_spawned_chain(refs, index + 1, cleanup_slots, parent))
+            0, lambda: self._clear_spawned_chain(refs, index + 1, cleanup_slots))
 
-    def _finish_clear_spawned_pets(self, cleanup_slots, parent) -> None:
-        """链式关闭收口：文件级退出残余子进程 + 结果框，并复位进行中标记。
+    def _finish_clear_spawned_pets(self, cleanup_slots) -> None:
+        """链式关闭收口：文件级退出残余子进程，并复位进行中标记。
 
-        批 G：文件级清理（逐 pid taskkill，每个一次 subprocess 调用 + 杀后
-        确认轮询）移到后台线程——在 UI 线程同步执行会冻结主桌宠（实机复现）；
-        结果经 QTimer.singleShot 回 UI 线程弹框。进行中标记在回调里复位，
-        清理执行期间重复点击被忽略（幂等）。
+        批 G：文件级清理（逐 pid taskkill）移到后台线程——在 UI 线程同步执行
+        会冻结主桌宠（实机复现）；完成经 QTimer.singleShot 回 UI 线程复位标记。
+        批 I：按用户要求去掉结果弹窗——子肥鱼消失本身就是反馈，结果写日志。
         """
         config_dir = self.config.dir
 
@@ -1457,26 +1450,19 @@ class AppShell:
             except Exception:
                 logging.exception("退出子肥鱼：文件级清理失败")
                 result = {"killed_pids": [], "failed_pids": []}
+            logging.info(
+                "退出子肥鱼：已退出 %d 只，未能退出 %d 只",
+                len(result.get("killed_pids", [])),
+                len(result.get("failed_pids", [])))
             # 带 context 的 singleShot：从后台线程安全投递回 UI 线程。
-            QTimer.singleShot(
-                0, self.app,
-                lambda: self._show_clear_spawned_result(result, parent))
+            QTimer.singleShot(0, self.app, self._clear_spawned_sweep_done)
 
         threading.Thread(
             target=sweep, daemon=True, name="pet-clear-spawned-sweep").start()
 
-    def _show_clear_spawned_result(self, result: dict, parent) -> None:
-        """文件级清理完成回调（UI 线程）：复位进行中标记并弹结果框。"""
+    def _clear_spawned_sweep_done(self) -> None:
+        """文件级清理完成回调（UI 线程）：复位进行中标记。"""
         self._clear_spawned_pending = False
-        if parent is not None and not shiboken6.isValid(parent):
-            # 链式让出事件循环期间主窗可能已销毁：结果框降级为无父窗。
-            parent = None
-        killed = len(result.get("killed_pids", []))
-        failed = len(result.get("failed_pids", []))
-        text = f"已退出 {killed} 个小肥鱼进程；它们的设置与数据已保留。"
-        if failed:
-            text += f"\n\n{failed} 个小肥鱼未能退出（仍在运行），可再次执行或手动关闭。"
-        QMessageBox.information(parent, "退出子肥鱼", text)
 
     def spawn_in_process_window(self, offset_index: int = 1) -> PetInstance:
         """批5.2 spike：进程内创建第二个 PetInstance（不共享库/Config/SessionStore）。

--- a/pet/app.py
+++ b/pet/app.py
@@ -24,6 +24,7 @@ import os
 import sys
 import threading
 import time
+import weakref
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
@@ -902,6 +903,8 @@ class AppShell:
         # 每窗容器：批5.1 单进程单窗仅一个；批5.2 spike 扩成多窗集合
         #（self.instance 指主窗 = instances[0]，兼容既有调用面）。
         self._instances: list[PetInstance] = []
+        # 批 E：清除子肥鱼链式关闭进行中标记（重复点击忽略，保持幂等）。
+        self._clear_spawned_pending = False
         self.instance = PetInstance(
             self, config, enable_chat=self.enable_chat, slot_handle=slot_handle,
             slot_id=slot_id, spawn_offset=spawn_offset,
@@ -1377,6 +1380,9 @@ class AppShell:
         """右键菜单快捷入口：确认后关闭所有小肥鱼并删除 slot 数据。"""
         from .child_pet_cleanup import clear_spawned_pets as cleanup_slots
 
+        if self._clear_spawned_pending:
+            # 链式关闭进行中：重复点击直接忽略（同一任务会清干净，保持幂等）。
+            return
         parent = self.win if self.win is not None and hasattr(self.win, "winId") else None
         answer = QMessageBox.question(
             parent,
@@ -1388,36 +1394,55 @@ class AppShell:
         if answer != QMessageBox.StandardButton.Yes:
             return
         # 单进程模式前置：进程内「非主窗」小肥鱼（PID=主进程）会被文件级清理的
-        # pid==os.getpid() 自我保护跳过而永远清不掉，先按进程内子窗登记表枚举
-        # 并关闭它们；再走文件级清理杀多进程子进程。两条路径都幂等，清完不留
-        # runtime 标记残留（不依赖子进程标记里的单进程 flag——那是冻结值）。
-        self._close_spawned_in_process_windows()
-        result = cleanup_slots(self.config.dir)
+        # pid==os.getpid() 自我保护跳过而永远清不掉，先按进程内子窗登记表枚举。
+        # 关闭走 QTimer.singleShot(0) 逐只链式执行（每只之间让出事件循环）：每窗
+        # 子写盘 writer 关闭最多阻塞 2s、还有 agent 关闭等重操作，N 只同步执行
+        # 就是 N 倍 UI 冻结（半透明窗冻结时出黑框）。全部关完再走文件级清理杀
+        # 多进程子进程并弹结果框。两条路径都幂等，清完不留 runtime 标记残留。
+        refs = [weakref.ref(inst) for inst in self._instances
+                if inst is not self.instance]
+        if not refs:
+            self._finish_clear_spawned_pets(cleanup_slots, parent)
+            return
+        self._clear_spawned_pending = True
+        QTimer.singleShot(
+            0, lambda: self._clear_spawned_chain(refs, 0, cleanup_slots, parent))
+
+    def _clear_spawned_chain(self, refs, index: int, cleanup_slots, parent) -> None:
+        """逐只异步关闭进程内子窗（每只之间让出事件循环，UI 不冻结）。
+
+        窗口已销毁（弱引用失效）或已被关闭（不在登记表）则跳过；链尾执行
+        文件级清理并弹结果框。异常只记录不中断，保证进行中标记一定复位。
+        """
+        if index >= len(refs):
+            self._finish_clear_spawned_pets(cleanup_slots, parent)
+            return
+        inst = refs[index]()
+        if inst is not None and inst in self._instances:
+            try:
+                self._on_window_exit_requested(inst)
+            except Exception:
+                logging.exception(
+                    "清除子肥鱼：关闭进程内小肥鱼失败 (slot=%s)",
+                    getattr(inst, "slot_id", None))
+        QTimer.singleShot(
+            0, lambda: self._clear_spawned_chain(refs, index + 1, cleanup_slots, parent))
+
+    def _finish_clear_spawned_pets(self, cleanup_slots, parent) -> None:
+        """链式关闭收口：文件级清理 + 结果框，并复位进行中标记（异常也复位）。"""
+        try:
+            result = cleanup_slots(self.config.dir)
+        finally:
+            self._clear_spawned_pending = False
+        if parent is not None and not shiboken6.isValid(parent):
+            # 链式让出事件循环期间主窗可能已销毁：结果框降级为无父窗。
+            parent = None
         QMessageBox.information(
             parent,
             "清除子肥鱼",
             f"已关闭 {len(result['killed_pids'])} 个小肥鱼进程，"
             f"并清除 {len(result['deleted'])} 个 slot 数据项。",
         )
-
-    def _close_spawned_in_process_windows(self) -> list[PetInstance]:
-        """单进程模式前置：关闭所有进程内「非主窗」小肥鱼实例。
-
-        单进程 spawn 的子肥鱼是进程内窗口（PID = 主进程），会被
-        ``child_pet_cleanup`` 的 ``pid == os.getpid()`` 自我保护跳过。这里按进程
-        内子窗登记表（``self._instances``）枚举并逐窗走「退出这只」收口（删
-        runtime 标记、释放 slot 锁、关本窗 writer），确保单进程与多进程两种模式
-        下都被清干净。幂等：无子窗时为空操作；重复调用无残留。
-        """
-        primary = self.instance
-        children = [inst for inst in self._instances if inst is not primary]
-        for inst in children:
-            try:
-                self._on_window_exit_requested(inst)
-            except Exception:
-                logging.exception(
-                    "清除子肥鱼：关闭进程内小肥鱼失败 (slot=%s)", inst.slot_id)
-        return children
 
     def spawn_in_process_window(self, offset_index: int = 1) -> PetInstance:
         """批5.2 spike：进程内创建第二个 PetInstance（不共享库/Config/SessionStore）。

--- a/pet/app.py
+++ b/pet/app.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import queue
 import sys
 import threading
 import time
@@ -359,7 +360,12 @@ class PetInstance:
         win.on_open_legacy_settings = None
         win.on_open_modern_settings = self._slot_wrap(self.open_modern_settings)
         win.on_spawn_pet = self._slot_wrap(self.shell.spawn_pet)
-        win.on_clear_spawned_pets = self._slot_wrap(self.shell.clear_spawned_pets)
+        # 「退出子肥鱼」只挂给主肥鱼（instance_id 为空）：子肥鱼进程里该入口的
+        # pid==os.getpid() 自我保护会跳过子鱼自己、把主鱼当子鱼 taskkill 掉
+        #（实机事故：从子鱼触发清除 → 主鱼被杀、触发的那只子鱼存活）。
+        win.on_clear_spawned_pets = (
+            self._slot_wrap(self.shell.clear_spawned_pets)
+            if not self.config.instance_id else None)
         win.on_open_todo_panel = self._slot_wrap(self.shell.open_todo_panel)
         win.on_restore_fun_windows = restore_ojingjing_windows
         win.on_hidden = self._slot_wrap(self._notify_pet_hidden)
@@ -1395,16 +1401,20 @@ class AppShell:
             return
         # 单进程模式前置：进程内「非主窗」小肥鱼（PID=主进程）会被文件级清理的
         # pid==os.getpid() 自我保护跳过而永远清不掉，先按进程内子窗登记表枚举。
-        # 关闭走 QTimer.singleShot(0) 逐只链式执行（每只之间让出事件循环）：每窗
-        # 子写盘 writer 关闭最多阻塞 2s、还有 agent 关闭等重操作，N 只同步执行
-        # 就是 N 倍 UI 冻结（半透明窗冻结时出黑框）。全部关完再走文件级清理杀
-        # 多进程子进程并弹结果框。两条路径都幂等，清完不留 runtime 标记残留。
+        # 关闭走 QTimer.singleShot(0) 逐只链式执行（每只之间让出事件循环），且
+        # 每窗的重资源回收（writer 关闭/agent shutdown/碰撞会话停止，各有界
+        # 阻塞秒级）挪到后台 reaper 线程（批 G，_on_window_exit_requested 的
+        # defer_heavy_teardown 路径），UI 线程只留关窗/摘标记等毫秒级必做步骤。
+        # 全部关完再走文件级清理杀多进程子进程（同样在后台线程跑，taskkill
+        # 不再冻 UI）并弹结果框。两条路径都幂等，清完不留 runtime 标记残留。
         refs = [weakref.ref(inst) for inst in self._instances
                 if inst is not self.instance]
+        # 进行中标记两条路径统一前置：链式与纯文件级清理都覆盖（批 G 起文件级
+        # 清理改后台线程，执行期间重复点击同样忽略）。
+        self._clear_spawned_pending = True
         if not refs:
             self._finish_clear_spawned_pets(cleanup_slots, parent)
             return
-        self._clear_spawned_pending = True
         QTimer.singleShot(
             0, lambda: self._clear_spawned_chain(refs, 0, cleanup_slots, parent))
 
@@ -1421,7 +1431,9 @@ class AppShell:
         inst = refs[index]()
         if inst is not None and inst in self._instances:
             try:
-                self._on_window_exit_requested(inst)
+                # 批 G：链式路径重资源回收后台化（writer/agent/碰撞的有界 join
+                # 移出 UI 线程），每窗 UI 线程单步阻塞压到毫秒级。
+                self._on_window_exit_requested(inst, defer_heavy_teardown=True)
             except Exception:
                 logging.exception(
                     "清除子肥鱼：关闭进程内小肥鱼失败 (slot=%s)",
@@ -1430,20 +1442,41 @@ class AppShell:
             0, lambda: self._clear_spawned_chain(refs, index + 1, cleanup_slots, parent))
 
     def _finish_clear_spawned_pets(self, cleanup_slots, parent) -> None:
-        """链式关闭收口：文件级退出残余子进程 + 结果框，并复位进行中标记。"""
-        try:
-            result = cleanup_slots(self.config.dir)
-        finally:
-            self._clear_spawned_pending = False
+        """链式关闭收口：文件级退出残余子进程 + 结果框，并复位进行中标记。
+
+        批 G：文件级清理（逐 pid taskkill，每个一次 subprocess 调用 + 杀后
+        确认轮询）移到后台线程——在 UI 线程同步执行会冻结主桌宠（实机复现）；
+        结果经 QTimer.singleShot 回 UI 线程弹框。进行中标记在回调里复位，
+        清理执行期间重复点击被忽略（幂等）。
+        """
+        config_dir = self.config.dir
+
+        def sweep() -> None:
+            try:
+                result = cleanup_slots(config_dir)
+            except Exception:
+                logging.exception("退出子肥鱼：文件级清理失败")
+                result = {"killed_pids": [], "failed_pids": []}
+            # 带 context 的 singleShot：从后台线程安全投递回 UI 线程。
+            QTimer.singleShot(
+                0, self.app,
+                lambda: self._show_clear_spawned_result(result, parent))
+
+        threading.Thread(
+            target=sweep, daemon=True, name="pet-clear-spawned-sweep").start()
+
+    def _show_clear_spawned_result(self, result: dict, parent) -> None:
+        """文件级清理完成回调（UI 线程）：复位进行中标记并弹结果框。"""
+        self._clear_spawned_pending = False
         if parent is not None and not shiboken6.isValid(parent):
             # 链式让出事件循环期间主窗可能已销毁：结果框降级为无父窗。
             parent = None
-        QMessageBox.information(
-            parent,
-            "退出子肥鱼",
-            f"已退出 {len(result['killed_pids'])} 个小肥鱼进程；"
-            f"它们的设置与数据已保留。",
-        )
+        killed = len(result.get("killed_pids", []))
+        failed = len(result.get("failed_pids", []))
+        text = f"已退出 {killed} 个小肥鱼进程；它们的设置与数据已保留。"
+        if failed:
+            text += f"\n\n{failed} 个小肥鱼未能退出（仍在运行），可再次执行或手动关闭。"
+        QMessageBox.information(parent, "退出子肥鱼", text)
 
     def spawn_in_process_window(self, offset_index: int = 1) -> PetInstance:
         """批5.2 spike：进程内创建第二个 PetInstance（不共享库/Config/SessionStore）。
@@ -1509,7 +1542,8 @@ class AppShell:
         logging.info("进程内新窗已创建 (slot=%s, instance=%s)", slot_id, instance_id)
         return inst
 
-    def _on_window_exit_requested(self, instance: PetInstance) -> None:
+    def _on_window_exit_requested(self, instance: PetInstance,
+                                  *, defer_heavy_teardown: bool = False) -> None:
         """窗级「退出这只」（R5 切分）：只收口本窗，不碰其它窗的进程级资源。
 
         顺序：存本窗位置 → 停本窗预热/Agent → 保存本窗三聊天窗 live session
@@ -1520,8 +1554,18 @@ class AppShell:
         从集合移除；若退的是主窗则把列表头提升为新主窗（P1-3）；若为最后一窗
         则触发全部退出（app.quit）。进程级仅剩 ``close_all_writers(permanent=True)``
         只在「全部退出」（托盘退出 / _on_about_to_quit）收口。
+
+        ``defer_heavy_teardown=True``（批 G，仅「退出子肥鱼」链式路径使用）：
+        把有界但秒级的重资源回收——本窗 sessions writer 关闭（最多 2s join）、
+        agent_link shutdown（最多 2s 共享 join）、碰撞会话停止（最多 3s+1s
+        wait）——挪到进程级后台 reaper 线程串行执行；UI 线程只保留关窗、
+        摘 runtime 标记、释放 slot 锁、从登记表移除等毫秒级必做步骤，
+        N 只连清时主桌宠不再冻结。默认 False = 「退出这只」单窗路径保持
+        既有同步语义逐位不变。重回收只做线程 join / queued 调用 / 纯 Python
+        注册表操作，不触碰 Qt 对象，后台执行安全。
         """
         win = instance.win
+        heavy_jobs: list[tuple[str, object]] = []  # defer 模式的重回收任务
         if win is not None:
             try:
                 win.save_position()
@@ -1532,11 +1576,18 @@ class AppShell:
                     win.lib.pause_warm()
             except Exception:
                 logging.exception("退出这只：暂停预热失败")
-            if getattr(win, 'agent_link_manager', None) is not None:
-                try:
-                    win.agent_link_manager.shutdown()
-                except Exception:
-                    logging.exception("退出这只：关闭 Agent 失败")
+            agent_mgr = getattr(win, 'agent_link_manager', None)
+            if agent_mgr is not None:
+                if defer_heavy_teardown:
+                    # 摘下引用再关窗：closeEvent 也会调 shutdown()，不在 UI
+                    # 线程重复 join（reaper 统一收口，shutdown 幂等）。
+                    win.agent_link_manager = None
+                    heavy_jobs.append(("关闭 Agent", agent_mgr.shutdown))
+                else:
+                    try:
+                        agent_mgr.shutdown()
+                    except Exception:
+                        logging.exception("退出这只：关闭 Agent 失败")
         # 批5.2 P0-2：先保存本窗三聊天窗的 live session，再关写盘 writer
         #（对齐 aboutToQuit 安全网：退出该窗不丢内存态会话）。
         for _w in (instance.legacy_chat_window, instance.modern_chat_window, instance.quick_chat):
@@ -1558,7 +1609,14 @@ class AppShell:
                 except Exception:
                     logging.exception("退出这只：删除 runtime 标记失败")
         # 批5.2 P1-7：运行期关窗不许冻 GUI 10s——只关本窗 writer，timeout 降到 2s。
-        self._close_instance_session_writer(instance)
+        # 批 G：defer 模式下这 2s 有界 join 也挪到 reaper 线程（会话保存已在
+        # 上方同步完成，顺序由 reaper 串行保证）。
+        if defer_heavy_teardown:
+            heavy_jobs.append(
+                ("关闭会话写盘 worker",
+                 lambda: self._close_instance_session_writer(instance)))
+        else:
+            self._close_instance_session_writer(instance)
         if instance.slot_handle is not None:
             try:
                 slot_manager_mod._unlock_file(instance.slot_handle)
@@ -1568,10 +1626,15 @@ class AppShell:
         # 批5.2 P1-1：停本窗自持的碰撞会话（只影响本窗）。批5.3 起 broker_facade
         # 指向进程级 DecodeFanoutHub，其 shutdown() 为 no-op——保留调用仅为
         # 形态对齐，不会误停共享 hub。
-        try:
-            instance.collision_ipc.stop()
-        except Exception:
-            logging.exception("退出这只：停止碰撞会话失败")
+        # 批 G：defer 模式下碰撞会话的 stop（QThread.wait 最多 3s+1s）挪到
+        # reaper 线程；stop 内部对 worker 的调用是 queued 语义，线程安全。
+        if defer_heavy_teardown:
+            heavy_jobs.append(("停止碰撞会话", instance.collision_ipc.stop))
+        else:
+            try:
+                instance.collision_ipc.stop()
+            except Exception:
+                logging.exception("退出这只：停止碰撞会话失败")
         try:
             instance.broker_facade.shutdown()
         except Exception:
@@ -1589,9 +1652,41 @@ class AppShell:
             # 托盘/灵动岛/Dock 动作永远指向存活实例，防「复活」已退出的主窗。
             self.instance = self._instances[0] if self._instances else None
         self._refresh_tray_menu()
+        if heavy_jobs:
+            self._enqueue_heavy_teardown(instance, heavy_jobs)
         if not self._instances:
             # 最后一窗关闭 → 走全部退出语义（进程级 broker/碰撞/permanent writer 收口）
             self.app.quit()
+
+    def _teardown_reaper_queue(self) -> "queue.Queue":
+        """懒创建的进程级重资源回收队列（批 G）：单条 daemon 线程串行执行
+        各窗退出时的 writer 关闭 / agent shutdown / 碰撞停止（都是有界但
+        秒级的线程 join/wait），UI 线程因此不被阻塞。daemon：进程退出不强等
+        （aboutToQuit 的进程级收口另有兜底），队列任务失败只记录不中断。"""
+        q = getattr(self, "_teardown_queue", None)
+        if q is None:
+            q = queue.Queue()
+
+            def reap() -> None:
+                while True:
+                    jobs = q.get()
+                    for label, fn in jobs:
+                        try:
+                            fn()
+                        except Exception:
+                            logging.exception("退出子肥鱼：后台重回收失败 (%s)", label)
+
+            threading.Thread(
+                target=reap, daemon=True, name="pet-teardown-reaper").start()
+            self._teardown_queue = q
+        return q
+
+    def _enqueue_heavy_teardown(self, instance: PetInstance, jobs: list) -> None:
+        """把一窗的重回收任务排进 reaper（幂等：同一实例只排一次）。"""
+        if getattr(instance, "_heavy_teardown_enqueued", False):
+            return
+        instance._heavy_teardown_enqueued = True
+        self._teardown_reaper_queue().put(jobs)
 
     def _close_instance_subwindows(self, instance: PetInstance) -> None:
         """批5.2 P1-5：关闭本窗拥有的聊天窗/设置窗并断开引用。

--- a/pet/app.py
+++ b/pet/app.py
@@ -1454,7 +1454,9 @@ class AppShell:
             raise slot_manager_mod.SlotManagerError(
                 "进程内生小肥鱼：前 128 个槽位均被占用或无法获取锁")
         instance_id = slot_manager_mod.slot_to_instance_id(slot_id)
-        # 新 slot 落种：首次多开跟随主设置（已有存档的 slot 不动）。
+        # 新 slot 落种：走共享落种函数。无存档 slot 按主设置落种；存在但未在该
+        # 子肥鱼设置界面自定义过的 slot 按主设置刷新；已自定义（user_customized）
+        # 的 slot 一个键都不碰。落种/刷新永不写位置键。
         slot_manager_mod.seed_slot_config_from_main(self.config.dir, slot_id)
         # 复用主窗同一配置根目录（AppShell.config.dir 的父目录），使所有窗的
         # config-slot-N.json / sessions-slot-N 落在同一 APP_DIR_NAME 下，仅按
@@ -1947,7 +1949,9 @@ def main(argv: list[str] | None = None, enable_chat: bool = True) -> int:
         if slot_id == 0:
             slot_manager_mod.migrate_legacy_spawns(config_dir)
 
-        # 新 slot 落种：首次多开的实例跟随主设置（已有存档的 slot 不动）。
+        # 新 slot 落种：走共享落种函数。无存档 slot 按主设置落种；存在但未在该
+        # 子肥鱼设置界面自定义过的 slot 按主设置刷新；已自定义（user_customized）
+        # 的 slot 一个键都不碰。落种/刷新永不写位置键。
         slot_manager_mod.seed_slot_config_from_main(config_dir, slot_id)
 
         config = Config(instance_id=instance_id)

--- a/pet/app.py
+++ b/pet/app.py
@@ -1387,6 +1387,11 @@ class AppShell:
         )
         if answer != QMessageBox.StandardButton.Yes:
             return
+        # 单进程模式前置：进程内「非主窗」小肥鱼（PID=主进程）会被文件级清理的
+        # pid==os.getpid() 自我保护跳过而永远清不掉，先按进程内子窗登记表枚举
+        # 并关闭它们；再走文件级清理杀多进程子进程。两条路径都幂等，清完不留
+        # runtime 标记残留（不依赖子进程标记里的单进程 flag——那是冻结值）。
+        self._close_spawned_in_process_windows()
         result = cleanup_slots(self.config.dir)
         QMessageBox.information(
             parent,
@@ -1394,6 +1399,25 @@ class AppShell:
             f"已关闭 {len(result['killed_pids'])} 个小肥鱼进程，"
             f"并清除 {len(result['deleted'])} 个 slot 数据项。",
         )
+
+    def _close_spawned_in_process_windows(self) -> list[PetInstance]:
+        """单进程模式前置：关闭所有进程内「非主窗」小肥鱼实例。
+
+        单进程 spawn 的子肥鱼是进程内窗口（PID = 主进程），会被
+        ``child_pet_cleanup`` 的 ``pid == os.getpid()`` 自我保护跳过。这里按进程
+        内子窗登记表（``self._instances``）枚举并逐窗走「退出这只」收口（删
+        runtime 标记、释放 slot 锁、关本窗 writer），确保单进程与多进程两种模式
+        下都被清干净。幂等：无子窗时为空操作；重复调用无残留。
+        """
+        primary = self.instance
+        children = [inst for inst in self._instances if inst is not primary]
+        for inst in children:
+            try:
+                self._on_window_exit_requested(inst)
+            except Exception:
+                logging.exception(
+                    "清除子肥鱼：关闭进程内小肥鱼失败 (slot=%s)", inst.slot_id)
+        return children
 
     def spawn_in_process_window(self, offset_index: int = 1) -> PetInstance:
         """批5.2 spike：进程内创建第二个 PetInstance（不共享库/Config/SessionStore）。

--- a/pet/app.py
+++ b/pet/app.py
@@ -1377,7 +1377,7 @@ class AppShell:
             _show_startup_error('生小肥鱼失败', str(exc))
 
     def clear_spawned_pets(self) -> None:
-        """右键菜单快捷入口：确认后关闭所有小肥鱼并删除 slot 数据。"""
+        """右键菜单快捷入口：确认后退出所有小肥鱼（设置与数据保留）。"""
         from .child_pet_cleanup import clear_spawned_pets as cleanup_slots
 
         if self._clear_spawned_pending:
@@ -1386,8 +1386,8 @@ class AppShell:
         parent = self.win if self.win is not None and hasattr(self.win, "winId") else None
         answer = QMessageBox.question(
             parent,
-            "清除子肥鱼",
-            "将关闭所有已生成的小肥鱼，并删除它们的配置、会话与待办数据。\n\n此操作不可撤销，确定继续吗？",
+            "退出子肥鱼",
+            "将退出所有已生成的小肥鱼。\n\n它们的设置与数据会保留，下次生成时原样恢复。确定继续吗？",
             QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.Cancel,
             QMessageBox.StandardButton.Cancel,
         )
@@ -1412,7 +1412,8 @@ class AppShell:
         """逐只异步关闭进程内子窗（每只之间让出事件循环，UI 不冻结）。
 
         窗口已销毁（弱引用失效）或已被关闭（不在登记表）则跳过；链尾执行
-        文件级清理并弹结果框。异常只记录不中断，保证进行中标记一定复位。
+        文件级收尾（杀残余多进程子进程）并弹结果框。异常只记录不中断，
+        保证进行中标记一定复位。
         """
         if index >= len(refs):
             self._finish_clear_spawned_pets(cleanup_slots, parent)
@@ -1429,7 +1430,7 @@ class AppShell:
             0, lambda: self._clear_spawned_chain(refs, index + 1, cleanup_slots, parent))
 
     def _finish_clear_spawned_pets(self, cleanup_slots, parent) -> None:
-        """链式关闭收口：文件级清理 + 结果框，并复位进行中标记（异常也复位）。"""
+        """链式关闭收口：文件级退出残余子进程 + 结果框，并复位进行中标记。"""
         try:
             result = cleanup_slots(self.config.dir)
         finally:
@@ -1439,9 +1440,9 @@ class AppShell:
             parent = None
         QMessageBox.information(
             parent,
-            "清除子肥鱼",
-            f"已关闭 {len(result['killed_pids'])} 个小肥鱼进程，"
-            f"并清除 {len(result['deleted'])} 个 slot 数据项。",
+            "退出子肥鱼",
+            f"已退出 {len(result['killed_pids'])} 个小肥鱼进程；"
+            f"它们的设置与数据已保留。",
         )
 
     def spawn_in_process_window(self, offset_index: int = 1) -> PetInstance:

--- a/pet/child_pet_cleanup.py
+++ b/pet/child_pet_cleanup.py
@@ -8,6 +8,7 @@ slot 配置、会话与待办数据——子肥鱼的设置（含 user_customize
 from __future__ import annotations
 
 import json
+import logging
 import os
 import signal
 import subprocess
@@ -68,22 +69,47 @@ def _terminate_pet_process(pid: int) -> None:
             pass
 
 
+def _wait_pid_dead(pid: int, timeout: float = 2.0) -> bool:
+    """杀进程后确认其真的退出（taskkill 返回 ≠ 目标进程已消失）。有界轮询。"""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not _pid_alive(pid):
+            return True
+        time.sleep(0.05)
+    return not _pid_alive(pid)
+
+
 def clear_spawned_pets(config_dir: Path | str) -> dict:
     """关闭所有小肥鱼（slot-N）进程并清理其 runtime 标记。
 
     只退出进程，**不删除** slot 配置/会话/待办数据（子肥鱼设置保留，
     下次生成按占位语义恢复）。只处理非当前进程的 runtime 标记；
     slot-0 主肥鱼不受影响。
-    返回 {"killed_pids": [...]}。
+    返回 {"killed_pids": [...], "failed_pids": [...]}。
+
+    批 G：杀进程后必须确认进程真的死掉才删标记——旧实现「杀失败静默吞掉 +
+    无条件删标记」，子进程存活且痕迹清零（实机复现：第二只子肥鱼幸存），
+    且全程零日志无法排查。杀失败的 pid 保留标记并记入 failed_pids，
+    供下次重试/结果框呈报。
     """
     root = Path(config_dir)
     killed_pids: list[int] = []
+    failed_pids: list[int] = []
 
     # 关闭仍在运行的子肥鱼进程，并清理 runtime 标记。
     # 同时认旧名 runtime-*.json 与批5.2 版本化新名 pet-runtime-v2-*.json
     #（多进程模式只写 v2 名，旧 glob 匹配不到 → 子进程杀不掉）。
     markers = slot_manager_mod.list_runtime_marker_files(root)
+    if markers:
+        logging.info(
+            "退出子肥鱼：发现 %d 个 runtime 标记: %s",
+            len(markers), [m.name for m in markers])
     for marker in markers:
+        # 兜底防御：v2 标记名带 slot 编号，slot-0 是主肥鱼，永不杀（即便调用方
+        # 是子肥鱼进程——其 pid==os.getpid() 只跳过自己，主鱼标记会被误杀）。
+        if marker.name.startswith(slot_manager_mod._RUNTIME_V2_PREFIX):
+            if marker.name.rsplit("-slot-", 1)[-1].removesuffix(".json") == "0":
+                continue
         try:
             data = json.loads(marker.read_text(encoding="utf-8"))
             pid = int(data.get("pid", 0))
@@ -91,12 +117,26 @@ def clear_spawned_pets(config_dir: Path | str) -> dict:
             pid = 0
         if pid == os.getpid():
             continue
-        if _pid_alive(pid):
-            _terminate_pet_process(pid)
-            killed_pids.append(pid)
+        if pid > 0 and _pid_alive(pid):
+            logging.info("退出子肥鱼：结束子进程 pid=%d (%s)", pid, marker.name)
+            dead = False
+            for attempt in (1, 2):
+                _terminate_pet_process(pid)
+                if _wait_pid_dead(pid):
+                    dead = True
+                    break
+                logging.warning(
+                    "退出子肥鱼：第 %d 次结束 pid=%d 后进程仍存活", attempt, pid)
+            if dead:
+                killed_pids.append(pid)
+            else:
+                failed_pids.append(pid)
+                logging.warning(
+                    "退出子肥鱼：pid=%d 未能退出，保留标记供下次重试", pid)
+                continue  # 进程仍活：保留标记，不毁灭痕迹
         try:
             marker.unlink()
         except OSError:
             pass
 
-    return {"killed_pids": killed_pids}
+    return {"killed_pids": killed_pids, "failed_pids": failed_pids}

--- a/pet/child_pet_cleanup.py
+++ b/pet/child_pet_cleanup.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
-"""一键清除子肥鱼：关闭所有小肥鱼进程并删除 slot 配置/会话/待办数据。
+"""一键退出子肥鱼：关闭所有小肥鱼进程并清理 runtime 标记。
 
-只操作 config 目录下“非当前进程”的 runtime 标记与 slot-* 数据文件；
-主肥鱼（slot-0/config.json）不受影响。
+只退出子肥鱼进程/窗口（相当于一键退出其他所有子肥鱼），**不删除**它们的
+slot 配置、会话与待办数据——子肥鱼的设置（含 user_customized 占位）全部
+保留，下次生成时按占位语义恢复。主肥鱼（slot-0/config.json）不受影响。
 """
 from __future__ import annotations
 
 import json
 import os
-import shutil
 import signal
 import subprocess
 import time
@@ -69,16 +69,17 @@ def _terminate_pet_process(pid: int) -> None:
 
 
 def clear_spawned_pets(config_dir: Path | str) -> dict:
-    """关闭并清理所有小肥鱼（slot-N）数据。
+    """关闭所有小肥鱼（slot-N）进程并清理其 runtime 标记。
 
-    返回 {"killed_pids": [...], "deleted": [路径...]}。
-    只处理非当前进程的 runtime 标记；slot-0 主肥鱼配置不会被删除。
+    只退出进程，**不删除** slot 配置/会话/待办数据（子肥鱼设置保留，
+    下次生成按占位语义恢复）。只处理非当前进程的 runtime 标记；
+    slot-0 主肥鱼不受影响。
+    返回 {"killed_pids": [...]}。
     """
     root = Path(config_dir)
     killed_pids: list[int] = []
-    deleted: list[str] = []
 
-    # 1) 关闭仍在运行的子肥鱼进程，并清理 runtime 标记。
+    # 关闭仍在运行的子肥鱼进程，并清理 runtime 标记。
     # 同时认旧名 runtime-*.json 与批5.2 版本化新名 pet-runtime-v2-*.json
     #（多进程模式只写 v2 名，旧 glob 匹配不到 → 子进程杀不掉）。
     markers = slot_manager_mod.list_runtime_marker_files(root)
@@ -98,25 +99,4 @@ def clear_spawned_pets(config_dir: Path | str) -> dict:
         except OSError:
             pass
 
-    # 2) 删除 slot-N 的配置、会话与待办数据（主 config.json / sessions / todo_items.json 不碰）。
-    for pattern in ("config-slot-*.json", "todo_items-slot-*.json"):
-        try:
-            matches = list(root.glob(pattern))
-        except OSError:
-            matches = []
-        for path in matches:
-            try:
-                path.unlink()
-                deleted.append(str(path))
-            except OSError:
-                pass
-    try:
-        session_dirs = list(root.glob("sessions-slot-*"))
-    except OSError:
-        session_dirs = []
-    for directory in session_dirs:
-        if directory.is_dir():
-            shutil.rmtree(directory, ignore_errors=True)
-            deleted.append(str(directory))
-
-    return {"killed_pids": killed_pids, "deleted": deleted}
+    return {"killed_pids": killed_pids}

--- a/pet/child_pet_cleanup.py
+++ b/pet/child_pet_cleanup.py
@@ -12,6 +12,7 @@ import logging
 import os
 import signal
 import subprocess
+import sys
 import time
 from pathlib import Path
 
@@ -43,7 +44,8 @@ def _pid_alive(pid: int) -> bool:
 
 
 def _terminate_pet_process(pid: int) -> None:
-    """终止子肥鱼进程。Windows 使用 taskkill /T /F，POSIX 先 SIGTERM 再补 SIGKILL。"""
+    """终止子肥鱼进程。Windows 使用 taskkill /T /F（CREATE_NO_WINDOW 防 GUI 应用
+    每杀一只弹一个空白控制台窗口——实机反馈），POSIX 先 SIGTERM 再补 SIGKILL。"""
     if os.name == "nt":
         try:
             subprocess.run(
@@ -51,6 +53,8 @@ def _terminate_pet_process(pid: int) -> None:
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 timeout=5,
+                # GUI 进程（无控制台）里起 taskkill 会弹空白控制台窗口
+                creationflags=subprocess.CREATE_NO_WINDOW,
             )
         except Exception:
             pass
@@ -79,6 +83,70 @@ def _wait_pid_dead(pid: int, timeout: float = 2.0) -> bool:
     return not _pid_alive(pid)
 
 
+def _pid_image_path(pid: int) -> str | None:
+    """读取进程可执行文件路径（识别 pid 复用：陈旧标记的 pid 可能已被无关
+    进程复用，直接 taskkill 会误杀无辜进程或打不动受保护进程——实机事故）。
+    读不到（无权限/不支持）返回 None。"""
+    if pid <= 0:
+        return None
+    if os.name == "nt":
+        try:
+            import ctypes
+            from ctypes import wintypes
+            handle = ctypes.windll.kernel32.OpenProcess(0x1000, False, pid)
+            if not handle:
+                return None
+            try:
+                buf = ctypes.create_unicode_buffer(1024)
+                size = wintypes.DWORD(1024)
+                ok = ctypes.windll.kernel32.QueryFullProcessImageNameW(
+                    handle, 0, buf, ctypes.byref(size))
+                return buf.value if ok else None
+            finally:
+                ctypes.windll.kernel32.CloseHandle(handle)
+        except Exception:
+            return None
+    try:
+        return os.readlink(f"/proc/{pid}/exe")
+    except OSError:
+        return None
+
+
+def _is_pet_process(pid: int) -> bool:
+    """pid 对应的进程就是本程序（exe 路径与 sys.executable 一致）。
+
+    Windows 读不到镜像路径 = 受保护/无关进程，不放行；POSIX（macOS 无
+    /proc）读不到时保持既有行为放行。
+    """
+    img = _pid_image_path(pid)
+    if img is None:
+        return os.name != "nt"
+    return (os.path.normcase(os.path.normpath(img))
+            == os.path.normcase(os.path.normpath(sys.executable)))
+
+
+def _slot_lock_pids(root: Path) -> list[int]:
+    """从 slots/slot-*.lock 的定长 PID 记录读子槽位属主 pid——runtime 标记
+    之外的第二枚举源（没写过标记的小肥鱼也持有 slot 锁）。锁文件本身不删。
+    """
+    pids: list[int] = []
+    try:
+        locks = sorted((root / "slots").glob("slot-*.lock"))
+    except OSError:
+        return pids
+    for lock in locks:
+        if lock.stem == "slot-0":
+            continue  # 主肥鱼永不杀
+        try:
+            raw = lock.read_bytes()[:slot_manager_mod.PID_RECORD_LEN]
+            pid = int(raw.decode("ascii", errors="ignore").strip())
+        except (OSError, ValueError):
+            continue
+        if pid > 0:
+            pids.append(pid)
+    return pids
+
+
 def clear_spawned_pets(config_dir: Path | str) -> dict:
     """关闭所有小肥鱼（slot-N）进程并清理其 runtime 标记。
 
@@ -91,14 +159,37 @@ def clear_spawned_pets(config_dir: Path | str) -> dict:
     无条件删标记」，子进程存活且痕迹清零（实机复现：第二只子肥鱼幸存），
     且全程零日志无法排查。杀失败的 pid 保留标记并记入 failed_pids，
     供下次重试/结果框呈报。
+
+    批 H：①枚举源加 slots/slot-*.lock（没写过 runtime 标记的小肥鱼也持有
+    slot 锁，否则未拖动过的新鱼漏清）；②杀前用 exe 路径核验身份——陈旧
+    标记的 pid 可能已被无关进程复用，误杀会杀死无辜进程/打不动受保护进程
+    （实机事故：0 杀 2 失败），识别为复用的按陈旧标记直接清理；③taskkill
+    加 CREATE_NO_WINDOW，GUI 下不再每杀一只弹空白控制台窗口。
     """
     root = Path(config_dir)
     killed_pids: list[int] = []
     failed_pids: list[int] = []
+    seen: set[int] = {os.getpid(), 0}  # 自己的 pid 永远跳过；两枚举源去重
 
-    # 关闭仍在运行的子肥鱼进程，并清理 runtime 标记。
-    # 同时认旧名 runtime-*.json 与批5.2 版本化新名 pet-runtime-v2-*.json
-    #（多进程模式只写 v2 名，旧 glob 匹配不到 → 子进程杀不掉）。
+    def _kill_one(pid: int, source: str) -> None:
+        logging.info("退出子肥鱼：结束子进程 pid=%d (%s)", pid, source)
+        dead = False
+        for attempt in (1, 2):
+            _terminate_pet_process(pid)
+            if _wait_pid_dead(pid):
+                dead = True
+                break
+            logging.warning(
+                "退出子肥鱼：第 %d 次结束 pid=%d 后进程仍存活", attempt, pid)
+        if dead:
+            killed_pids.append(pid)
+        else:
+            failed_pids.append(pid)
+            logging.warning(
+                "退出子肥鱼：pid=%d 未能退出，保留标记供下次重试", pid)
+
+    # 第一枚举源：runtime 标记（旧名 runtime-*.json + v2 新名
+    # pet-runtime-v2-*.json，多进程模式只写旧名、单进程模式写 v2 名）。
     markers = slot_manager_mod.list_runtime_marker_files(root)
     if markers:
         logging.info(
@@ -115,28 +206,30 @@ def clear_spawned_pets(config_dir: Path | str) -> dict:
             pid = int(data.get("pid", 0))
         except (OSError, ValueError, TypeError):
             pid = 0
-        if pid == os.getpid():
+        if pid in seen:
             continue
+        seen.add(pid)
         if pid > 0 and _pid_alive(pid):
-            logging.info("退出子肥鱼：结束子进程 pid=%d (%s)", pid, marker.name)
-            dead = False
-            for attempt in (1, 2):
-                _terminate_pet_process(pid)
-                if _wait_pid_dead(pid):
-                    dead = True
-                    break
-                logging.warning(
-                    "退出子肥鱼：第 %d 次结束 pid=%d 后进程仍存活", attempt, pid)
-            if dead:
-                killed_pids.append(pid)
+            if not _is_pet_process(pid):
+                # pid 复用：标记是陈旧的，指向无关进程——不杀，按陈旧标记清理
+                logging.info(
+                    "退出子肥鱼：标记 %s 的 pid=%d 已被无关进程复用，按陈旧标记清理",
+                    marker.name, pid)
             else:
-                failed_pids.append(pid)
-                logging.warning(
-                    "退出子肥鱼：pid=%d 未能退出，保留标记供下次重试", pid)
-                continue  # 进程仍活：保留标记，不毁灭痕迹
+                _kill_one(pid, marker.name)
+                if pid in failed_pids:
+                    continue  # 进程仍活：保留标记，不毁灭痕迹
         try:
             marker.unlink()
         except OSError:
             pass
+
+    # 第二枚举源：slot 锁文件（没写过 runtime 标记的小肥鱼也持有锁）。
+    for pid in _slot_lock_pids(root):
+        if pid in seen:
+            continue
+        seen.add(pid)
+        if _pid_alive(pid) and _is_pet_process(pid):
+            _kill_one(pid, "slot 锁")
 
     return {"killed_pids": killed_pids, "failed_pids": failed_pids}

--- a/pet/child_pet_cleanup.py
+++ b/pet/child_pet_cleanup.py
@@ -14,6 +14,8 @@ import subprocess
 import time
 from pathlib import Path
 
+from . import slot_manager as slot_manager_mod
+
 
 def _pid_alive(pid: int) -> bool:
     """跨平台探活：Windows 用 OpenProcess，其余用 kill(pid, 0)。"""
@@ -77,10 +79,9 @@ def clear_spawned_pets(config_dir: Path | str) -> dict:
     deleted: list[str] = []
 
     # 1) 关闭仍在运行的子肥鱼进程，并清理 runtime 标记。
-    try:
-        markers = list(root.glob("runtime-*.json"))
-    except OSError:
-        markers = []
+    # 同时认旧名 runtime-*.json 与批5.2 版本化新名 pet-runtime-v2-*.json
+    #（多进程模式只写 v2 名，旧 glob 匹配不到 → 子进程杀不掉）。
+    markers = slot_manager_mod.list_runtime_marker_files(root)
     for marker in markers:
         try:
             data = json.loads(marker.read_text(encoding="utf-8"))

--- a/pet/child_pet_cleanup.py
+++ b/pet/child_pet_cleanup.py
@@ -20,20 +20,31 @@ from . import slot_manager as slot_manager_mod
 
 
 def _pid_alive(pid: int) -> bool:
-    """跨平台探活：Windows 用 OpenProcess，其余用 kill(pid, 0)。"""
+    """跨平台探活：Windows 用 GetExitCodeProcess==STILL_ACTIVE 判定真死活，
+    其余用 kill(pid, 0)。
+
+    注意不能用「OpenProcess 能不能打开」当死活：父进程 spawn 子进程后持有
+    子进程句柄，子进程被 taskkill 杀掉后其进程对象仍因句柄存活而可被打开
+    ——实机事故：杀成功了却被误判存活，白等重试两轮还误报「未能退出」。
+    """
     if pid <= 0:
         return False
     if os.name == "nt":
         try:
             import ctypes
-            PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+            from ctypes import wintypes
             handle = ctypes.windll.kernel32.OpenProcess(
-                PROCESS_QUERY_LIMITED_INFORMATION, False, pid
-            )
+                0x1000, False, pid)  # PROCESS_QUERY_LIMITED_INFORMATION
             if not handle:
                 return False
-            ctypes.windll.kernel32.CloseHandle(handle)
-            return True
+            try:
+                code = wintypes.DWORD()
+                if not ctypes.windll.kernel32.GetExitCodeProcess(
+                        handle, ctypes.byref(code)):
+                    return False
+                return code.value == 259  # STILL_ACTIVE
+            finally:
+                ctypes.windll.kernel32.CloseHandle(handle)
         except Exception:
             return False
     try:
@@ -79,16 +90,6 @@ def _terminate_pet_process(pid: int) -> None:
             os.kill(pid, signal.SIGKILL)
         except ProcessLookupError:
             pass
-
-
-def _wait_pid_dead(pid: int, timeout: float = 2.0) -> bool:
-    """杀进程后确认其真的退出（taskkill 返回 ≠ 目标进程已消失）。有界轮询。"""
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        if not _pid_alive(pid):
-            return True
-        time.sleep(0.05)
-    return not _pid_alive(pid)
 
 
 def _pid_image_path(pid: int) -> str | None:
@@ -173,31 +174,20 @@ def clear_spawned_pets(config_dir: Path | str) -> dict:
     标记的 pid 可能已被无关进程复用，误杀会杀死无辜进程/打不动受保护进程
     （实机事故：0 杀 2 失败），识别为复用的按陈旧标记直接清理；③taskkill
     加 CREATE_NO_WINDOW，GUI 下不再每杀一只弹空白控制台窗口。
+
+    批 I：①探活改 GetExitCodeProcess==STILL_ACTIVE——OpenProcess 对「已死但
+    父进程还持有句柄」的子进程仍可打开，旧探活把杀成功的子鱼误判存活
+    （实机：杀了还白等两轮 2s 并误报未能退出）；②两段式杀法——先一口气
+    全部结束再统一等确认，N 只也只需一次等待窗口（旧逐只杀等串行 N×2s）；
+    ③逐只重试取消（探活准确后重试无意义）。
     """
     root = Path(config_dir)
     killed_pids: list[int] = []
     failed_pids: list[int] = []
     seen: set[int] = {os.getpid(), 0}  # 自己的 pid 永远跳过；两枚举源去重
+    targets: list[tuple[int, Path | None]] = []  # (pid, 对应标记文件或 None)
 
-    def _kill_one(pid: int, source: str) -> None:
-        logging.info("退出子肥鱼：结束子进程 pid=%d (%s)", pid, source)
-        dead = False
-        for attempt in (1, 2):
-            _terminate_pet_process(pid)
-            if _wait_pid_dead(pid):
-                dead = True
-                break
-            logging.warning(
-                "退出子肥鱼：第 %d 次结束 pid=%d 后进程仍存活", attempt, pid)
-        if dead:
-            killed_pids.append(pid)
-        else:
-            failed_pids.append(pid)
-            # 诊断：杀不掉时记录存活者到底是谁（pid 复用？还是真没杀掉）
-            logging.warning(
-                "退出子肥鱼：pid=%d 未能退出，存活者镜像=%s，保留标记供下次重试",
-                pid, _pid_image_path(pid))
-
+    # 第一阶段：收集目标。陈旧（进程已死 / pid 已被无关进程复用）的标记直接删。
     # 第一枚举源：runtime 标记（旧名 runtime-*.json + v2 新名
     # pet-runtime-v2-*.json，多进程模式只写旧名、单进程模式写 v2 名）。
     markers = slot_manager_mod.list_runtime_marker_files(root)
@@ -226,9 +216,8 @@ def clear_spawned_pets(config_dir: Path | str) -> dict:
                     "退出子肥鱼：标记 %s 的 pid=%d 已被无关进程复用，按陈旧标记清理",
                     marker.name, pid)
             else:
-                _kill_one(pid, marker.name)
-                if pid in failed_pids:
-                    continue  # 进程仍活：保留标记，不毁灭痕迹
+                targets.append((pid, marker))
+                continue  # 标记留待杀成后删（杀失败则保留供重试）
         try:
             marker.unlink()
         except OSError:
@@ -240,6 +229,33 @@ def clear_spawned_pets(config_dir: Path | str) -> dict:
             continue
         seen.add(pid)
         if _pid_alive(pid) and _is_pet_process(pid):
-            _kill_one(pid, "slot 锁")
+            targets.append((pid, None))
+
+    # 第二阶段：先一口气全部结束，再统一等确认——旧实现逐只「杀→等 2s 确认」，
+    # N 只串行等 N×2s（实机反馈太慢）；两段式 N 只也只需一次等待窗口。
+    for pid, marker in targets:
+        logging.info("退出子肥鱼：结束子进程 pid=%d (%s)",
+                     pid, marker.name if marker is not None else "slot 锁")
+        _terminate_pet_process(pid)
+    remaining = {pid for pid, _m in targets}
+    deadline = time.monotonic() + 2.0
+    while remaining and time.monotonic() < deadline:
+        remaining = {pid for pid in remaining if _pid_alive(pid)}
+        if remaining:
+            time.sleep(0.05)
+    for pid, marker in targets:
+        if pid in remaining:
+            failed_pids.append(pid)
+            # 诊断：杀不掉时记录存活者到底是谁（pid 复用？还是真没杀掉）
+            logging.warning(
+                "退出子肥鱼：pid=%d 未能退出，存活者镜像=%s，保留标记供下次重试",
+                pid, _pid_image_path(pid))
+        else:
+            killed_pids.append(pid)
+            if marker is not None:
+                try:
+                    marker.unlink()
+                except OSError:
+                    pass
 
     return {"killed_pids": killed_pids, "failed_pids": failed_pids}

--- a/pet/child_pet_cleanup.py
+++ b/pet/child_pet_cleanup.py
@@ -45,19 +45,27 @@ def _pid_alive(pid: int) -> bool:
 
 def _terminate_pet_process(pid: int) -> None:
     """终止子肥鱼进程。Windows 使用 taskkill /T /F（CREATE_NO_WINDOW 防 GUI 应用
-    每杀一只弹一个空白控制台窗口——实机反馈），POSIX 先 SIGTERM 再补 SIGKILL。"""
+    每杀一只弹一个空白控制台窗口——实机反馈），POSIX 先 SIGTERM 再补 SIGKILL。
+
+    taskkill 的输出不再吞掉：返回码/stdout/stderr 写日志——实机上出现过
+    「taskkill 跑完进程还在」且零线索可查（20:56 事件），失败原因必须可见。
+    """
     if os.name == "nt":
         try:
-            subprocess.run(
+            proc = subprocess.run(
                 ["taskkill", "/PID", str(pid), "/T", "/F"],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
+                capture_output=True, text=True,
                 timeout=5,
                 # GUI 进程（无控制台）里起 taskkill 会弹空白控制台窗口
                 creationflags=subprocess.CREATE_NO_WINDOW,
             )
+            if proc.returncode != 0:
+                logging.warning(
+                    "退出子肥鱼：taskkill pid=%d 返回码 %s: %s%s",
+                    pid, proc.returncode,
+                    (proc.stdout or "").strip(), (proc.stderr or "").strip())
         except Exception:
-            pass
+            logging.exception("退出子肥鱼：taskkill pid=%d 执行异常", pid)
         return
     try:
         os.kill(pid, signal.SIGTERM)
@@ -185,8 +193,10 @@ def clear_spawned_pets(config_dir: Path | str) -> dict:
             killed_pids.append(pid)
         else:
             failed_pids.append(pid)
+            # 诊断：杀不掉时记录存活者到底是谁（pid 复用？还是真没杀掉）
             logging.warning(
-                "退出子肥鱼：pid=%d 未能退出，保留标记供下次重试", pid)
+                "退出子肥鱼：pid=%d 未能退出，存活者镜像=%s，保留标记供下次重试",
+                pid, _pid_image_path(pid))
 
     # 第一枚举源：runtime 标记（旧名 runtime-*.json + v2 新名
     # pet-runtime-v2-*.json，多进程模式只写旧名、单进程模式写 v2 名）。

--- a/pet/collision_client.py
+++ b/pet/collision_client.py
@@ -65,6 +65,10 @@ class CollisionClient(QObject):
         self.pending_predicted_contact: tuple[float, float, list[list[float]]] | None = None
         self.impulse_watermarks = collision_codec.WatermarkDeduplicator()
         self.last_collision_squash_at = float('-inf')
+        # 批 A：碰撞撞飞（is_real_hit 且非 contact_deviation）已发起 throw 物理；
+        # 一旦 throw 落地停稳（_stop_physics 把 _physics_mode 置 None 并回调
+        # _submit_collision_state）即通知边缘探头控制器开始重进倒计时。
+        self._reentry_after_throw_armed = False
 
         self.timer = QTimer(self)
         self.timer.setInterval(500)
@@ -208,6 +212,16 @@ class CollisionClient(QObject):
 
     def _submit_collision_state(self, force: bool = False) -> None:
         win = self._win
+        # 批 A：碰撞撞飞落地停稳（throw 物理结束）→ 通知边缘探头开始重进倒计时。
+        # 判定依据：撞飞已 armed（_reentry_after_throw_armed）且当前已不在 throw
+        # 物理模式（_stop_physics 已把 _physics_mode 置 None 并回调本方法）。
+        if self._reentry_after_throw_armed and win._physics_mode != 'throw':
+            self._reentry_after_throw_armed = False
+            edge = getattr(win, '_edge_probe', None)
+            if edge is not None:
+                on_settled = getattr(edge, 'on_throw_settled', None)
+                if callable(on_settled):
+                    on_settled()
         session = self.session
         if session is None:
             return
@@ -377,6 +391,15 @@ class CollisionClient(QObject):
             win._phys_pos[:] = [float(win.x()), float(win.y())]
             win._last_physics_tick_time = None
             win._physics_timer.start()
+            # 批 A：真实撞击进入飞行前取消边缘探头会话（restore=False，物理引擎
+            # 已接管位置，回拉会抢位置）。撞飞落地停稳后由 _submit_collision_state
+            # 触发边缘探头重进倒计时。
+            edge_probe = getattr(win, '_edge_probe', None)
+            if edge_probe is not None:
+                cancel = getattr(edge_probe, 'cancel', None)
+                if callable(cancel):
+                    cancel("collision_throw", restore=False)
+            self._reentry_after_throw_armed = True
         now = time.monotonic()
         if (is_real_hit and not win._squash_active
                 and now - self.last_collision_squash_at >= 0.25):

--- a/pet/collision_client.py
+++ b/pet/collision_client.py
@@ -367,6 +367,9 @@ class CollisionClient(QObject):
         if speed > win._throw_speed_cap:
             clamped = physics_mod.soft_clamp_speed(speed, win._throw_speed_cap)
             win._phys_vel[:] = [win._phys_vel[0] * clamped / speed, win._phys_vel[1] * clamped / speed]
+        egg = getattr(win, '_throw_egg', None)
+        if egg is not None and egg.active:
+            egg.on_pet_contact(math.hypot(*win._phys_vel))
         if abs(dx) > 1e-9 or abs(dy) > 1e-9:
             win._cancel_move()
             win._cancel_animation_gap()
@@ -509,6 +512,9 @@ class CollisionClient(QObject):
                 clamped = physics_mod.soft_clamp_speed(speed, win._throw_speed_cap)
                 win._phys_vel[:] = [win._phys_vel[0] * clamped / speed,
                                      win._phys_vel[1] * clamped / speed]
+            egg = getattr(win, '_throw_egg', None)
+            if egg is not None and egg.active:
+                egg.on_pet_contact(math.hypot(*win._phys_vel))
             self.predicted_bounces[pair] = now
             self.pending_predicted_bounce = (float(bounce_vx), float(bounce_vy))
             self.pending_predicted_contact = (

--- a/pet/config.py
+++ b/pet/config.py
@@ -532,6 +532,7 @@ class Config:
             "spawn_inherit_size": True,  # 生小肥鱼继承主肥鱼大小（False 用 spawn_scale）
             "spawn_scale": catalog.DEFAULT_SCALE,  # 关闭继承时生小肥鱼使用的尺寸
             "spawn_inherit_dynamic_island": False,  # 生小肥鱼继承主肥鱼灵动岛（默认关=不开灵动岛）
+            "user_customized": False,  # 批 C：仅当用户在该子肥鱼自己的设置界面保存过才置真
             "on_top": True,
             "show_dock_icon": True,
             "no_move": False,
@@ -645,70 +646,26 @@ class Config:
             pass
 
     def _seed_slot_config_from_main(self) -> None:
-        """新建副槽时继承主配置（issue #69-6），避免“生小肥鱼恢复默认设置”。
+        """新建副槽时继承主配置（批 C）：委托 slot_manager 的共享落种函数。
 
-        只在该槽位还没有个体配置文件时执行；已有存档的 slot-N 配置（用户
-        改过的）一律保持独立记忆，「生小肥鱼」复用旧槽位也不覆盖。复制主
-        config.json 后做副槽化处理：位置回到自动摆放、开机自启仍只归主槽
-        所有。写盘副本沿用主配置的脱敏策略，不把明文 API Key 复制进副槽。
+        只在该槽位还没有个体配置文件时执行；已有存档的 slot-N 配置（用户改过
+        的）一律保持独立记忆，「生小肥鱼」复用旧槽位也不覆盖。副本生成逻辑
+        （spawn_inherit_size / spawn_scale / spawn_inherit_dynamic_island、位置键
+        剔除、脱敏、user_customized 置假）统一收敛在
+        ``slot_manager.seed_slot_config_from_main``，这里只负责把 instance_id
+        解析成 slot_id 后转发。
         """
-        main_path = self.dir / "config.json"
-        if self.path.exists() or not main_path.is_file():
+        if not self.instance_id:
             return
-        try:
-            raw = json.loads(main_path.read_text(encoding="utf-8"))
-        except (OSError, ValueError):
+        if not self.instance_id.startswith("slot-"):
             return
-        if not isinstance(raw, dict):
+        suffix = self.instance_id[len("slot-"):]
+        if not suffix.isdigit():
+            # 非数值 slot 标识（如碰撞 IPC 测试用 slot-a/slot-p）不做落种。
             return
-        seed = copy.deepcopy(raw)
-        seed["version"] = 4
-        # 副槽不继承主桌宠的位置/屏幕，避免新鱼叠在旧鱼身上；自启仍仅主槽。
-        seed["rx"] = None
-        seed["ry"] = None
-        seed["screen_name"] = None
-        seed["autostart_wanted"] = False
-        seed["harness_autostart"] = False
-        # 生小肥鱼大小策略：开启继承 → 保留主配置 scale；
-        # 关闭继承 → 用主配置里给“小肥鱼”单独选择的 spawn_scale。
-        inherit_size = _bool_or_default(seed.get("spawn_inherit_size"), True)
-        seed["spawn_inherit_size"] = inherit_size
-        if not inherit_size:
-            try:
-                seed["scale"] = float(seed.get("spawn_scale", catalog.DEFAULT_SCALE))
-            except (TypeError, ValueError):
-                seed["scale"] = catalog.DEFAULT_SCALE
-        # 生小肥鱼灵动岛策略：默认不继承 → 小肥鱼不开启自己的灵动岛；
-        # 开启继承 → 保留主配置的 dynamic_island（含是否启用）。
-        inherit_island = _bool_or_default(seed.get("spawn_inherit_dynamic_island"), False)
-        seed["spawn_inherit_dynamic_island"] = inherit_island
-        island = seed.get("dynamic_island")
-        if isinstance(island, dict):
-            island["enabled"] = bool(inherit_island)
-        else:
-            seed["dynamic_island"] = {"enabled": bool(inherit_island)}
-        chat = seed.get("chat")
-        if isinstance(chat, dict):
-            providers = chat.get("providers")
-            if isinstance(providers, dict):
-                for provider in providers.values():
-                    if isinstance(provider, dict):
-                        provider.pop("api_key", None)
-                        provider.pop("vision_api_key", None)
-        try:
-            self.dir.mkdir(parents=True, exist_ok=True)
-            temp = self.path.with_name(f"{self.path.name}.{os.getpid()}.seed.tmp")
-            temp.write_text(
-                json.dumps(seed, ensure_ascii=False, indent=2),
-                encoding="utf-8",
-            )
-            os.replace(temp, self.path)
-        except OSError as exc:
-            logging.warning("从主配置播种副槽配置失败: %s (%s)", self.path, exc)
-            try:
-                temp.unlink(missing_ok=True)
-            except OSError:
-                pass
+        slot_id = int(suffix)
+        from . import slot_manager as slot_manager_mod
+        slot_manager_mod.seed_slot_config_from_main(self.dir, slot_id)
 
     def reload(self):
         if not self.path.is_file():
@@ -779,6 +736,7 @@ class Config:
         for key in (
             "rx", "ry", "screen_name", "facing", "scale", "on_top", "show_dock_icon", "no_move", "character",
             "spawn_inherit_size", "spawn_scale", "spawn_inherit_dynamic_island",
+            "user_customized",
             "playback_speed", "animation_gap_seconds", "self_talk_enabled",
             "self_talk_min_interval", "self_talk_max_interval", "self_talk_texts",
             "self_talk_duration_seconds", "self_talk_image_dir",

--- a/pet/context_menus/registry.py
+++ b/pet/context_menus/registry.py
@@ -50,7 +50,7 @@ ACTION_LABELS = {
     "size": "大小", "drag_physics": "拖动物理", "no_move": "不移动",
     "mouse_through": "鼠标穿透", "on_top": "窗口置顶", "autostart": "开机自启",
     "return_corner": "回到右下角", "hide_pet": "隐藏桌宠",
-    "spawn_pet": "生小肥鱼", "clear_spawned_pets": "清除子肥鱼",
+    "spawn_pet": "生小肥鱼", "clear_spawned_pets": "退出子肥鱼",
     "golden_spin": "黄金回旋", "edge_probe": "边缘探头",
     "quick_launch": "快捷启动", "balance": "DeepSeek 余额",
     "harness": "启动 DeepSeek Harness", "deepseek_web": "打开网页版 DeepSeek",

--- a/pet/context_menus/shared.py
+++ b/pet/context_menus/shared.py
@@ -461,13 +461,13 @@ def add_spawn_pet(menu: QMenu, pet):
 
 
 def add_clear_spawned_pets(menu: QMenu, pet, *, icons: bool = True):
-    """右键菜单快捷入口：清除所有小肥鱼（slot-N）数据。"""
+    """右键菜单快捷入口：退出所有小肥鱼（slot-N），设置与数据保留。"""
     callback = getattr(pet, "on_clear_spawned_pets", None)
     if callback is None:
         return None
     return add_action(
         menu,
-        "清除子肥鱼",
+        "退出子肥鱼",
         "clear" if icons else None,
         callback,
         close_on_trigger=True,

--- a/pet/edge_probe.py
+++ b/pet/edge_probe.py
@@ -24,6 +24,8 @@ EDGE_ENTER_MS = 300
 EDGE_STRAIGHTEN_MS = 250
 EDGE_RETURN_MS = 300
 EDGE_IDLE_SECONDS = 5.0
+# 碰撞撞飞落地停稳后允许重新进入探头吸附前的等待秒数（批 A）。
+EDGE_REENTRY_SECONDS = 5.0
 
 OFF = "OFF"
 ENTERING = "ENTERING"
@@ -92,6 +94,13 @@ class EdgeProbeController:
         self._transition_to_exposure = 1.0
         self._hidden = False
         self._paused_at = 0.0
+        # 批 A：碰撞撞飞取消会话后，是否等待/正在执行“落地停稳→边缘重进”流程。
+        # _reentry_armed    True 表示本次撞飞取消源于碰撞，落地后可重新进入探头。
+        # _reentry_active   True 表示 5 秒重进倒计时正在进行。
+        # _reentry_remaining 剩余秒数。
+        self._reentry_armed = False
+        self._reentry_active = False
+        self._reentry_remaining = 0.0
         self._timer = QTimer(win)
         self._timer.setInterval(16)
         self._timer.setTimerType(Qt.TimerType.PreciseTimer)
@@ -139,6 +148,9 @@ class EdgeProbeController:
         # 非拖拽点击走窗口 _on_click -> _effects_consume_click -> on_clicked
 
     def on_drag_started(self) -> None:
+        if self._reentry_active:
+            # 批 A：重新进入探头吸附的倒计时期间发生拖拽，作废本次倒计时。
+            self._cancel_reentry()
         if self.active and self.enabled and not self._hidden:
             self.cancel("drag_away", restore=False)
 
@@ -166,8 +178,43 @@ class EdgeProbeController:
             # 已在转直/进入中，不重复打断；若已接近转直则重置倒计时稍后由状态落定处理。
             pass
 
+    def on_throw_settled(self) -> None:
+        """碰撞撞飞落地停稳后触发（由 CollisionClient 在 throw 物理结束时回调）。
+
+        若会话此前因碰撞被取消（_reentry_armed）且当前静止于屏幕边缘，则开始
+        5 秒重进倒计时；倒计时内拖拽作废（on_drag_started），到期仍静止于边缘
+        则重新进入探头吸附。幂等：未 armed、被禁用/隐藏、已激活或不在边缘时直接返回。
+        """
+        if not self._reentry_armed:
+            return
+        self._reentry_armed = False
+        if not self.enabled or self._hidden or self.active:
+            return
+        scr = self.win.screen_available()
+        avail = scr.availableGeometry() if scr is not None else None
+        if avail is None:
+            return
+        if edge_side_at_rest(self.win, avail) is None:
+            return
+        self._reentry_active = True
+        self._reentry_remaining = EDGE_REENTRY_SECONDS
+        self._last_tick_time = self._clock()
+        self._timer.start()
+
+    def _cancel_reentry(self) -> None:
+        """作废正在执行的重进倒计时（拖拽/取消会话/到期前被打断时调用）。幂等。"""
+        if not self._reentry_active:
+            return
+        self._reentry_active = False
+        self._reentry_remaining = 0.0
+        self._timer.stop()
+
     def cancel(self, reason: str = "", restore: bool = False) -> None:
-        """取消会话。restore=True 时恢复进入探头前的窗口 x（用于关闭功能/角色切换）。"""
+        """取消会话。restore=True 时恢复进入探头前的窗口 x（用于关闭功能/角色切换）。
+
+        批 A：碰撞撞飞（reason == "collision_throw"）并确实处于激活会话时，标记
+        落地后允许重新进入探头（_reentry_armed），由 on_throw_settled 接续。
+        """
         was_active = self.active
         self._mode = OFF
         self._side = None
@@ -175,6 +222,11 @@ class EdgeProbeController:
         self._exposure = 1.0
         self._idle_remaining = 0.0
         self._timer.stop()
+        if was_active and reason == "collision_throw":
+            self._reentry_armed = True
+        else:
+            self._reentry_armed = False
+        self._cancel_reentry()
         restore_x = self._restore_x
         self._restore_x = None
         self._vis_local = None
@@ -204,7 +256,7 @@ class EdgeProbeController:
         if not self._hidden:
             return
         self._hidden = False
-        if not self.active:
+        if not self.active and not self._reentry_active:
             return
         now = self._clock()
         if self._mode in _TRANSITION_MODES:
@@ -212,7 +264,7 @@ class EdgeProbeController:
             elapsed_at_pause = max(0.0, self._paused_at - self._transition_start)
             self._transition_start = now - elapsed_at_pause
         self._last_tick_time = now
-        if self._mode in _TRANSITION_MODES or self._mode == STRAIGHTENED:
+        if self._mode in _TRANSITION_MODES or self._mode == STRAIGHTENED or self._reentry_active:
             self._timer.start()
 
     # ------------------------------------------------------------ 状态机
@@ -275,6 +327,14 @@ class EdgeProbeController:
         if self._hidden:
             return
         now = self._clock()
+        if self._reentry_active:
+            dt = max(0.0, now - self._last_tick_time)
+            self._last_tick_time = now
+            self._reentry_remaining = max(0.0, self._reentry_remaining - dt)
+            if self._reentry_remaining <= 0.0:
+                self._cancel_reentry()
+                self._maybe_enter()
+            return
         if self._mode in _TRANSITION_MODES:
             self._tick_transition(now)
         elif self._mode == STRAIGHTENED:

--- a/pet/edge_probe.py
+++ b/pet/edge_probe.py
@@ -224,6 +224,9 @@ class EdgeProbeController:
         self._timer.stop()
         if was_active and reason == "collision_throw":
             self._reentry_armed = True
+            _egg = getattr(self.win, "_throw_egg", None)
+            if _egg is not None:
+                _egg.arm()
         else:
             self._reentry_armed = False
         self._cancel_reentry()

--- a/pet/modern_settings_dialog.py
+++ b/pet/modern_settings_dialog.py
@@ -300,7 +300,7 @@ class ModernSettingsDialog(QDialog):
             SettingRow("spawn_inherit_dynamic_island", "生小肥鱼继承灵动岛",
                        "默认关闭：新生成的小肥鱼不打开自己的灵动岛。开启后小肥鱼继承主肥鱼的灵动岛设置。",
                        self.spawn_inherit_dynamic_island_check),
-            SettingRow("clear_spawned_pets", "一键清除子肥鱼",
+            SettingRow("clear_spawned_pets", "一键退出子肥鱼",
                        "关闭所有已生成的小肥鱼，并删除它们的配置、会话与待办数据。",
                        self.clear_spawned_pets_btn),
         ], behavior_content))
@@ -563,7 +563,7 @@ class ModernSettingsDialog(QDialog):
         self.spawn_inherit_dynamic_island_check.setChecked(
             bool(self.config.get("spawn_inherit_dynamic_island", False))
         )
-        self.clear_spawned_pets_btn = QPushButton("一键清除…", self)
+        self.clear_spawned_pets_btn = QPushButton("一键退出…", self)
         self.clear_spawned_pets_btn.clicked.connect(self._on_clear_spawned_pets)
 
         self.on_top_check = ToggleSwitch(self)
@@ -1384,11 +1384,11 @@ class ModernSettingsDialog(QDialog):
         )
 
     def _on_clear_spawned_pets(self) -> None:
-        """一键关闭并清除所有小肥鱼（slot-N）的配置/会话/待办数据。
+        """一键退出所有小肥鱼（slot-N）；它们的设置与数据保留。
 
         优先走 PetWindow 上已接线的 ``on_clear_spawned_pets``（= AppShell 路径，
         自带确认框与进程内子窗前置于关闭，单进程模式才清得掉）；拿不到回调时
-        回退为原有的「确认 + 直接文件级清理」。
+        回退为「确认 + 直接文件级退出」。
         """
         callback = getattr(self.parentWidget(), "on_clear_spawned_pets", None)
         if callable(callback):
@@ -1396,8 +1396,8 @@ class ModernSettingsDialog(QDialog):
             return
         answer = QMessageBox.question(
             self,
-            "清除子肥鱼",
-            "将关闭所有已生成的小肥鱼，并删除它们的配置、会话与待办数据。\n\n此操作不可撤销，确定继续吗？",
+            "退出子肥鱼",
+            "将退出所有已生成的小肥鱼。\n\n它们的设置与数据会保留，下次生成时原样恢复。确定继续吗？",
             QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.Cancel,
             QMessageBox.StandardButton.Cancel,
         )
@@ -1407,9 +1407,9 @@ class ModernSettingsDialog(QDialog):
         result = clear_spawned_pets(self.config.dir)
         QMessageBox.information(
             self,
-            "清除子肥鱼",
-            f"已关闭 {len(result['killed_pids'])} 个小肥鱼进程，"
-            f"并清除 {len(result['deleted'])} 个 slot 数据项。",
+            "退出子肥鱼",
+            f"已退出 {len(result['killed_pids'])} 个小肥鱼进程；"
+            f"它们的设置与数据已保留。",
         )
 
     def _apply_agent_sound_enabled_now(self, checked: bool) -> None:

--- a/pet/modern_settings_dialog.py
+++ b/pet/modern_settings_dialog.py
@@ -1384,7 +1384,16 @@ class ModernSettingsDialog(QDialog):
         )
 
     def _on_clear_spawned_pets(self) -> None:
-        """一键关闭并清除所有小肥鱼（slot-N）的配置/会话/待办数据。"""
+        """一键关闭并清除所有小肥鱼（slot-N）的配置/会话/待办数据。
+
+        优先走 PetWindow 上已接线的 ``on_clear_spawned_pets``（= AppShell 路径，
+        自带确认框与进程内子窗前置于关闭，单进程模式才清得掉）；拿不到回调时
+        回退为原有的「确认 + 直接文件级清理」。
+        """
+        callback = getattr(self.parentWidget(), "on_clear_spawned_pets", None)
+        if callable(callback):
+            callback()
+            return
         answer = QMessageBox.question(
             self,
             "清除子肥鱼",

--- a/pet/modern_settings_dialog.py
+++ b/pet/modern_settings_dialog.py
@@ -565,6 +565,11 @@ class ModernSettingsDialog(QDialog):
         )
         self.clear_spawned_pets_btn = QPushButton("一键退出…", self)
         self.clear_spawned_pets_btn.clicked.connect(self._on_clear_spawned_pets)
+        if self.config.instance_id:
+            # 「退出子肥鱼」只对主肥鱼开放：子肥鱼进程里执行会把主鱼当子鱼
+            # 杀掉（pid==os.getpid() 只跳过自己），故子鱼对话框禁用该按钮。
+            self.clear_spawned_pets_btn.setEnabled(False)
+            self.clear_spawned_pets_btn.setToolTip("请在主肥鱼的设置里操作")
 
         self.on_top_check = ToggleSwitch(self)
         self.on_top_check.setChecked(bool(self.config.get("on_top", True)))
@@ -1393,6 +1398,10 @@ class ModernSettingsDialog(QDialog):
         callback = getattr(self.parentWidget(), "on_clear_spawned_pets", None)
         if callable(callback):
             callback()
+            return
+        if self.config.instance_id:
+            # 双保险：子肥鱼不开放该操作（按钮已禁用；即便被旧接线调到也不执行，
+            # 否则子鱼进程会把主鱼当子鱼杀掉）。
             return
         answer = QMessageBox.question(
             self,

--- a/pet/modern_settings_dialog.py
+++ b/pet/modern_settings_dialog.py
@@ -1959,6 +1959,10 @@ class ModernSettingsDialog(QDialog):
             self.config.set("proactive_screen", pro_data)
         self.config.set("autostart_wanted", self.autostart_check.isChecked())
         self.config.set("harness_autostart", self.harness_autostart_check.isChecked())
+        # 批 C：落种占位语义——仅当用户在该子肥鱼自己的设置界面保存过才置真；
+        # 位置自动保存等一切后台写盘不得置位。主配置（slot 0/主肥鱼）保存不置位。
+        if self.config.instance_id:
+            self.config.set("user_customized", True)
         ok = self.config.save()
         if not ok:
             QMessageBox.warning(

--- a/pet/modern_settings_dialog.py
+++ b/pet/modern_settings_dialog.py
@@ -1389,11 +1389,12 @@ class ModernSettingsDialog(QDialog):
         )
 
     def _on_clear_spawned_pets(self) -> None:
-        """一键退出所有小肥鱼（slot-N）；它们的设置与数据保留。
+        """一键静默退出所有小肥鱼（slot-N）；它们的设置与数据保留。
 
         优先走 PetWindow 上已接线的 ``on_clear_spawned_pets``（= AppShell 路径，
-        自带确认框与进程内子窗前置于关闭，单进程模式才清得掉）；拿不到回调时
-        回退为「确认 + 直接文件级退出」。
+        含进程内子窗前置于关闭，单进程模式才清得掉）；拿不到回调时回退为
+        直接文件级退出。批 I：无确认框无结果框（操作不删数据可重新生成，
+        子肥鱼消失即反馈）。
         """
         callback = getattr(self.parentWidget(), "on_clear_spawned_pets", None)
         if callable(callback):
@@ -1403,23 +1404,11 @@ class ModernSettingsDialog(QDialog):
             # 双保险：子肥鱼不开放该操作（按钮已禁用；即便被旧接线调到也不执行，
             # 否则子鱼进程会把主鱼当子鱼杀掉）。
             return
-        answer = QMessageBox.question(
-            self,
-            "退出子肥鱼",
-            "将退出所有已生成的小肥鱼。\n\n它们的设置与数据会保留，下次生成时原样恢复。确定继续吗？",
-            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.Cancel,
-            QMessageBox.StandardButton.Cancel,
-        )
-        if answer != QMessageBox.StandardButton.Yes:
-            return
         from .child_pet_cleanup import clear_spawned_pets
         result = clear_spawned_pets(self.config.dir)
-        QMessageBox.information(
-            self,
-            "退出子肥鱼",
-            f"已退出 {len(result['killed_pids'])} 个小肥鱼进程；"
-            f"它们的设置与数据已保留。",
-        )
+        logging.info(
+            "退出子肥鱼：已退出 %d 只，未能退出 %d 只",
+            len(result.get("killed_pids", [])), len(result.get("failed_pids", [])))
 
     def _apply_agent_sound_enabled_now(self, checked: bool) -> None:
         """音效总开关即时生效，不等对话框关闭（合并写回，不动其他 agent_link 键）。"""

--- a/pet/slot_manager.py
+++ b/pet/slot_manager.py
@@ -6,6 +6,7 @@
 """
 from __future__ import annotations
 
+import copy
 import json
 import logging
 import os
@@ -15,6 +16,9 @@ import time
 import re
 from pathlib import Path
 from typing import Any, BinaryIO
+
+from . import catalog
+from .config import _bool_or_default
 
 # 定长 PID 格式（16字节，右补空格与换行）
 PID_RECORD_LEN = 16
@@ -214,30 +218,91 @@ def get_config_path_for_slot(config_dir: Path | str, slot_id: int) -> Path:
     return config_path / "config.json" if slot_id == 0 else config_path / f"config-slot-{slot_id}.json"
 
 
-# 新 slot 落种时剔除的每窗状态键（位置/朝向不继承，其余设置跟随主配置）
+# 新 slot 落种/刷新时剔除的每窗状态键（位置/朝向不继承，其余设置跟随主配置）。
+# 批 C：落种/刷新永不写位置键（位置由各子肥鱼拖动后自存自管，生成逻辑不碰）。
 _SEED_EXCLUDE_KEYS = ("rx", "ry", "screen_name", "facing")
 
 
 def seed_slot_config_from_main(config_dir: Path | str, slot_id: int) -> bool:
-    """新 slot 的初始配置跟随主设置：slot 配置文件不存在时，用主 config.json
-    落种一份（剔除每窗状态键）。已有存档的 slot（用户改过的）一律不动。
+    """新 slot 的初始配置跟随主设置；对目标 slot 三分支（批 C）：
+
+    - slot 配置文件不存在 → 按当前主设置落种（含 spawn_inherit_size /
+      spawn_scale / spawn_inherit_dynamic_island 逻辑）；
+    - slot 存在但 ``user_customized`` 为假（含旧存档无此键）→ 按当前主设置
+      重新刷新一遍（仍保留该 slot 自己拖动后自存的位置键）；
+    - slot 存在且 ``user_customized`` 为真 → 整个跳过，一个键都不碰。
+
+    落种/刷新**永不写位置键**（_SEED_EXCLUDE_KEYS）：位置由各子肥鱼拖动后
+    自存自管，生成逻辑不碰——同时根治"原来位置的设置被顶掉"。
 
     用户反馈：多开出的新桌宠从零默认设置起步不合理，应跟随主设置。
-    返回 True 表示落了种。"""
+    返回 True 表示落种/刷新成功；False 表示跳过（slot 0 / 已自定义 / 读取失败）。
+    """
     if not slot_id:
         return False
+    config_dir = Path(config_dir)
     slot_path = get_config_path_for_slot(config_dir, slot_id)
+    main_path = config_dir / "config.json"
+    # 已自定义的 slot 不碰；刷新时先保留其自存位置键（旧存档无 user_customized
+    # 一律按假处理 -> 刷新跟随主设置）。
     if slot_path.exists():
-        return False  # 已有存档，不动
-    main_path = Path(config_dir) / "config.json"
+        try:
+            existing = json.loads(slot_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            existing = {}
+        if not isinstance(existing, dict):
+            existing = {}
+        if _bool_or_default(existing.get("user_customized"), False):
+            return False  # 用户在该子肥鱼自己的设置界面保存过 -> 整个跳过
+        existing_position = {k: existing.get(k) for k in _SEED_EXCLUDE_KEYS}
+    else:
+        existing_position = {}
     try:
         data = json.loads(main_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except (OSError, ValueError):
         return False
+    if not isinstance(data, dict):
+        return False
+    seed = copy.deepcopy(data)
+    seed["version"] = 4
+    # 副槽不继承主桌宠的位置/屏幕，避免新鱼叠在旧鱼身上；自启仍仅主槽。
+    seed["autostart_wanted"] = False
+    seed["harness_autostart"] = False
+    # 生小肥鱼大小策略：开启继承 → 保留主配置 scale；
+    # 关闭继承 → 用主配置里给“小肥鱼”单独选择的 spawn_scale。
+    inherit_size = _bool_or_default(seed.get("spawn_inherit_size"), True)
+    seed["spawn_inherit_size"] = inherit_size
+    if not inherit_size:
+        try:
+            seed["scale"] = float(seed.get("spawn_scale", catalog.DEFAULT_SCALE))
+        except (TypeError, ValueError):
+            seed["scale"] = catalog.DEFAULT_SCALE
+    # 生小肥鱼灵动岛策略：默认不继承 → 小肥鱼不开启自己的灵动岛；
+    # 开启继承 → 保留主配置的 dynamic_island（含是否启用）。
+    inherit_island = _bool_or_default(seed.get("spawn_inherit_dynamic_island"), False)
+    seed["spawn_inherit_dynamic_island"] = inherit_island
+    island = seed.get("dynamic_island")
+    if isinstance(island, dict):
+        island["enabled"] = bool(inherit_island)
+    else:
+        seed["dynamic_island"] = {"enabled": bool(inherit_island)}
+    chat = seed.get("chat")
+    if isinstance(chat, dict):
+        providers = chat.get("providers")
+        if isinstance(providers, dict):
+            for provider in providers.values():
+                if isinstance(provider, dict):
+                    provider.pop("api_key", None)
+                    provider.pop("vision_api_key", None)
+    # 落种/刷新永不写位置键：剔除从主配置继承的位置键，再还原本 slot 自存的位置。
     for key in _SEED_EXCLUDE_KEYS:
-        data.pop(key, None)
+        seed.pop(key, None)
+    for key, value in existing_position.items():
+        if value is not None:
+            seed[key] = value
+    seed["user_customized"] = False
     try:
-        slot_path.write_text(json.dumps(data, ensure_ascii=False, indent=2),
+        slot_path.write_text(json.dumps(seed, ensure_ascii=False, indent=2),
                              encoding="utf-8")
     except OSError:
         return False

--- a/pet/slot_manager.py
+++ b/pet/slot_manager.py
@@ -341,8 +341,9 @@ def migrate_legacy_spawns(config_dir: Path | str) -> bool:
             pass
         return True
 
-    # 检查是否有旧实例正在运行（通过 runtime marker 探测）
-    for runtime_file in config_path.glob("runtime-*.json"):
+    # 检查是否有旧实例正在运行（通过 runtime marker 探测；同时认旧名与
+    # 批5.2 版本化新名，否则多进程模式的新标记匹配不到、迁移被误放行）
+    for runtime_file in list_runtime_marker_files(config_path):
         try:
             data = json.loads(runtime_file.read_text(encoding="utf-8"))
             pid = data.get("pid")
@@ -547,6 +548,22 @@ def delete_runtime_marker(config_dir: Path | str, instance_id: str = "",
                 path.unlink()
         except OSError:
             pass
+
+
+def list_runtime_marker_files(config_dir: Path | str) -> list[Path]:
+    """列出 config 目录内全部 runtime 标记文件。
+
+    同时认旧名 ``runtime-<pid>.json`` 与批5.2 版本化新名
+    ``pet-runtime-v2-<pid>-slot-<N>.json``。清理/迁移必须覆盖两种命名，否则
+    多进程模式下的新标记（只写 v2 名）匹配不到、子进程杀不掉/迁移被误放行。
+    """
+    root = Path(config_dir)
+    try:
+        files = list(root.glob("runtime-*.json"))
+        files.extend(root.glob(f"{_RUNTIME_V2_PREFIX}*.json"))
+        return files
+    except OSError:
+        return []
 
 
 def read_live_instances(

--- a/pet/throw_egg.py
+++ b/pet/throw_egg.py
@@ -4,25 +4,19 @@
 > 批 D / 通用约束：非探头状态被击飞维持批 A 现状；不加配置开关，彩蛋常开。
 > 控制器只维护激活状态与当前角度；整帧旋转由 PetWindow 经 pet/window_effects.py
 > 应用（与 edge_probe / golden_spin 同一绘制管线，begin_rotation/end_rotation）。
-> 落地停稳（_stop_physics 兜底）、低速触碰屏幕边界或其它桌宠、或飞行超过
-> THROW_EGG_MAX_FLIGHT_SECONDS 后恢复正常（角度归零）。
+> 落地停稳（_stop_physics 兜底）、低速触碰屏幕边界或其它桌宠后恢复正常
+> （角度归零）。用户明确要求不设飞行时间硬上限。
 """
 from __future__ import annotations
 
 import math
-import time
 from typing import Any
 
 # 速度低于该阈值（并触碰边界/桌宠）时结束彩蛋、恢复正常姿态。
 # 量级参照 physics.is_at_rest 的静止判定（REST_VY / REST_VX 为几十 px/s 量级）。
-# 120 太低：多只桌宠互撞时 _predict_collision_bounce 不断补速度，速度长期
-# 在 120~240 徘徊降不到阈值 → 彩蛋卡死，故提到 240（另见时间硬上限兜底）。
-THROW_EGG_RECOVER_SPEED = 240.0  # px/s
-
-# 飞行时间硬上限（秒）：超过即无条件结束彩蛋。
-# 纯速度阈值在「多只桌宠互撞、速度被反复补充」时可能永远不满足，
-# 必须有一条与速度无关的时间兜底，保证彩蛋不会永久卡死。
-THROW_EGG_MAX_FLIGHT_SECONDS = 8.0
+# 120/240 都太低：多只桌宠互撞时 _predict_collision_bounce 不断补速度，速度
+# 降不到阈值 → 彩蛋卡死，故拉到 400（用户实机要求，明确不要时间硬上限）。
+THROW_EGG_RECOVER_SPEED = 400.0  # px/s
 
 
 class ThrowEggController:
@@ -30,16 +24,13 @@ class ThrowEggController:
 
     每个 PetWindow 持有同一实例；仅在边缘探头激活被撞时由 arm() 开启。
     飞行中每 tick 以 update() 跟随速度方向更新角度；落地停稳（_stop_physics
-    兜底）、低速触碰边界或桌宠、或飞行超过时间硬上限时 end() 结束并恢复
-    正常姿态。不依赖素材。
+    兜底）、低速触碰边界或桌宠时 end() 结束并恢复正常姿态。不依赖素材。
     """
 
     def __init__(self, win: Any) -> None:
         self.win = win
         self._active = False
         self._angle_deg = 0.0
-        # arm() 起点（time.monotonic）：飞行时间硬上限兜底用。
-        self._armed_at = 0.0
 
     # ------------------------------------------------------------ 查询
     @property
@@ -54,20 +45,15 @@ class ThrowEggController:
         """仅探头激活被撞时由 edge_probe.cancel 调用 → 开始头部跟随速度。"""
         self._active = True
         self._angle_deg = 0.0
-        self._armed_at = time.monotonic()
         self._notify()
 
     def update(self, vx: float, vy: float, touching_boundary: bool) -> None:
-        """每 tick 由 _tick_throw_physics 调用；低速贴界或超时则恢复正常姿态。
+        """每 tick 由 _tick_throw_physics 调用；低速贴界则恢复正常姿态。
 
         速度高于阈值时才更新角度（低于阈值保持当前角，防抖）；
-        速度低于阈值且触碰边界 → end()；飞行超过 THROW_EGG_MAX_FLIGHT_SECONDS
-        无条件 end()（多只桌宠互撞时速度可能永远降不到阈值，时间兜底防卡死）。
+        速度低于阈值且触碰边界 → end()。不设飞行时间上限（用户明确要求）。
         """
         if not self._active:
-            return
-        if time.monotonic() - self._armed_at >= THROW_EGG_MAX_FLIGHT_SECONDS:
-            self.end()
             return
         speed = math.hypot(vx, vy)
         if speed >= THROW_EGG_RECOVER_SPEED:

--- a/pet/throw_egg.py
+++ b/pet/throw_egg.py
@@ -14,9 +14,10 @@ from typing import Any
 
 # 速度低于该阈值（并触碰边界/桌宠）时结束彩蛋、恢复正常姿态。
 # 量级参照 physics.is_at_rest 的静止判定（REST_VY / REST_VX 为几十 px/s 量级）。
-# 120/240 都太低：多只桌宠互撞时 _predict_collision_bounce 不断补速度，速度
-# 降不到阈值 → 彩蛋卡死，故拉到 400（用户实机要求，明确不要时间硬上限）。
-THROW_EGG_RECOVER_SPEED = 400.0  # px/s
+# 120/240/400 都太低：低速贴地时会快速连续碰撞，速度方向反复翻转导致鱼头
+# 快速来回变向（用户实机反馈"很奇怪"），故拉到 780——低速弹跳段直接不再
+# 更新角度且一碰就回正（用户实机要求，明确不要时间硬上限）。
+THROW_EGG_RECOVER_SPEED = 780.0  # px/s
 
 
 class ThrowEggController:

--- a/pet/throw_egg.py
+++ b/pet/throw_egg.py
@@ -4,16 +4,25 @@
 > 批 D / 通用约束：非探头状态被击飞维持批 A 现状；不加配置开关，彩蛋常开。
 > 控制器只维护激活状态与当前角度；整帧旋转由 PetWindow 经 pet/window_effects.py
 > 应用（与 edge_probe / golden_spin 同一绘制管线，begin_rotation/end_rotation）。
-> 落地停稳（_stop_physics 兜底）、低速触碰屏幕边界或其它桌宠后恢复正常（角度归零）。
+> 落地停稳（_stop_physics 兜底）、低速触碰屏幕边界或其它桌宠、或飞行超过
+> THROW_EGG_MAX_FLIGHT_SECONDS 后恢复正常（角度归零）。
 """
 from __future__ import annotations
 
 import math
+import time
 from typing import Any
 
 # 速度低于该阈值（并触碰边界/桌宠）时结束彩蛋、恢复正常姿态。
 # 量级参照 physics.is_at_rest 的静止判定（REST_VY / REST_VX 为几十 px/s 量级）。
-THROW_EGG_RECOVER_SPEED = 120.0  # px/s
+# 120 太低：多只桌宠互撞时 _predict_collision_bounce 不断补速度，速度长期
+# 在 120~240 徘徊降不到阈值 → 彩蛋卡死，故提到 240（另见时间硬上限兜底）。
+THROW_EGG_RECOVER_SPEED = 240.0  # px/s
+
+# 飞行时间硬上限（秒）：超过即无条件结束彩蛋。
+# 纯速度阈值在「多只桌宠互撞、速度被反复补充」时可能永远不满足，
+# 必须有一条与速度无关的时间兜底，保证彩蛋不会永久卡死。
+THROW_EGG_MAX_FLIGHT_SECONDS = 8.0
 
 
 class ThrowEggController:
@@ -21,13 +30,16 @@ class ThrowEggController:
 
     每个 PetWindow 持有同一实例；仅在边缘探头激活被撞时由 arm() 开启。
     飞行中每 tick 以 update() 跟随速度方向更新角度；落地停稳（_stop_physics
-    兜底）、低速触碰边界或桌宠时 end() 结束并恢复正常姿态。不依赖素材。
+    兜底）、低速触碰边界或桌宠、或飞行超过时间硬上限时 end() 结束并恢复
+    正常姿态。不依赖素材。
     """
 
     def __init__(self, win: Any) -> None:
         self.win = win
         self._active = False
         self._angle_deg = 0.0
+        # arm() 起点（time.monotonic）：飞行时间硬上限兜底用。
+        self._armed_at = 0.0
 
     # ------------------------------------------------------------ 查询
     @property
@@ -42,15 +54,20 @@ class ThrowEggController:
         """仅探头激活被撞时由 edge_probe.cancel 调用 → 开始头部跟随速度。"""
         self._active = True
         self._angle_deg = 0.0
+        self._armed_at = time.monotonic()
         self._notify()
 
     def update(self, vx: float, vy: float, touching_boundary: bool) -> None:
-        """每 tick 由 _tick_throw_physics 调用；低速贴界则恢复正常姿态。
+        """每 tick 由 _tick_throw_physics 调用；低速贴界或超时则恢复正常姿态。
 
         速度高于阈值时才更新角度（低于阈值保持当前角，防抖）；
-        速度低于阈值且触碰边界 → end()。
+        速度低于阈值且触碰边界 → end()；飞行超过 THROW_EGG_MAX_FLIGHT_SECONDS
+        无条件 end()（多只桌宠互撞时速度可能永远降不到阈值，时间兜底防卡死）。
         """
         if not self._active:
+            return
+        if time.monotonic() - self._armed_at >= THROW_EGG_MAX_FLIGHT_SECONDS:
+            self.end()
             return
         speed = math.hypot(vx, vy)
         if speed >= THROW_EGG_RECOVER_SPEED:

--- a/pet/throw_egg.py
+++ b/pet/throw_egg.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+"""彩蛋：边缘探头状态的桌宠被击飞时，飞行中整帧旋转使头部跟随速度方向。
+
+> 批 D / 通用约束：非探头状态被击飞维持批 A 现状；不加配置开关，彩蛋常开。
+> 控制器只维护激活状态与当前角度；整帧旋转由 PetWindow 经 pet/window_effects.py
+> 应用（与 edge_probe / golden_spin 同一绘制管线，begin_rotation/end_rotation）。
+> 落地停稳（_stop_physics 兜底）、低速触碰屏幕边界或其它桌宠后恢复正常（角度归零）。
+"""
+from __future__ import annotations
+
+import math
+from typing import Any
+
+# 速度低于该阈值（并触碰边界/桌宠）时结束彩蛋、恢复正常姿态。
+# 量级参照 physics.is_at_rest 的静止判定（REST_VY / REST_VX 为几十 px/s 量级）。
+THROW_EGG_RECOVER_SPEED = 120.0  # px/s
+
+
+class ThrowEggController:
+    """管理“被击飞时头部跟随速度方向”的旋转会话。
+
+    每个 PetWindow 持有同一实例；仅在边缘探头激活被撞时由 arm() 开启。
+    飞行中每 tick 以 update() 跟随速度方向更新角度；落地停稳（_stop_physics
+    兜底）、低速触碰边界或桌宠时 end() 结束并恢复正常姿态。不依赖素材。
+    """
+
+    def __init__(self, win: Any) -> None:
+        self.win = win
+        self._active = False
+        self._angle_deg = 0.0
+
+    # ------------------------------------------------------------ 查询
+    @property
+    def active(self) -> bool:
+        return self._active
+
+    def current_angle_deg(self) -> float:
+        return self._angle_deg if self._active else 0.0
+
+    # ------------------------------------------------------------ 开关
+    def arm(self) -> None:
+        """仅探头激活被撞时由 edge_probe.cancel 调用 → 开始头部跟随速度。"""
+        self._active = True
+        self._angle_deg = 0.0
+        self._notify()
+
+    def update(self, vx: float, vy: float, touching_boundary: bool) -> None:
+        """每 tick 由 _tick_throw_physics 调用；低速贴界则恢复正常姿态。
+
+        速度高于阈值时才更新角度（低于阈值保持当前角，防抖）；
+        速度低于阈值且触碰边界 → end()。
+        """
+        if not self._active:
+            return
+        speed = math.hypot(vx, vy)
+        if speed >= THROW_EGG_RECOVER_SPEED:
+            # 屏幕坐标 y 朝下：向右飞=90°、向下=180°、向上=0°、向左=270°。
+            self._angle_deg = 90.0 + math.degrees(math.atan2(vy, vx))
+        if speed < THROW_EGG_RECOVER_SPEED and touching_boundary:
+            self.end()
+            return
+        self._notify()
+
+    def on_pet_contact(self, speed: float) -> None:
+        """飞行中再次撞到其它桌宠：低速则立刻恢复正常姿态。"""
+        if not self._active:
+            return
+        if speed < THROW_EGG_RECOVER_SPEED:
+            self.end()
+
+    def end(self) -> None:
+        """恢复正常姿态；幂等。落地停稳（_stop_physics）无条件调用兜底。"""
+        if not self._active:
+            return
+        self._active = False
+        self._angle_deg = 0.0
+        self._notify()
+
+    # ------------------------------------------------------------ 内部
+    def _notify(self) -> None:
+        try:
+            self.win.update()
+        except Exception:
+            pass

--- a/pet/window.py
+++ b/pet/window.py
@@ -4140,6 +4140,9 @@ class PetWindow(QWidget, WindowFeatureGateMixin):
             self._interaction_state = IDLE
         self._phys_vel[:] = [0.0, 0.0]
         self._submit_collision_state(force=True)
+        _te = getattr(self, '_throw_egg', None)
+        if _te is not None:
+            _te.end()
 
     def _enter_physics_mode(self, mode: str) -> None:
         """进入物理模式（'drag'/'throw'）：统一取消自主移动计划与动画间隔，
@@ -4208,6 +4211,9 @@ class PetWindow(QWidget, WindowFeatureGateMixin):
 
         self._phys_pos[:] = [px, py]
         self._phys_vel[:] = [vx, vy]
+        _te = getattr(self, '_throw_egg', None)
+        if _te is not None:
+            _te.update(vx, vy, px <= left + 1e-6 or px >= right - 1e-6 or py >= bottom - 1e-6)
         predict_bounce = getattr(self, '_predict_collision_bounce', None)
         if callable(predict_bounce):
             predict_bounce(start_px, start_py)

--- a/pet/window.py
+++ b/pet/window.py
@@ -920,6 +920,10 @@ class PetWindow(QWidget, WindowFeatureGateMixin):
                 self.visible_content_rect(), pet_scale=self.scale
             )
         self.update()
+        # 右键菜单改大小属于用户主动设置：子肥鱼置位 user_customized（占位），
+        # 下次生成不被主设置刷新；位置自存等后台写盘不置位（_save_position 不动旗）。
+        if getattr(getattr(self, "cfg", None), "instance_id", None):
+            self.cfg.set("user_customized", True)
         self._save_position()
 
     # ================================================================ 位置
@@ -1172,6 +1176,13 @@ class PetWindow(QWidget, WindowFeatureGateMixin):
         self._submit_collision_state(force=True)
         self._schedule_macos_window_level(bool(self.cfg.get('on_top', True)))
         self._apply_opacity()
+        # 启动即登记 runtime 标记：否则没被拖动过的新生小肥鱼没有标记，
+        # 「退出子肥鱼」按标记枚举时根本看不见它（实机：总有一只清不掉）。
+        # 尽力而为：登记失败不影响窗口显示。
+        try:
+            self._write_runtime_marker()
+        except Exception:
+            logging.debug("登记 runtime 标记失败", exc_info=True)
         # 隐藏期暂停的活动在此恢复（与 hide() 中的 _pause_activity 配对）
         if self._hidden_paused:
             self._hidden_paused = False

--- a/pet/window_optional_services.py
+++ b/pet/window_optional_services.py
@@ -25,6 +25,7 @@ class WindowFeatureGateMixin:
     _broker_facade: Any = None
     _golden_spin: Any = None
     _edge_probe: Any = None
+    _throw_egg: Any = None
 
     # ------------------------------------------------------------ 判定
     def _proactive_wanted(self) -> bool:
@@ -72,6 +73,9 @@ class WindowFeatureGateMixin:
         if self._golden_spin is None:
             from .golden_spin import GoldenSpinController
             self._golden_spin = GoldenSpinController(self)
+        if self._throw_egg is None:
+            from .throw_egg import ThrowEggController
+            self._throw_egg = ThrowEggController(self)
         return self
 
     def trigger_golden_spin(self) -> None:
@@ -97,6 +101,9 @@ class WindowFeatureGateMixin:
     def _effects_current_angle(self) -> float:
         if self._effects_probe_active():
             return float(self._edge_probe.current_angle_deg())
+        egg = getattr(self, "_throw_egg", None)
+        if egg is not None and egg.active:
+            return float(egg.current_angle_deg())
         spin = getattr(self, "_golden_spin", None)
         if spin is not None and spin.active:
             return float(spin.current_angle_deg())
@@ -118,9 +125,11 @@ class WindowFeatureGateMixin:
         return unrotate_point(point, rect, self._effects_current_angle())
 
     def _effects_filter_switch(self, name: str) -> str:
-        """边缘探头会话期间只允许待机/转向动画；其它请求降级到随机待机。"""
+        """边缘探头/彩蛋飞行会话期间只允许待机/转向动画；其它请求降级到随机待机。"""
         if not self._effects_probe_active():
-            return name
+            egg = getattr(self, "_throw_egg", None)
+            if egg is None or not egg.active:
+                return name
         idles = list(getattr(self, "idles", ()) or ())
         turns = list(getattr(self, "turns", ()) or ())
         if name in idles or name in turns or not idles:

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -54,8 +54,9 @@ WINDOW_PY_LINE_BUDGET = 4352
 # 2026-09-06 上调到 1992：合入上游 main（PR73）带来动画预热开关等 +85 行
 # （实测 1942），预算随实测校准。
 # 2026-09-08 上调到 1996：新增「随桌宠启动 dsh 服务」开关行（+4，实测 1996）。
+# 2026-09-08 上调到 2000：批 C 落种占位语义在保存路径加 user_customized 置位（+4，实测 2000）。
 # 本文件拆分仍是待办，拆分前预算只随实测校准。
-MODERN_SETTINGS_DIALOG_PY_LINE_BUDGET = 1996
+MODERN_SETTINGS_DIALOG_PY_LINE_BUDGET = 2000
 
 
 def _read(name: str) -> str:

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -58,8 +58,12 @@ WINDOW_PY_LINE_BUDGET = 4358
 # （实测 1942），预算随实测校准。
 # 2026-09-08 上调到 1996：新增「随桌宠启动 dsh 服务」开关行（+4，实测 1996）。
 # 2026-09-08 上调到 2000：批 C 落种占位语义在保存路径加 user_customized 置位（+4，实测 2000）。
+# 2026-09-08 上调到 2009：批 E 清除子肥鱼走 shell 已接线回调（+9，实测 2009）——
+# _on_clear_spawned_pets 优先调 win.on_clear_spawned_pets（自带确认框与进程内
+# 子窗前置于关闭），拿不到回调时回退原有确认+直接清理；按文件约定校准预算，
+# 不为达标压缩行宽/合并语句。
 # 本文件拆分仍是待办，拆分前预算只随实测校准。
-MODERN_SETTINGS_DIALOG_PY_LINE_BUDGET = 2000
+MODERN_SETTINGS_DIALOG_PY_LINE_BUDGET = 2009
 
 
 def _read(name: str) -> str:

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -43,7 +43,10 @@ PET_DIR = Path(__file__).resolve().parents[1] / "pet"
 # 取消激活中的边缘探头会话，防止宠物斜着出现在右下角；实测 4350）。
 # 2026-09-08 上调到 4352：合入识屏自我识别 pet_name 传递（+4）与死键清理（-2），
 # 实测 4352。window.py 分块拆分仍是待办，拆分前预算只随实测校准。
-WINDOW_PY_LINE_BUDGET = 4352
+# 2026-09-08 上调到 4358：批 D 彩蛋（边缘探头被击飞时飞行中整帧旋转跟随速度方向）——
+# window.py 仅保留薄钩子（_tick_throw_physics 调 throw_egg.update、_stop_physics 调
+# throw_egg.end），控制器实现在 throw_egg.py；实测 4358。
+WINDOW_PY_LINE_BUDGET = 4358
 
 # modern_settings_dialog.py 行数预算：按结构线拆分后实测 1857 行（拆分前 4811 行）。
 # 主对话框 ModernSettingsDialog + 对话框装配/配置写回 + 为 pet/ 与 tests/ 保留的

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -46,7 +46,10 @@ PET_DIR = Path(__file__).resolve().parents[1] / "pet"
 # 2026-09-08 上调到 4358：批 D 彩蛋（边缘探头被击飞时飞行中整帧旋转跟随速度方向）——
 # window.py 仅保留薄钩子（_tick_throw_physics 调 throw_egg.update、_stop_physics 调
 # throw_egg.end），控制器实现在 throw_egg.py；实测 4358。
-WINDOW_PY_LINE_BUDGET = 4358
+# 2026-09-08 上调到 4369：批 G——change_scale 子肥鱼置位 user_customized（+4）、
+# showEvent 启动即登记 runtime 标记（+7，含 try 兜底，修「退出子肥鱼」漏清未
+# 拖动过的小肥鱼），实测 4369。
+WINDOW_PY_LINE_BUDGET = 4369
 
 # modern_settings_dialog.py 行数预算：按结构线拆分后实测 1857 行（拆分前 4811 行）。
 # 主对话框 ModernSettingsDialog + 对话框装配/配置写回 + 为 pet/ 与 tests/ 保留的
@@ -62,8 +65,10 @@ WINDOW_PY_LINE_BUDGET = 4358
 # _on_clear_spawned_pets 优先调 win.on_clear_spawned_pets（自带确认框与进程内
 # 子窗前置于关闭），拿不到回调时回退原有确认+直接清理；按文件约定校准预算，
 # 不为达标压缩行宽/合并语句。
+# 2026-09-08 上调到 2018：批 G——「退出子肥鱼」按钮对子肥鱼禁用（+5）+
+# _on_clear_spawned_pets 加 instance_id 双保险（+5，含注释折行），实测 2018。
 # 本文件拆分仍是待办，拆分前预算只随实测校准。
-MODERN_SETTINGS_DIALOG_PY_LINE_BUDGET = 2009
+MODERN_SETTINGS_DIALOG_PY_LINE_BUDGET = 2018
 
 
 def _read(name: str) -> str:

--- a/tests/test_child_pet_cleanup.py
+++ b/tests/test_child_pet_cleanup.py
@@ -3,8 +3,18 @@
 from __future__ import annotations
 
 import json
+import os
+
+import pytest
 
 from pet import child_pet_cleanup
+from pet import slot_manager as slot_manager_mod
+
+
+def _stub_pet_identity(monkeypatch):
+    """批 H：杀前用 exe 路径核验 pid 身份（防 pid 复用误杀）。测试用假 pid，
+    统一打桩为「是本程序」；身份核验本身由专门用例覆盖。"""
+    monkeypatch.setattr(child_pet_cleanup, "_is_pet_process", lambda pid: True)
 
 
 def test_clear_spawned_pets_kills_processes_and_keeps_slot_data(tmp_path, monkeypatch):
@@ -30,6 +40,7 @@ def test_clear_spawned_pets_kills_processes_and_keeps_slot_data(tmp_path, monkey
 
     terminated = []
     alive = {222}
+    _stub_pet_identity(monkeypatch)
     monkeypatch.setattr(
         child_pet_cleanup,
         "_pid_alive",
@@ -89,6 +100,7 @@ def test_clear_spawned_pets_removes_v2_markers_and_keeps_slot_data(tmp_path, mon
 
     terminated = []
     alive = {444}
+    _stub_pet_identity(monkeypatch)
     monkeypatch.setattr(
         child_pet_cleanup,
         "_pid_alive",
@@ -135,6 +147,7 @@ def test_clear_spawned_pets_handles_legacy_and_v2_together_idempotent(
 
     terminated = []
     alive = {111, 222}
+    _stub_pet_identity(monkeypatch)
     monkeypatch.setattr(
         child_pet_cleanup, "_pid_alive", lambda pid: pid in alive)
 
@@ -174,6 +187,7 @@ def test_clear_spawned_pets_kill_failure_keeps_marker_and_reports(
     live_marker.write_text(json.dumps({"pid": 777}), encoding="utf-8")
 
     terminated = []
+    _stub_pet_identity(monkeypatch)
     monkeypatch.setattr(
         child_pet_cleanup, "_pid_alive", lambda pid: pid == 777)
     monkeypatch.setattr(
@@ -202,6 +216,7 @@ def test_clear_spawned_pets_retry_succeeds_on_second_attempt(
 
     terminated = []
     alive = {888}
+    _stub_pet_identity(monkeypatch)
     monkeypatch.setattr(
         child_pet_cleanup, "_pid_alive", lambda pid: pid in alive)
 
@@ -233,6 +248,7 @@ def test_clear_spawned_pets_never_kills_slot0_v2_marker(tmp_path, monkeypatch):
 
     alive = {999, 888}
     terminated = []
+    _stub_pet_identity(monkeypatch)
     monkeypatch.setattr(
         child_pet_cleanup, "_pid_alive", lambda pid: pid in alive)
 
@@ -248,3 +264,69 @@ def test_clear_spawned_pets_never_kills_slot0_v2_marker(tmp_path, monkeypatch):
     assert result["killed_pids"] == [888]
     assert main_v2.exists(), "主肥鱼标记必须保留"
     assert not child_v2.exists()
+
+
+def test_clear_spawned_pets_recycled_pid_treated_as_stale_marker(tmp_path, monkeypatch):
+    """批 H：陈旧标记的 pid 被无关进程复用（存活但不是本程序）→ 不误杀、
+    按陈旧标记删除，不计入 failed_pids（实机事故：0 杀 2 失败）。"""
+    root = tmp_path / "dsh-pet-standalone"
+    root.mkdir(parents=True)
+    marker = root / "runtime-777.json"
+    marker.write_text(json.dumps({"pid": 777}), encoding="utf-8")
+
+    monkeypatch.setattr(child_pet_cleanup, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(child_pet_cleanup, "_is_pet_process", lambda pid: False)
+    terminated = []
+    monkeypatch.setattr(
+        child_pet_cleanup, "_terminate_pet_process",
+        lambda pid: terminated.append(pid))
+
+    result = child_pet_cleanup.clear_spawned_pets(root)
+    assert terminated == [], "pid 被无关进程复用时不得 taskkill"
+    assert result["killed_pids"] == []
+    assert result["failed_pids"] == []
+    assert not marker.exists(), "复用 pid 的陈旧标记应被清理"
+
+
+def test_clear_spawned_pets_slot_lock_as_second_source(tmp_path, monkeypatch):
+    """批 H：没写过 runtime 标记的小肥鱼也持有 slots/slot-N.lock（内含 pid），
+    锁文件作为第二枚举源把这类漏网之鱼杀掉；slot-0（主肥鱼）跳过。"""
+    root = tmp_path / "dsh-pet-standalone"
+    (root / "slots").mkdir(parents=True)
+    (root / "slots" / "slot-0.lock").write_bytes(
+        slot_manager_mod._format_pid_record(999))
+    (root / "slots" / "slot-2.lock").write_bytes(
+        slot_manager_mod._format_pid_record(888))
+
+    alive = {999, 888}
+    terminated = []
+    monkeypatch.setattr(
+        child_pet_cleanup, "_pid_alive", lambda pid: pid in alive)
+    monkeypatch.setattr(child_pet_cleanup, "_is_pet_process", lambda pid: True)
+
+    def fake_terminate(pid):
+        terminated.append(pid)
+        alive.discard(pid)
+
+    monkeypatch.setattr(
+        child_pet_cleanup, "_terminate_pet_process", fake_terminate)
+
+    result = child_pet_cleanup.clear_spawned_pets(root)
+    assert terminated == [888], "slot-2（子肥鱼）杀掉，slot-0（主肥鱼）跳过"
+    assert result["killed_pids"] == [888]
+
+
+@pytest.mark.skipif(os.name != "nt", reason="CREATE_NO_WINDOW 仅 Windows 有")
+def test_terminate_uses_create_no_window_on_windows(monkeypatch):
+    """批 H：Windows 下 taskkill 必须带 CREATE_NO_WINDOW——GUI 进程无控制台，
+    裸 subprocess 会每杀一只弹一个空白终端窗口（实机反馈）。"""
+    import subprocess as sp
+
+    import pet.child_pet_cleanup as mod
+
+    calls = []
+    monkeypatch.setattr(mod.subprocess, "run",
+                        lambda *a, **kw: calls.append(kw))
+    mod._terminate_pet_process(12345)
+    assert len(calls) == 1
+    assert calls[0].get("creationflags") == sp.CREATE_NO_WINDOW

--- a/tests/test_child_pet_cleanup.py
+++ b/tests/test_child_pet_cleanup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""一键清除子肥鱼：关闭 slot-N 进程并删除 slot 数据，主 slot-0 不受影响。"""
+"""一键退出子肥鱼：关闭 slot-N 进程并清理 runtime 标记；slot 数据保留，主 slot-0 不受影响。"""
 from __future__ import annotations
 
 import json
@@ -7,7 +7,7 @@ import json
 from pet import child_pet_cleanup
 
 
-def test_clear_spawned_pets_removes_slot_data_and_markers(tmp_path, monkeypatch):
+def test_clear_spawned_pets_kills_processes_and_keeps_slot_data(tmp_path, monkeypatch):
     root = tmp_path / "dsh-pet-standalone"
     root.mkdir(parents=True)
 
@@ -46,20 +46,21 @@ def test_clear_spawned_pets_removes_slot_data_and_markers(tmp_path, monkeypatch)
     assert terminated == [222]
     assert not dead_marker.exists()
     assert not live_marker.exists()
-    assert not (root / "config-slot-1.json").exists()
-    assert not (root / "config-slot-2.json").exists()
-    assert not (root / "todo_items-slot-2.json").exists()
-    assert not (root / "sessions-slot-1").exists()
+    # 批 F 起只退出进程：slot 配置/会话/待办数据全部保留（占位语义靠它们恢复）
+    assert (root / "config-slot-1.json").exists()
+    assert (root / "config-slot-2.json").exists()
+    assert (root / "todo_items-slot-2.json").exists()
+    assert (root / "sessions-slot-1").is_dir()
     # 主数据必须保留
     assert (root / "config.json").exists()
     assert (root / "sessions").is_dir()
 
 
-def test_clear_spawned_pets_removes_v2_markers_and_slot_data(tmp_path, monkeypatch):
+def test_clear_spawned_pets_removes_v2_markers_and_keeps_slot_data(tmp_path, monkeypatch):
     """批 B：多进程模式的 v2 标记（只写 pet-runtime-v2-*.json 新名）被找到并清理。
 
     旧 glob 只认 runtime-*.json，会匹配不到新标记 → 子进程杀不掉；修复后
-    两处 glob 同时认新旧两种命名。v2 标记与 slot 数据一并清掉，主鱼不碰。
+    两处 glob 同时认新旧两种命名。批 F 起 slot 数据保留，主鱼不碰。
     """
     root = tmp_path / "dsh-pet-standalone"
     root.mkdir(parents=True)
@@ -97,9 +98,10 @@ def test_clear_spawned_pets_removes_v2_markers_and_slot_data(tmp_path, monkeypat
     assert terminated == [444]
     assert not dead_v2.exists()
     assert not live_v2.exists()
-    assert not (root / "config-slot-1.json").exists()
-    assert not (root / "config-slot-2.json").exists()
-    assert not (root / "sessions-slot-1").exists()
+    # 批 F：slot 数据保留
+    assert (root / "config-slot-1.json").exists()
+    assert (root / "config-slot-2.json").exists()
+    assert (root / "sessions-slot-1").is_dir()
     # 主数据必须保留
     assert (root / "config.json").exists()
     assert (root / "sessions").is_dir()
@@ -131,8 +133,7 @@ def test_clear_spawned_pets_handles_legacy_and_v2_together_idempotent(
     assert not v2.exists()
     assert terminated == [111, 222]
 
-    # 幂等：再跑一遍无残留、不重复杀、不重复删
+    # 幂等：再跑一遍无残留、不重复杀
     result = child_pet_cleanup.clear_spawned_pets(root)
     assert result["killed_pids"] == []
-    assert result["deleted"] == []
     assert terminated == [111, 222]

--- a/tests/test_child_pet_cleanup.py
+++ b/tests/test_child_pet_cleanup.py
@@ -29,20 +29,27 @@ def test_clear_spawned_pets_kills_processes_and_keeps_slot_data(tmp_path, monkey
     live_marker.write_text(json.dumps({"pid": 222}), encoding="utf-8")
 
     terminated = []
+    alive = {222}
     monkeypatch.setattr(
         child_pet_cleanup,
         "_pid_alive",
-        lambda pid: pid == 222,
+        lambda pid: pid in alive,
     )
+
+    def fake_terminate(pid):
+        terminated.append(pid)
+        alive.discard(pid)  # 杀后确认：进程真的退出
+
     monkeypatch.setattr(
         child_pet_cleanup,
         "_terminate_pet_process",
-        lambda pid: terminated.append(pid),
+        fake_terminate,
     )
 
     result = child_pet_cleanup.clear_spawned_pets(root)
 
     assert result["killed_pids"] == [222]
+    assert result["failed_pids"] == []
     assert terminated == [222]
     assert not dead_marker.exists()
     assert not live_marker.exists()
@@ -81,20 +88,27 @@ def test_clear_spawned_pets_removes_v2_markers_and_keeps_slot_data(tmp_path, mon
     live_v2.write_text(json.dumps({"pid": 444}), encoding="utf-8")
 
     terminated = []
+    alive = {444}
     monkeypatch.setattr(
         child_pet_cleanup,
         "_pid_alive",
-        lambda pid: pid == 444,
+        lambda pid: pid in alive,
     )
+
+    def fake_terminate(pid):
+        terminated.append(pid)
+        alive.discard(pid)
+
     monkeypatch.setattr(
         child_pet_cleanup,
         "_terminate_pet_process",
-        lambda pid: terminated.append(pid),
+        fake_terminate,
     )
 
     result = child_pet_cleanup.clear_spawned_pets(root)
 
     assert result["killed_pids"] == [444]
+    assert result["failed_pids"] == []
     assert terminated == [444]
     assert not dead_v2.exists()
     assert not live_v2.exists()
@@ -120,11 +134,17 @@ def test_clear_spawned_pets_handles_legacy_and_v2_together_idempotent(
     v2.write_text(json.dumps({"pid": 222}), encoding="utf-8")
 
     terminated = []
+    alive = {111, 222}
     monkeypatch.setattr(
-        child_pet_cleanup, "_pid_alive", lambda pid: True)
+        child_pet_cleanup, "_pid_alive", lambda pid: pid in alive)
+
+    def fake_terminate(pid):
+        terminated.append(pid)
+        alive.discard(pid)
+
     monkeypatch.setattr(
         child_pet_cleanup, "_terminate_pet_process",
-        lambda pid: terminated.append(pid),
+        fake_terminate,
     )
 
     child_pet_cleanup.clear_spawned_pets(root)
@@ -136,4 +156,95 @@ def test_clear_spawned_pets_handles_legacy_and_v2_together_idempotent(
     # 幂等：再跑一遍无残留、不重复杀
     result = child_pet_cleanup.clear_spawned_pets(root)
     assert result["killed_pids"] == []
+    assert result["failed_pids"] == []
     assert terminated == [111, 222]
+
+
+def test_clear_spawned_pets_kill_failure_keeps_marker_and_reports(
+        tmp_path, monkeypatch):
+    """批 G：杀进程失败（taskkill 异常/超时、权限不足等）不再静默吞掉——
+    保留 runtime 标记（不毁灭痕迹，供下次重试），pid 记入 failed_pids。
+
+    实机复现：旧实现杀失败照删标记 → 子肥鱼存活且清理方无迹可查。
+    """
+    root = tmp_path / "dsh-pet-standalone"
+    root.mkdir(parents=True)
+
+    live_marker = root / "runtime-777.json"
+    live_marker.write_text(json.dumps({"pid": 777}), encoding="utf-8")
+
+    terminated = []
+    monkeypatch.setattr(
+        child_pet_cleanup, "_pid_alive", lambda pid: pid == 777)
+    monkeypatch.setattr(
+        child_pet_cleanup, "_terminate_pet_process",
+        lambda pid: terminated.append(pid),  # 杀不动：进程始终存活
+    )
+    # 加速：确认轮询不真的等满 2s×2
+    monkeypatch.setattr(child_pet_cleanup, "_wait_pid_dead", lambda pid: False)
+
+    result = child_pet_cleanup.clear_spawned_pets(root)
+
+    assert result["killed_pids"] == []
+    assert result["failed_pids"] == [777]
+    assert terminated == [777, 777], "杀失败重试一次"
+    assert live_marker.exists(), "进程仍活时标记必须保留"
+
+
+def test_clear_spawned_pets_retry_succeeds_on_second_attempt(
+        tmp_path, monkeypatch):
+    """批 G：第一次杀不死、重试成功 → 计入 killed_pids 并正常删标记。"""
+    root = tmp_path / "dsh-pet-standalone"
+    root.mkdir(parents=True)
+
+    live_marker = root / "runtime-888.json"
+    live_marker.write_text(json.dumps({"pid": 888}), encoding="utf-8")
+
+    terminated = []
+    alive = {888}
+    monkeypatch.setattr(
+        child_pet_cleanup, "_pid_alive", lambda pid: pid in alive)
+
+    def fake_terminate(pid):
+        terminated.append(pid)
+        if len(terminated) >= 2:
+            alive.discard(pid)  # 第二次才杀死
+
+    monkeypatch.setattr(
+        child_pet_cleanup, "_terminate_pet_process", fake_terminate)
+
+    result = child_pet_cleanup.clear_spawned_pets(root)
+
+    assert result["killed_pids"] == [888]
+    assert result["failed_pids"] == []
+    assert terminated == [888, 888]
+    assert not live_marker.exists()
+
+
+def test_clear_spawned_pets_never_kills_slot0_v2_marker(tmp_path, monkeypatch):
+    """批 G 兜底：v2 标记名带 slot 编号，slot-0 是主肥鱼——即便从子肥鱼进程
+    调用（其 pid 自保护只跳过自己），主鱼标记也永不杀、永不删。"""
+    root = tmp_path / "dsh-pet-standalone"
+    root.mkdir(parents=True)
+    main_v2 = root / "pet-runtime-v2-999-slot-0.json"
+    main_v2.write_text(json.dumps({"pid": 999}), encoding="utf-8")
+    child_v2 = root / "pet-runtime-v2-888-slot-1.json"
+    child_v2.write_text(json.dumps({"pid": 888}), encoding="utf-8")
+
+    alive = {999, 888}
+    terminated = []
+    monkeypatch.setattr(
+        child_pet_cleanup, "_pid_alive", lambda pid: pid in alive)
+
+    def fake_terminate(pid):
+        terminated.append(pid)
+        alive.discard(pid)
+
+    monkeypatch.setattr(
+        child_pet_cleanup, "_terminate_pet_process", fake_terminate)
+
+    result = child_pet_cleanup.clear_spawned_pets(root)
+    assert terminated == [888], "只杀子肥鱼，主肥鱼 slot-0 跳过"
+    assert result["killed_pids"] == [888]
+    assert main_v2.exists(), "主肥鱼标记必须保留"
+    assert not child_v2.exists()

--- a/tests/test_child_pet_cleanup.py
+++ b/tests/test_child_pet_cleanup.py
@@ -53,3 +53,86 @@ def test_clear_spawned_pets_removes_slot_data_and_markers(tmp_path, monkeypatch)
     # 主数据必须保留
     assert (root / "config.json").exists()
     assert (root / "sessions").is_dir()
+
+
+def test_clear_spawned_pets_removes_v2_markers_and_slot_data(tmp_path, monkeypatch):
+    """批 B：多进程模式的 v2 标记（只写 pet-runtime-v2-*.json 新名）被找到并清理。
+
+    旧 glob 只认 runtime-*.json，会匹配不到新标记 → 子进程杀不掉；修复后
+    两处 glob 同时认新旧两种命名。v2 标记与 slot 数据一并清掉，主鱼不碰。
+    """
+    root = tmp_path / "dsh-pet-standalone"
+    root.mkdir(parents=True)
+
+    # 主数据
+    (root / "config.json").write_text("{}", encoding="utf-8")
+    (root / "sessions").mkdir()
+    # 子槽数据
+    (root / "config-slot-1.json").write_text("{}", encoding="utf-8")
+    (root / "config-slot-2.json").write_text("{}", encoding="utf-8")
+    (root / "sessions-slot-1").mkdir()
+    (root / "sessions-slot-1" / "s1.json").write_text("{}", encoding="utf-8")
+
+    # v2 runtime 标记：一个已死、一个存活（用假 PID，不真杀）
+    dead_v2 = root / "pet-runtime-v2-333-slot-1.json"
+    dead_v2.write_text(json.dumps({"pid": 333}), encoding="utf-8")
+    live_v2 = root / "pet-runtime-v2-444-slot-2.json"
+    live_v2.write_text(json.dumps({"pid": 444}), encoding="utf-8")
+
+    terminated = []
+    monkeypatch.setattr(
+        child_pet_cleanup,
+        "_pid_alive",
+        lambda pid: pid == 444,
+    )
+    monkeypatch.setattr(
+        child_pet_cleanup,
+        "_terminate_pet_process",
+        lambda pid: terminated.append(pid),
+    )
+
+    result = child_pet_cleanup.clear_spawned_pets(root)
+
+    assert result["killed_pids"] == [444]
+    assert terminated == [444]
+    assert not dead_v2.exists()
+    assert not live_v2.exists()
+    assert not (root / "config-slot-1.json").exists()
+    assert not (root / "config-slot-2.json").exists()
+    assert not (root / "sessions-slot-1").exists()
+    # 主数据必须保留
+    assert (root / "config.json").exists()
+    assert (root / "sessions").is_dir()
+
+
+def test_clear_spawned_pets_handles_legacy_and_v2_together_idempotent(
+        tmp_path, monkeypatch):
+    """批 B：混合新旧命名标记在同一调用里都被找到并清理；重复调用幂等无残留。"""
+    root = tmp_path / "dsh-pet-standalone"
+    root.mkdir(parents=True)
+    (root / "config.json").write_text("{}", encoding="utf-8")
+
+    legacy = root / "runtime-111.json"
+    legacy.write_text(json.dumps({"pid": 111}), encoding="utf-8")
+    v2 = root / "pet-runtime-v2-222-slot-1.json"
+    v2.write_text(json.dumps({"pid": 222}), encoding="utf-8")
+
+    terminated = []
+    monkeypatch.setattr(
+        child_pet_cleanup, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(
+        child_pet_cleanup, "_terminate_pet_process",
+        lambda pid: terminated.append(pid),
+    )
+
+    child_pet_cleanup.clear_spawned_pets(root)
+    # 新旧两种命名都被找到并清理
+    assert not legacy.exists()
+    assert not v2.exists()
+    assert terminated == [111, 222]
+
+    # 幂等：再跑一遍无残留、不重复杀、不重复删
+    result = child_pet_cleanup.clear_spawned_pets(root)
+    assert result["killed_pids"] == []
+    assert result["deleted"] == []
+    assert terminated == [111, 222]

--- a/tests/test_child_pet_cleanup.py
+++ b/tests/test_child_pet_cleanup.py
@@ -177,6 +177,7 @@ def test_clear_spawned_pets_kill_failure_keeps_marker_and_reports(
         tmp_path, monkeypatch):
     """批 G：杀进程失败（taskkill 异常/超时、权限不足等）不再静默吞掉——
     保留 runtime 标记（不毁灭痕迹，供下次重试），pid 记入 failed_pids。
+    批 I：两段式杀法（先全杀再统一等确认），不再有逐只重试。
 
     实机复现：旧实现杀失败照删标记 → 子肥鱼存活且清理方无迹可查。
     """
@@ -194,20 +195,18 @@ def test_clear_spawned_pets_kill_failure_keeps_marker_and_reports(
         child_pet_cleanup, "_terminate_pet_process",
         lambda pid: terminated.append(pid),  # 杀不动：进程始终存活
     )
-    # 加速：确认轮询不真的等满 2s×2
-    monkeypatch.setattr(child_pet_cleanup, "_wait_pid_dead", lambda pid: False)
 
     result = child_pet_cleanup.clear_spawned_pets(root)
 
     assert result["killed_pids"] == []
     assert result["failed_pids"] == [777]
-    assert terminated == [777, 777], "杀失败重试一次"
+    assert terminated == [777], "两段式杀法：每只只杀一次，统一等确认"
     assert live_marker.exists(), "进程仍活时标记必须保留"
 
 
-def test_clear_spawned_pets_retry_succeeds_on_second_attempt(
+def test_clear_spawned_pets_kill_success_removes_marker(
         tmp_path, monkeypatch):
-    """批 G：第一次杀不死、重试成功 → 计入 killed_pids 并正常删标记。"""
+    """批 I 两段式：杀成功 → 计入 killed_pids 并正常删标记。"""
     root = tmp_path / "dsh-pet-standalone"
     root.mkdir(parents=True)
 
@@ -222,8 +221,7 @@ def test_clear_spawned_pets_retry_succeeds_on_second_attempt(
 
     def fake_terminate(pid):
         terminated.append(pid)
-        if len(terminated) >= 2:
-            alive.discard(pid)  # 第二次才杀死
+        alive.discard(pid)
 
     monkeypatch.setattr(
         child_pet_cleanup, "_terminate_pet_process", fake_terminate)
@@ -232,7 +230,7 @@ def test_clear_spawned_pets_retry_succeeds_on_second_attempt(
 
     assert result["killed_pids"] == [888]
     assert result["failed_pids"] == []
-    assert terminated == [888, 888]
+    assert terminated == [888]
     assert not live_marker.exists()
 
 
@@ -339,3 +337,25 @@ def test_terminate_uses_create_no_window_on_windows(monkeypatch):
     mod._terminate_pet_process(12345)
     assert len(calls) == 1
     assert calls[0].get("creationflags") == sp.CREATE_NO_WINDOW
+
+
+def test_pid_alive_false_after_child_killed_with_handle_held():
+    """批 I 回归（实机事故）：父进程持有子进程句柄时，子进程被杀后其进程
+    对象仍可被 OpenProcess 打开——_pid_alive 必须用 GetExitCodeProcess 判定
+    真死活，否则杀成功的子鱼被误判存活，白等重试两轮并误报「未能退出」。"""
+    import subprocess
+    import sys
+
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        assert child_pet_cleanup._pid_alive(proc.pid)
+        proc.kill()
+        proc.wait()  # 已死，但 Popen 对象仍持有进程句柄（不 close/del）
+        assert not child_pet_cleanup._pid_alive(proc.pid), (
+            "句柄未释放不等于存活：必须读退出码判定")
+    finally:
+        try:
+            proc.kill()
+        except Exception:
+            pass

--- a/tests/test_child_pet_cleanup.py
+++ b/tests/test_child_pet_cleanup.py
@@ -325,8 +325,17 @@ def test_terminate_uses_create_no_window_on_windows(monkeypatch):
     import pet.child_pet_cleanup as mod
 
     calls = []
-    monkeypatch.setattr(mod.subprocess, "run",
-                        lambda *a, **kw: calls.append(kw))
+
+    class _FakeProc:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(*a, **kw):
+        calls.append(kw)
+        return _FakeProc()
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
     mod._terminate_pet_process(12345)
     assert len(calls) == 1
     assert calls[0].get("creationflags") == sp.CREATE_NO_WINDOW

--- a/tests/test_collision_window.py
+++ b/tests/test_collision_window.py
@@ -963,12 +963,12 @@ def test_probe_collision_throw_arms_egg_and_rotation_follows_velocity(tmp_path, 
     assert egg.active is True
     assert egg.current_angle_deg() == 0.0
 
-    # 飞行中向右飞（300 px/s，高于批 E 上调后的恢复阈值 240）：_tick_throw_physics
+    # 飞行中向右飞（500 px/s，高于批 F 上调后的恢复阈值 400）：_tick_throw_physics
     # 每 tick 调 update → 角度跟随速度。
     win._physics_mode = "throw"
     win._interaction_state = THROWN
     win._phys_pos[:] = [float(avail.center().x()), float(avail.center().y())]
-    win._phys_vel[:] = [300.0, 0.0]
+    win._phys_vel[:] = [500.0, 0.0]
     win._tick_throw_physics(0.016)
     assert egg.active
     # 角度 = 90 + atan2(vy, vx)（含重力,实际速度方向为右下，略大于 90°）。

--- a/tests/test_collision_window.py
+++ b/tests/test_collision_window.py
@@ -963,12 +963,12 @@ def test_probe_collision_throw_arms_egg_and_rotation_follows_velocity(tmp_path, 
     assert egg.active is True
     assert egg.current_angle_deg() == 0.0
 
-    # 飞行中向右飞（500 px/s，高于批 F 上调后的恢复阈值 400）：_tick_throw_physics
+    # 飞行中向右飞（900 px/s，高于批 F 上调后的恢复阈值 780）：_tick_throw_physics
     # 每 tick 调 update → 角度跟随速度。
     win._physics_mode = "throw"
     win._interaction_state = THROWN
     win._phys_pos[:] = [float(avail.center().x()), float(avail.center().y())]
-    win._phys_vel[:] = [500.0, 0.0]
+    win._phys_vel[:] = [900.0, 0.0]
     win._tick_throw_physics(0.016)
     assert egg.active
     # 角度 = 90 + atan2(vy, vx)（含重力,实际速度方向为右下，略大于 90°）。

--- a/tests/test_collision_window.py
+++ b/tests/test_collision_window.py
@@ -937,3 +937,45 @@ def test_real_collision_impulse_cancels_edge_probe_and_settle_arms_reentry(tmp_p
     assert probe._reentry_active is True
     assert abs(probe._reentry_remaining - EDGE_REENTRY_SECONDS) < 1e-6
     win.close()
+
+
+def test_probe_collision_throw_arms_egg_and_rotation_follows_velocity(tmp_path, app):
+    """批 D 集成：探头激活→真实撞击 arm 彩蛋→飞行整帧旋转跟随速度→落地停稳兜底恢复。"""
+    win, session = _make_pet_window(tmp_path, "pet_probe_egg")
+    avail = win.screen_available().availableGeometry()
+    local = win.character_local_region()
+    win.move(avail.left() - local.left(), 100)
+    win.cfg.set("edge_probe_enabled", True)
+    win.sync_optional_services()
+    probe = win._edge_probe
+    probe.on_release(was_dragging=True)
+    assert probe.active
+
+    egg = win._throw_egg
+    assert not egg.active
+
+    # 真实撞击：进入 throw 物理前取消探头会话并 arm 彩蛋（飞行中整帧旋转开始）。
+    msg = {"a": "pet_probe_egg", "b": "other", "pair": "other|pet_probe_egg",
+           "dvx_a": 400.0, "dvy_a": 0.0, "dx_a": 0.0, "dy_a": 0.0}
+    win._on_collision_impulse(msg)
+    assert probe.active is False
+    assert probe.mode == "OFF"
+    assert egg.active is True
+    assert egg.current_angle_deg() == 0.0
+
+    # 飞行中向右飞（200 px/s）：_tick_throw_physics 每 tick 调 update → 角度跟随速度。
+    win._physics_mode = "throw"
+    win._interaction_state = THROWN
+    win._phys_pos[:] = [float(avail.center().x()), float(avail.center().y())]
+    win._phys_vel[:] = [200.0, 0.0]
+    win._tick_throw_physics(0.016)
+    assert egg.active
+    # 角度 = 90 + atan2(vy, vx)（含重力,实际速度方向为右下，略大于 90°）。
+    expected = 90.0 + math.degrees(math.atan2(win._phys_vel[1], win._phys_vel[0]))
+    assert egg.current_angle_deg() == pytest.approx(expected, abs=1e-6)
+
+    # 落地停稳兜底：_stop_physics 无条件调用 end()，恢复正常姿态。
+    win._stop_physics()
+    assert not egg.active
+    assert egg.current_angle_deg() == 0.0
+    win.close()

--- a/tests/test_collision_window.py
+++ b/tests/test_collision_window.py
@@ -12,6 +12,7 @@ from PySide6.QtWidgets import QApplication
 from pet import catalog, collision
 from pet import physics as physics_mod
 from pet.config import Config
+from pet.edge_probe import EDGE_REENTRY_SECONDS
 from pet.window import PetWindow, THROWN
 
 NAMES = [
@@ -907,4 +908,32 @@ def test_self_talk_prunes_images_deleted_while_running(tmp_path, app):
     img.unlink()  # 运行期间被删
     assert win._show_random_self_talk() is False  # 无文本无图 → 不弹
     assert win._self_talk_images == []            # 惰性剔除生效
+    win.close()
+
+
+def test_real_collision_impulse_cancels_edge_probe_and_settle_arms_reentry(tmp_path, app):
+    """批 A 集成：探头激活→真实撞击→会话被取消→撞飞落地停稳后启动重进倒计时。"""
+    win, session = _make_pet_window(tmp_path, "pet_probe")
+    avail = win.screen_available().availableGeometry()
+    local = win.character_local_region()
+    win.move(avail.left() - local.left(), 100)
+    win.cfg.set("edge_probe_enabled", True)
+    win.sync_optional_services()
+    probe = win._edge_probe
+    probe.on_release(was_dragging=True)
+    assert probe.active
+
+    msg = {"a": "pet_probe", "b": "other", "pair": "other|pet_probe",
+           "dvx_a": 400.0, "dvy_a": 0.0, "dx_a": 0.0, "dy_a": 0.0}
+    win._on_collision_impulse(msg)
+    # 真实撞击进入 throw 物理前已取消探头会话（不回拉位置）。
+    assert probe.active is False
+    assert probe.mode == "OFF"
+    assert probe._reentry_armed is True
+
+    # 撞飞落地停稳：_stop_physics 会先把 _physics_mode 置 None 再回调状态提交，
+    # 由 CollisionClient 检测到 throw 结束并通知边缘探头开始重进倒计时。
+    win._stop_physics()
+    assert probe._reentry_active is True
+    assert abs(probe._reentry_remaining - EDGE_REENTRY_SECONDS) < 1e-6
     win.close()

--- a/tests/test_collision_window.py
+++ b/tests/test_collision_window.py
@@ -963,11 +963,12 @@ def test_probe_collision_throw_arms_egg_and_rotation_follows_velocity(tmp_path, 
     assert egg.active is True
     assert egg.current_angle_deg() == 0.0
 
-    # 飞行中向右飞（200 px/s）：_tick_throw_physics 每 tick 调 update → 角度跟随速度。
+    # 飞行中向右飞（300 px/s，高于批 E 上调后的恢复阈值 240）：_tick_throw_physics
+    # 每 tick 调 update → 角度跟随速度。
     win._physics_mode = "throw"
     win._interaction_state = THROWN
     win._phys_pos[:] = [float(avail.center().x()), float(avail.center().y())]
-    win._phys_vel[:] = [200.0, 0.0]
+    win._phys_vel[:] = [300.0, 0.0]
     win._tick_throw_physics(0.016)
     assert egg.active
     # 角度 = 90 + atan2(vy, vx)（含重力,实际速度方向为右下，略大于 90°）。

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -5,7 +5,7 @@ pet/config.py 里 __init__ 的默认值 dict（约 498-566 行）与 reload() �
 元组（约 656-691 行）是两份独立维护的键列表。本测试把现状文档化并加护栏：
 
 实测两集合**不一致**（现状文档化，不修产品代码）：
-- 默认值 dict 共 76 键；reload 白名单共 72 键。
+- 默认值 dict 共 77 键；reload 白名单共 73 键。
 - 差异 = 默认值多出 4 键：{version, proactive_screen, agent_link, chat}。
   这 4 键在 reload() 里走专门路径（version 末尾强制回写 4；
   proactive_screen / agent_link / chat 分别经 _merge_*_data 合并），
@@ -51,6 +51,7 @@ RELOAD_WHITELIST_SNAPSHOT = frozenset({
     "self_talk_image_dir", "self_talk_image_scale", "self_talk_max_interval", "self_talk_min_interval",
     "self_talk_texts", "shift_drag", "show_dock_icon", "slingshot_enabled",
     "spawn_inherit_dynamic_island", "spawn_inherit_size", "spawn_scale",
+    "user_customized",
     "stream_capture_mode", "system_notifications_enabled", "throw_strength",
     "experimental_single_process_spawn", "experimental_shared_decode",
     "todo_reminder_enabled", "todo_reminder_lead_minutes",
@@ -59,7 +60,7 @@ RELOAD_WHITELIST_SNAPSHOT = frozenset({
 # 默认值 dict 里不走普通白名单、由 reload() 专门路径处理的键（现状文档化）。
 SPECIAL_CASED_KEYS = frozenset({"version", "proactive_screen", "agent_link", "chat"})
 
-# 默认值 dict 键集合现状快照（77 键）= 白名单 ∪ 特例键。
+# 默认值 dict 键集合现状快照（78 键）= 白名单 ∪ 特例键。
 DEFAULTS_SNAPSHOT = RELOAD_WHITELIST_SNAPSHOT | SPECIAL_CASED_KEYS
 
 

--- a/tests/test_desktop_pet_features.py
+++ b/tests/test_desktop_pet_features.py
@@ -666,7 +666,7 @@ def test_modern_pet_context_menu_has_spawn_action_with_avatar_icon(monkeypatch):
     assert not spawn_action.icon().isNull()
     spawn_action.trigger()
     assert pet.spawn_count == 1
-    clear_action = next(action for action in controls.actions() if action.text() == "清除子肥鱼")
+    clear_action = next(action for action in controls.actions() if action.text() == "退出子肥鱼")
     assert not clear_action.icon().isNull()
     clear_action.trigger()
     assert pet.clear_count == 1

--- a/tests/test_edge_probe.py
+++ b/tests/test_edge_probe.py
@@ -11,8 +11,10 @@ from pet.edge_probe import (
     EDGE_IDLE_SECONDS,
     EDGE_PEEK_EXPOSURE,
     EDGE_PROBE_ANGLE,
+    EDGE_REENTRY_SECONDS,
     EDGE_RETURN_MS,
     EDGE_STRAIGHTEN_MS,
+    OFF,
     PEEKING,
     STRAIGHTENED,
     EdgeProbeController,
@@ -236,3 +238,83 @@ def test_feature_off_cancels_and_restores_position():
     ctrl.set_enabled(False)
     assert not ctrl.active
     assert ctrl.win.x() == -100
+
+
+def _activate_probe_at_left_edge(ctrl, times):
+    ctrl.win.move(-100, 100)
+    ctrl.win.anim = "idle"
+    ctrl.on_release(was_dragging=True)
+    times[0] += EDGE_ENTER_MS / 1000.0
+    ctrl._on_timer()
+    assert ctrl.mode == PEEKING
+
+
+def test_collision_throw_cancels_and_settle_reenters_probe():
+    """批 A：碰撞撞飞取消探头会话→落地停稳后 5 秒到期重新进入探头吸附。"""
+    _qapp()
+    ctrl, times = _controller_and_clock()
+    _activate_probe_at_left_edge(ctrl, times)
+    # 真实撞击：取消会话（物理引擎接管位置，不回拉），并标记落地后可重进。
+    ctrl.cancel("collision_throw", restore=False)
+    assert not ctrl.active
+    assert ctrl.mode == OFF
+    assert ctrl._reentry_armed
+    # 落地停稳（仍静止于左边缘）→ 开始 5s 重进倒计时。
+    ctrl.on_throw_settled()
+    assert ctrl._reentry_active
+    assert abs(ctrl._reentry_remaining - EDGE_REENTRY_SECONDS) < 1e-6
+    # 倒计时内未拖拽 → 到期重新进入探头。
+    times[0] += EDGE_REENTRY_SECONDS + 0.1
+    ctrl._on_timer()
+    assert not ctrl._reentry_active
+    assert ctrl.active
+    assert ctrl.mode == "ENTERING"
+    times[0] += EDGE_ENTER_MS / 1000.0
+    ctrl._on_timer()
+    assert ctrl.mode == PEEKING
+    assert ctrl.win.x() == -220
+    ctrl.cancel(restore=True)
+
+
+def test_collision_throw_reentry_countdown_cancelled_by_drag():
+    """批 A：重进倒计时期间发生拖拽 → 作废本次倒计时，不再重新进入探头。"""
+    _qapp()
+    ctrl, times = _controller_and_clock()
+    _activate_probe_at_left_edge(ctrl, times)
+    ctrl.cancel("collision_throw", restore=False)
+    ctrl.on_throw_settled()
+    assert ctrl._reentry_active
+    ctrl.on_drag_started()
+    assert not ctrl._reentry_active
+    # 倒计时已被作废：即便时间走到 5 秒也不再重新进入探头。
+    times[0] += EDGE_REENTRY_SECONDS + 0.1
+    ctrl._on_timer()
+    assert not ctrl.active
+    assert ctrl.mode == OFF
+    ctrl.cancel(restore=True)
+
+
+def test_non_collision_cancel_does_not_arm_reentry():
+    """批 A：非碰撞导致的取消（如拖离）不标记落地后重进。"""
+    _qapp()
+    ctrl, times = _controller_and_clock()
+    _activate_probe_at_left_edge(ctrl, times)
+    ctrl.cancel("drag_away", restore=False)
+    assert not ctrl._reentry_armed
+    ctrl.on_throw_settled()
+    assert not ctrl._reentry_active
+    assert not ctrl.active
+    ctrl.cancel(restore=True)
+
+
+def test_collision_throw_settle_off_edge_does_not_start_countdown():
+    """批 A：撞飞落地后静止于屏幕中央（非边缘）时不开始重进倒计时。"""
+    _qapp()
+    ctrl, times = _controller_and_clock()
+    _activate_probe_at_left_edge(ctrl, times)
+    ctrl.cancel("collision_throw", restore=False)
+    ctrl.win.move(400, 300)  # 中央，不在左/右边缘
+    ctrl.on_throw_settled()
+    assert not ctrl._reentry_active
+    assert not ctrl.active
+    ctrl.cancel(restore=True)

--- a/tests/test_menu_layout.py
+++ b/tests/test_menu_layout.py
@@ -493,7 +493,7 @@ def test_default_layout_populates_real_qmenu_hierarchy(monkeypatch):
         "回到右下角",
         "隐藏桌宠",
         "生小肥鱼",
-        "清除子肥鱼",
+        "退出子肥鱼",
         "黄金回旋",
         "边缘探头",
     ]

--- a/tests/test_settings_and_resources.py
+++ b/tests/test_settings_and_resources.py
@@ -199,3 +199,97 @@ def test_position_autosave_does_not_set_user_customized(tmp_path):
     assert cfg.get("user_customized") is False
     reloaded = Config(cfg_root, instance_id="slot-2")
     assert reloaded.get("user_customized") is False
+
+
+def test_clear_spawned_pets_button_routes_through_shell_callback(
+        qapp, tmp_path: Path, monkeypatch):
+    """批 E：设置界面「一键清除」优先调 PetWindow 已接线的 on_clear_spawned_pets
+    （= AppShell 路径，自带确认框与进程内子窗前置于关闭）——对话框不再二次确认，
+    也不直接走文件级清理。"""
+    from PySide6.QtWidgets import QMessageBox, QWidget
+
+    import pet.child_pet_cleanup as cleanup_mod
+
+    calls = []
+    parent = QWidget()
+    parent.on_clear_spawned_pets = lambda: calls.append("shell")
+    cfg = Config(tmp_path / "appdata")
+    questions = []
+    cleanup_calls = []
+    monkeypatch.setattr(
+        QMessageBox, "question",
+        lambda *a, **kw: (questions.append(a),
+                          QMessageBox.StandardButton.Cancel)[1])
+    monkeypatch.setattr(
+        cleanup_mod, "clear_spawned_pets",
+        lambda *a, **kw: cleanup_calls.append(a) or
+        {"killed_pids": [], "deleted": []})
+    dialog = ModernSettingsDialog(cfg, parent, include_ai=False)
+    try:
+        dialog.clear_spawned_pets_btn.click()
+        assert calls == ["shell"], "应调用 win.on_clear_spawned_pets 回调"
+        assert questions == [], "走 shell 回调时对话框不应二次确认"
+        assert cleanup_calls == [], "走 shell 回调时不应直接文件级清理"
+    finally:
+        dialog.deleteLater()
+        parent.close()
+        qapp.processEvents()
+
+
+def test_clear_spawned_pets_button_falls_back_without_callback(
+        qapp, tmp_path: Path, monkeypatch):
+    """批 E：拿不到 win.on_clear_spawned_pets（无父窗/旧接线）时回退原有
+    「确认 + 直接文件级清理」路径。"""
+    from PySide6.QtWidgets import QMessageBox
+
+    import pet.child_pet_cleanup as cleanup_mod
+
+    cfg = Config(tmp_path / "appdata")
+    cleaned = []
+    monkeypatch.setattr(
+        cleanup_mod, "clear_spawned_pets",
+        lambda cfg_dir: (cleaned.append(cfg_dir),
+                         {"killed_pids": [1], "deleted": ["a", "b"]})[1])
+    monkeypatch.setattr(
+        QMessageBox, "question",
+        lambda *a, **kw: QMessageBox.StandardButton.Yes)
+    infos = []
+    monkeypatch.setattr(
+        QMessageBox, "information", lambda *a, **kw: infos.append(a))
+    dialog = ModernSettingsDialog(cfg, include_ai=False)
+    try:
+        dialog._on_clear_spawned_pets()
+        assert cleaned == [cfg.dir]
+        assert len(infos) == 1
+    finally:
+        dialog.deleteLater()
+        qapp.processEvents()
+
+
+def test_clear_spawned_pets_button_fallback_cancel_does_nothing(
+        qapp, tmp_path: Path, monkeypatch):
+    """批 E：回退路径下用户取消 → 不清理、不弹结果框。"""
+    from PySide6.QtWidgets import QMessageBox
+
+    import pet.child_pet_cleanup as cleanup_mod
+
+    cfg = Config(tmp_path / "appdata")
+    cleanup_calls = []
+    monkeypatch.setattr(
+        cleanup_mod, "clear_spawned_pets",
+        lambda *a, **kw: cleanup_calls.append(a) or
+        {"killed_pids": [], "deleted": []})
+    monkeypatch.setattr(
+        QMessageBox, "question",
+        lambda *a, **kw: QMessageBox.StandardButton.Cancel)
+    infos = []
+    monkeypatch.setattr(
+        QMessageBox, "information", lambda *a, **kw: infos.append(a))
+    dialog = ModernSettingsDialog(cfg, include_ai=False)
+    try:
+        dialog._on_clear_spawned_pets()
+        assert cleanup_calls == []
+        assert infos == []
+    finally:
+        dialog.deleteLater()
+        qapp.processEvents()

--- a/tests/test_settings_and_resources.py
+++ b/tests/test_settings_and_resources.py
@@ -293,3 +293,16 @@ def test_clear_spawned_pets_button_fallback_cancel_does_nothing(
     finally:
         dialog.deleteLater()
         qapp.processEvents()
+
+
+def test_clear_spawned_pets_button_disabled_for_child_config(qapp, tmp_path):
+    """批 G：子肥鱼（slot-N）的设置对话框禁用「一键退出」按钮——该操作只对
+    主肥鱼开放（子鱼进程执行会把主鱼当子鱼杀掉）。"""
+    cfg = Config(tmp_path / "appdata", instance_id="slot-1")
+    dialog = ModernSettingsDialog(cfg, include_ai=False)
+    try:
+        assert not dialog.clear_spawned_pets_btn.isEnabled()
+        assert dialog.clear_spawned_pets_btn.toolTip()
+    finally:
+        dialog.deleteLater()
+        qapp.processEvents()

--- a/tests/test_settings_and_resources.py
+++ b/tests/test_settings_and_resources.py
@@ -260,15 +260,15 @@ def test_clear_spawned_pets_button_falls_back_without_callback(
     try:
         dialog._on_clear_spawned_pets()
         assert cleaned == [cfg.dir]
-        assert len(infos) == 1
+        assert infos == [], "批 I：结果弹窗已移除（结果写日志）"
     finally:
         dialog.deleteLater()
         qapp.processEvents()
 
 
-def test_clear_spawned_pets_button_fallback_cancel_does_nothing(
+def test_clear_spawned_pets_button_fallback_runs_without_dialogs(
         qapp, tmp_path: Path, monkeypatch):
-    """批 E：回退路径下用户取消 → 不清理、不弹结果框。"""
+    """批 I：回退路径无确认框无结果框，一键直接静默执行。"""
     from PySide6.QtWidgets import QMessageBox
 
     import pet.child_pet_cleanup as cleanup_mod
@@ -279,17 +279,20 @@ def test_clear_spawned_pets_button_fallback_cancel_does_nothing(
         cleanup_mod, "clear_spawned_pets",
         lambda *a, **kw: cleanup_calls.append(a) or
         {"killed_pids": [], "deleted": []})
+    questions = []
     monkeypatch.setattr(
         QMessageBox, "question",
-        lambda *a, **kw: QMessageBox.StandardButton.Cancel)
+        lambda *a, **kw: (questions.append(1),
+                          QMessageBox.StandardButton.Cancel)[1])
     infos = []
     monkeypatch.setattr(
         QMessageBox, "information", lambda *a, **kw: infos.append(a))
     dialog = ModernSettingsDialog(cfg, include_ai=False)
     try:
         dialog._on_clear_spawned_pets()
-        assert cleanup_calls == []
-        assert infos == []
+        assert questions == [], "批 I：无确认框"
+        assert cleanup_calls != [], "回退路径直接执行清理"
+        assert infos == [], "批 I：无结果框"
     finally:
         dialog.deleteLater()
         qapp.processEvents()

--- a/tests/test_settings_and_resources.py
+++ b/tests/test_settings_and_resources.py
@@ -154,3 +154,48 @@ def test_agent_sound_controls_visibility_and_subcontrols(qapp, tmp_path: Path):
         assert dialog.agent_sound_start_preview.isHidden() is False
     finally:
         dialog.deleteLater()
+
+
+def test_subfish_settings_save_sets_user_customized(qapp, tmp_path: Path):
+    """批 C：子肥鱼自己的设置界面保存会置位 user_customized=True。"""
+    cfg_root = tmp_path / "appdata"
+    cfg = Config(cfg_root, instance_id="slot-1")
+    dialog = ModernSettingsDialog(cfg, include_ai=False)
+    try:
+        ok = dialog._write_config()
+        assert ok is True
+    finally:
+        dialog.deleteLater()
+    assert cfg.get("user_customized") is True
+    reloaded = Config(cfg_root, instance_id="slot-1")
+    assert reloaded.get("user_customized") is True
+
+
+def test_main_settings_save_does_not_set_user_customized(qapp, tmp_path: Path):
+    """批 C：主配置（slot 0/主肥鱼）保存不置位 user_customized（保持默认假）。"""
+    cfg_root = tmp_path / "appdata"
+    cfg = Config(cfg_root)
+    dialog = ModernSettingsDialog(cfg, include_ai=False)
+    try:
+        ok = dialog._write_config()
+        assert ok is True
+    finally:
+        dialog.deleteLater()
+    assert cfg.get("user_customized") is False
+    reloaded = Config(cfg_root)
+    assert reloaded.get("user_customized") is False
+
+
+def test_position_autosave_does_not_set_user_customized(tmp_path):
+    """批 C：位置自动保存等后台写盘不得置位 user_customized（保留默认假）。"""
+    cfg_root = tmp_path / "appdata"
+    cfg = Config(cfg_root, instance_id="slot-2")
+    # 模拟窗口 _save_position：写位置键 + save()，不经过设置界面。
+    cfg.set("rx", 0.5)
+    cfg.set("ry", 0.5)
+    cfg.set("screen_name", "X")
+    cfg.set("facing", "right")
+    cfg.save()
+    assert cfg.get("user_customized") is False
+    reloaded = Config(cfg_root, instance_id="slot-2")
+    assert reloaded.get("user_customized") is False

--- a/tests/test_single_process_spawn.py
+++ b/tests/test_single_process_spawn.py
@@ -32,7 +32,7 @@ from pet.app import AppShell, PetInstance, _read_spawn_offset_env
 from pet.chat import session_store as session_store_mod
 from pet.chat.session_store import SessionStore
 from pet.collision_ipc import CollisionIpcSession
-from pet.config import Config
+from pet.config import APP_DIR_NAME, Config
 from pet.window import PetWindow
 
 
@@ -981,7 +981,7 @@ def test_non_primary_switch_builds_no_tray(tmp_path, app, monkeypatch):
 
 # ---------------------------------------------------------------- 新 slot 落种
 def test_seed_slot_config_follows_main_settings(tmp_path):
-    """新 slot 首次多开：配置跟随主设置（剔除每窗状态键）。"""
+    """新 slot 首次多开：配置跟随主设置（剔除每窗状态键，落种含 user_customized=False）。"""
     config_dir = tmp_path / "cfg"
     config_dir.mkdir()
     main_cfg = {"character": "shenshen", "click_sound_enabled": False,
@@ -994,22 +994,150 @@ def test_seed_slot_config_follows_main_settings(tmp_path):
         (config_dir / "config-slot-2.json").read_text(encoding="utf-8"))
     assert seeded["click_sound_enabled"] is False  # 跟随主设置
     assert seeded["character"] == "shenshen"
+    assert seeded.get("user_customized") is False  # 落种默认不置位
     for k in ("rx", "ry", "screen_name", "facing"):
         assert k not in seeded, f"每窗状态键 {k} 不得继承"
 
 
-def test_seed_slot_config_preserves_existing(tmp_path):
-    """已有存档（用户改过的）的 slot 不被落种覆盖。"""
+def test_seed_slot_config_applies_spawn_inherit_logic(tmp_path):
+    """批 C：落种遵循 spawn_inherit_size / spawn_scale / spawn_inherit_dynamic_island。"""
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+    (config_dir / "config.json").write_text(json.dumps({
+        "scale": 1.0,
+        "spawn_inherit_size": False,
+        "spawn_scale": 0.5,
+        "spawn_inherit_dynamic_island": True,
+        "dynamic_island": {"enabled": True},
+    }), encoding="utf-8")
+
+    assert slot_manager_mod.seed_slot_config_from_main(config_dir, 7) is True
+    seeded = json.loads(
+        (config_dir / "config-slot-7.json").read_text(encoding="utf-8"))
+    # 关闭继承大小 → 用主配置为小肥鱼选定的 spawn_scale；继承灵动岛 → enabled=True
+    assert seeded["scale"] == 0.5
+    assert seeded["spawn_inherit_size"] is False
+    assert seeded["spawn_scale"] == 0.5
+    assert seeded["spawn_inherit_dynamic_island"] is True
+    assert seeded["dynamic_island"]["enabled"] is True
+    assert seeded.get("user_customized") is False
+
+
+def test_seed_slot_config_refreshes_non_customized_slot(tmp_path):
+    """批 C：slot 存在但 user_customized 为假（含旧存档无此键）→ 按当前主设置重新刷新。"""
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+    (config_dir / "config.json").write_text(
+        json.dumps({"character": "shenshen", "spawn_inherit_size": True}),
+        encoding="utf-8")
+    # 旧存档（无 user_customized 键）按假处理 → 应被刷新成主设置。
+    existing = {"character": "other", "custom": 1}
+    (config_dir / "config-slot-3.json").write_text(json.dumps(existing), encoding="utf-8")
+
+    assert slot_manager_mod.seed_slot_config_from_main(config_dir, 3) is True
+    refreshed = json.loads(
+        (config_dir / "config-slot-3.json").read_text(encoding="utf-8"))
+    assert refreshed["character"] == "shenshen"  # 跟随主设置
+    assert refreshed.get("user_customized") is False
+
+
+def test_seed_slot_config_preserves_customized_slot(tmp_path):
+    """批 C：slot 存在且 user_customized 为真 → 整个跳过，一个键都不碰。"""
     config_dir = tmp_path / "cfg"
     config_dir.mkdir()
     (config_dir / "config.json").write_text(
         json.dumps({"character": "shenshen"}), encoding="utf-8")
-    existing = {"character": "other", "custom": 1}
-    (config_dir / "config-slot-3.json").write_text(
-        json.dumps(existing), encoding="utf-8")
-    assert slot_manager_mod.seed_slot_config_from_main(config_dir, 3) is False
-    assert json.loads((config_dir / "config-slot-3.json").read_text(
+    existing = {"character": "other", "custom": 1, "user_customized": True}
+    (config_dir / "config-slot-4.json").write_text(json.dumps(existing), encoding="utf-8")
+
+    assert slot_manager_mod.seed_slot_config_from_main(config_dir, 4) is False
+    assert json.loads((config_dir / "config-slot-4.json").read_text(
         encoding="utf-8")) == existing
+
+
+def test_seed_slot_config_refresh_preserves_slot_position(tmp_path):
+    """批 C：落种/刷新永不写位置键——刷新不覆盖 slot 自己拖动后自存的位置。"""
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+    # 主配置的位置键是另一个值；刷新后 slot 应保留自己的位置，不被主配置覆盖。
+    (config_dir / "config.json").write_text(json.dumps({
+        "character": "shenshen",
+        "rx": 0.1, "ry": 0.2, "screen_name": "MAIN", "facing": "left",
+    }), encoding="utf-8")
+    existing = {"character": "other",
+                "rx": 0.6, "ry": 0.7, "screen_name": "SLOT", "facing": "right"}
+    (config_dir / "config-slot-5.json").write_text(json.dumps(existing), encoding="utf-8")
+
+    assert slot_manager_mod.seed_slot_config_from_main(config_dir, 5) is True
+    refreshed = json.loads(
+        (config_dir / "config-slot-5.json").read_text(encoding="utf-8"))
+    assert refreshed["rx"] == 0.6
+    assert refreshed["ry"] == 0.7
+    assert refreshed["screen_name"] == "SLOT"
+    assert refreshed["facing"] == "right"
+
+
+def test_multi_process_start_seed_then_config_roundtrip(tmp_path):
+    """批 C：多进程启动路径（main 先 seed 再构造 Config）落种含 spawn 逻辑，Config 可读回。"""
+    config_dir = tmp_path / APP_DIR_NAME
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "config.json").write_text(json.dumps({
+        "scale": 1.0,
+        "spawn_inherit_size": False,
+        "spawn_scale": 0.5,
+        "spawn_inherit_dynamic_island": True,
+        "dynamic_island": {"enabled": True},
+    }), encoding="utf-8")
+
+    # 与 main() 的 seed → Config(instance_id) 次序一致。
+    assert slot_manager_mod.seed_slot_config_from_main(config_dir, 2) is True
+    cfg = Config(base=tmp_path, instance_id="slot-2")
+    assert cfg.get("scale") == 0.5
+    assert cfg.get("spawn_inherit_size") is False
+    assert cfg.get("spawn_scale") == 0.5
+    assert cfg.get("dynamic_island", {}).get("enabled") is True
+    assert cfg.get("user_customized") is False
+
+
+def test_spawn_in_process_window_routes_through_shared_seed(tmp_path, app, monkeypatch):
+    """批 C：进程内 spawn 调用点统一走共享落种函数（传对 slot_id），并产出 spawn 逻辑。"""
+    shell, config, primary_handle = _make_primary_with_slot(tmp_path)
+    real_seed = slot_manager_mod.seed_slot_config_from_main
+    calls = []
+
+    def spy(seed_dir, seed_slot):
+        calls.append((str(seed_dir), seed_slot))
+        return real_seed(seed_dir, seed_slot)
+
+    def fake_build_window(self, character_id, lib=None, build_tray=True):
+        win = _FakeWindow()
+        win.cfg = self.config
+        win._single_process_spawn = self.shell._single_process_spawn
+        self.win = win
+        return win
+
+    monkeypatch.setattr(slot_manager_mod, "seed_slot_config_from_main", spy)
+    monkeypatch.setattr(app_mod.PetInstance, "_build_window", fake_build_window)
+    monkeypatch.setattr(app_mod.PetInstance, "_apply_spawn_offset", lambda self: None)
+    monkeypatch.setattr(
+        app_mod.PetInstance, "_check_autostart_wanted", lambda self: None)
+
+    second = shell.spawn_in_process_window(1)
+
+    assert calls, "进程内 spawn 调用点应经共享落种函数"
+    # 共享落种函数收到的是主窗配置根 + 新 slot id
+    assert calls[0][1] == 1
+    # spawn 产物 slot 配置存在且落种 mark 默认假
+    seed_path = config.dir.parent / APP_DIR_NAME / "config-slot-1.json"
+    assert seed_path.exists()
+    seeded = json.loads(seed_path.read_text(encoding="utf-8"))
+    assert seeded.get("user_customized") is False
+
+    _stop_sessions(second)
+    second.win.close()
+    slot_manager_mod._unlock_file(second.slot_handle)
+    second.slot_handle = None
+    slot_manager_mod._unlock_file(primary_handle)
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_single_process_spawn.py
+++ b/tests/test_single_process_spawn.py
@@ -1010,3 +1010,118 @@ def test_seed_slot_config_preserves_existing(tmp_path):
     assert slot_manager_mod.seed_slot_config_from_main(config_dir, 3) is False
     assert json.loads((config_dir / "config-slot-3.json").read_text(
         encoding="utf-8")) == existing
+
+
+# --------------------------------------------------------------------------
+# 批 B：clear_spawned_pets 单进程模式（进程内子窗）前置关闭
+# --------------------------------------------------------------------------
+def test_clear_spawned_pets_closes_in_process_children_no_residue(
+        tmp_path, app, monkeypatch):
+    """批 B：单进程模式下 clear_spawned_pets 先关闭进程内「非主窗」子肥鱼窗口、
+    删除其 runtime 标记，主窗保留；重复调用幂等无残留。
+
+    子肥鱼在单进程模式是进程内窗口（PID=主进程），会被文件级清理的
+    pid==os.getpid() 自我保护跳过而永远不会被关；修复后先按进程内子窗登记表
+    （self._instances）枚举并关闭，再走文件级清理杀多进程子进程。
+    """
+    shell, config, primary_handle = _make_primary_with_slot(tmp_path)
+
+    # 主窗窗身 + 主窗 runtime 标记（主肥鱼不清，须保留）
+    primary = shell.instance
+    primary_win = _FakeWindow()
+    primary_win.cfg = config
+    primary_win._single_process_spawn = True
+    primary.win = primary_win
+    primary_marker = slot_manager_mod.runtime_marker_path(
+        config.dir, config.instance_id, versioned=True)
+    primary_marker.write_text(
+        json.dumps({"pid": os.getpid(), "x": 0, "y": 0, "w": 100, "h": 100}),
+        encoding="utf-8")
+
+    # 第二个实例（进程内子窗，同 pid=主进程）
+    slot_id, slot_handle = slot_manager_mod.acquire_pet_slot(
+        config.dir, preferred_slot=1)
+    sec = PetInstance(shell, Config(base=tmp_path, instance_id="slot-1"),
+                      enable_chat=True, slot_handle=slot_handle, slot_id=slot_id)
+    sec_win = _FakeWindow()
+    sec_win.cfg = sec.config
+    sec_win._single_process_spawn = True
+    sec.win = sec_win
+    shell._instances.append(sec)
+    sec_marker = slot_manager_mod.runtime_marker_path(
+        config.dir, sec.config.instance_id, versioned=True)
+    sec_marker.write_text(
+        json.dumps({"pid": os.getpid(), "x": 100, "y": 100, "w": 100, "h": 100}),
+        encoding="utf-8")
+
+    # 子窗会话/broker 打桩（避免真实 QLocal/共享 hub 收口的副作用）
+    monkeypatch.setattr(sec.collision_ipc, "stop", lambda: None)
+    monkeypatch.setattr(sec.broker_facade, "shutdown", lambda: None)
+
+    # 确认对话框返回 Yes
+    monkeypatch.setattr(
+        app_mod.QMessageBox, "question",
+        lambda *a, **kw: app_mod.QMessageBox.StandardButton.Yes)
+
+    assert len(shell.instances) == 2
+    shell.clear_spawned_pets()
+
+    # 子窗被关闭并移除；主窗保留
+    assert len(shell.instances) == 1
+    assert shell.instance is primary
+    assert sec not in shell.instances
+    assert sec_win.calls == ["save", "marker_del", "close"]
+    # 子窗 v2 标记被删；主窗标记保留（主肥鱼仍在跑）
+    assert not sec_marker.exists()
+    assert primary_marker.exists()
+    # 子窗 slot 锁已释放
+    assert sec.slot_handle is None
+
+    # 幂等：再跑一遍无残留、不报错
+    shell.clear_spawned_pets()
+    assert len(shell.instances) == 1
+    assert shell.instance is primary
+    assert primary_marker.exists()
+
+    slot_manager_mod._unlock_file(primary_handle)
+
+
+def test_clear_spawned_pets_multi_process_flag_off_no_in_process_children(
+        tmp_path, app, monkeypatch):
+    """批 B：多进程模式（flag 关）clear_spawned_pets 无进程内子窗时，前置路径
+    为空操作，随后文件级清理照常跑通、主窗保留（幂等、不误关主窗）。"""
+    import pet.child_pet_cleanup as cleanup_mod
+
+    config = Config(tmp_path)
+    config.set("experimental_single_process_spawn", False)
+    config.save()
+    shell = AppShell(QApplication.instance(), config, enable_chat=True)
+
+    primary_win = _FakeWindow()
+    primary_win.cfg = config
+    shell.instance.win = primary_win
+
+    # 模拟多进程子肥鱼：一个 v2 存活标记（假 PID）+ slot 数据
+    root = config.dir
+    (root / "config-slot-1.json").write_text("{}", encoding="utf-8")
+    v2 = root / "pet-runtime-v2-555-slot-1.json"
+    v2.write_text(json.dumps({"pid": 555}), encoding="utf-8")
+
+    terminated = []
+    monkeypatch.setattr(cleanup_mod, "_pid_alive", lambda pid: pid == 555)
+    monkeypatch.setattr(
+        cleanup_mod, "_terminate_pet_process", lambda pid: terminated.append(pid))
+    monkeypatch.setattr(
+        app_mod.QMessageBox, "question",
+        lambda *a, **kw: app_mod.QMessageBox.StandardButton.Yes)
+
+    # 无进程内子窗（flag 关），只有主窗
+    assert len(shell.instances) == 1
+    shell.clear_spawned_pets()
+
+    # 多进程子进程被文件级清理杀/删；主窗保留
+    assert terminated == [555]
+    assert not v2.exists()
+    assert not (root / "config-slot-1.json").exists()
+    assert len(shell.instances) == 1
+    assert shell.instance is shell.instances[0]

--- a/tests/test_single_process_spawn.py
+++ b/tests/test_single_process_spawn.py
@@ -1239,16 +1239,29 @@ def test_clear_spawned_pets_multi_process_flag_off_no_in_process_children(
     v2.write_text(json.dumps({"pid": 555}), encoding="utf-8")
 
     terminated = []
-    monkeypatch.setattr(cleanup_mod, "_pid_alive", lambda pid: pid == 555)
+    alive = {555}
     monkeypatch.setattr(
-        cleanup_mod, "_terminate_pet_process", lambda pid: terminated.append(pid))
+        cleanup_mod, "_pid_alive", lambda pid: pid in alive)
+
+    def fake_terminate(pid):
+        terminated.append(pid)
+        alive.discard(pid)  # 批 G：杀后确认——进程真的退出
+
+    monkeypatch.setattr(
+        cleanup_mod, "_terminate_pet_process", fake_terminate)
     monkeypatch.setattr(
         app_mod.QMessageBox, "question",
         lambda *a, **kw: app_mod.QMessageBox.StandardButton.Yes)
+    infos = []
+    monkeypatch.setattr(
+        app_mod.QMessageBox, "information",
+        lambda *a, **kw: infos.append(a))
 
     # 无进程内子窗（flag 关），只有主窗
     assert len(shell.instances) == 1
     shell.clear_spawned_pets()
+    # 批 G：文件级清理移到后台线程（taskkill 不冻 UI），结果经事件循环回弹。
+    _pump(0.5)
 
     # 多进程子进程被文件级收尾杀掉；批 F 起 slot 数据保留；主窗保留
     assert terminated == [555]
@@ -1256,6 +1269,8 @@ def test_clear_spawned_pets_multi_process_flag_off_no_in_process_children(
     assert (root / "config-slot-1.json").exists()
     assert len(shell.instances) == 1
     assert shell.instance is shell.instances[0]
+    assert len(infos) == 1
+    assert shell._clear_spawned_pending is False
 
 
 # --------------------------------------------------------------------------
@@ -1373,6 +1388,51 @@ def test_clear_spawned_pets_chain_skips_removed_or_destroyed_child(
     slot_manager_mod._unlock_file(primary_handle)
 
 
+def test_clear_spawned_pets_defers_heavy_teardown_to_reaper_thread(
+        tmp_path, app, monkeypatch):
+    """批 G：链式「退出子肥鱼」把每窗的重资源回收（writer 关闭 / agent
+    shutdown / 碰撞会话停止——各有界阻塞秒级）挪到进程级 reaper 线程执行；
+    UI 线程只保留关窗/摘标记/释放锁等毫秒级步骤，主桌宠不再冻结。"""
+    import threading
+
+    shell, config, primary_handle = _make_primary_with_slot(tmp_path)
+    inst, win = _add_child_instance(shell, tmp_path, config, 1, monkeypatch)
+
+    heavy_threads = []
+    monkeypatch.setattr(
+        inst.collision_ipc, "stop",
+        lambda: heavy_threads.append(
+            ("collision", threading.current_thread().name)))
+    monkeypatch.setattr(
+        win.agent_link_manager, "shutdown",
+        lambda: heavy_threads.append(
+            ("agent", threading.current_thread().name)))
+    monkeypatch.setattr(
+        app_mod.AppShell, "_close_instance_session_writer",
+        lambda self, _inst: heavy_threads.append(
+            ("writer", threading.current_thread().name)))
+    monkeypatch.setattr(
+        app_mod.QMessageBox, "question",
+        lambda *a, **kw: app_mod.QMessageBox.StandardButton.Yes)
+    monkeypatch.setattr(app_mod.QMessageBox, "information", lambda *a, **kw: None)
+
+    shell.clear_spawned_pets()
+    _pump(0.5)
+
+    # UI 必做步骤照常同步完成（关窗/摘标记/移除登记表）
+    assert win.calls == ["save", "marker_del", "close"]
+    assert inst not in shell.instances
+    # 重回收全部发生，且都在 reaper 线程而非 UI 主线程
+    labels = sorted(label for label, _t in heavy_threads)
+    assert labels == ["agent", "collision", "writer"]
+    assert all(t == "pet-teardown-reaper" for _label, t in heavy_threads)
+    # defer 模式下关窗前摘下 agent 引用：closeEvent 不在 UI 线程重复 join
+    assert win.agent_link_manager is None
+    assert shell._clear_spawned_pending is False
+
+    slot_manager_mod._unlock_file(primary_handle)
+
+
 def test_settings_dialog_clear_button_routes_through_shell_chain(
         tmp_path, app, monkeypatch):
     """批 E：设置界面「一键清除」经 win.on_clear_spawned_pets（真实接线 =
@@ -1415,3 +1475,45 @@ def test_settings_dialog_clear_button_routes_through_shell_chain(
         slot_manager_mod._unlock_file(child.slot_handle)
         child.slot_handle = None
     slot_manager_mod._unlock_file(primary_handle)
+
+
+def test_clear_spawned_entry_wired_only_on_primary(tmp_path, app, monkeypatch):
+    """批 G：「退出子肥鱼」入口只挂给主肥鱼（instance_id 为空）；子肥鱼窗
+    该回调为 None——否则子鱼进程里 pid==os.getpid() 只跳过自己，会把主鱼
+    当子鱼 taskkill 掉（实机事故）。"""
+    shell, config, primary_handle = _make_primary_with_slot(tmp_path)
+    try:
+        main_win = _FakeWindow()
+        main_win.cfg = config
+        shell.instance._wire_window(main_win)
+        assert callable(main_win.on_clear_spawned_pets), "主肥鱼必须有入口"
+
+        inst, _win = _add_child_instance(shell, tmp_path, config, 1, monkeypatch)
+        child_win = _FakeWindow()
+        child_win.cfg = inst.config
+        inst._wire_window(child_win)
+        assert child_win.on_clear_spawned_pets is None, "子肥鱼不得有入口"
+    finally:
+        slot_manager_mod._unlock_file(primary_handle)
+
+
+def test_runtime_marker_written_on_first_show(tmp_path, app):
+    """批 G：窗口首次显示即登记 runtime 标记——没被拖动过的新生小肥鱼也有
+    标记，「退出子肥鱼」按标记枚举时不会漏掉它。"""
+    from tests.test_collision_window import FakeCollisionSession, FakeLibrary
+
+    from pet.window import PetWindow
+
+    config = Config(tmp_path)
+    config.set("collision_enabled", False)
+    config.save()
+    win = PetWindow(FakeLibrary(), config,
+                    collision_session=FakeCollisionSession("pet_marker_boot"))
+    win.show()
+    QApplication.instance().processEvents()
+    # 默认（flag 关）写旧名 runtime-<pid>.json
+    marker = config.dir / f"runtime-{os.getpid()}.json"
+    assert marker.exists(), "首次显示必须登记 runtime 标记"
+    data = json.loads(marker.read_text(encoding="utf-8"))
+    assert data["pid"] == os.getpid()
+    win.close()

--- a/tests/test_single_process_spawn.py
+++ b/tests/test_single_process_spawn.py
@@ -1193,6 +1193,8 @@ def test_clear_spawned_pets_closes_in_process_children_no_residue(
 
     assert len(shell.instances) == 2
     shell.clear_spawned_pets()
+    # 批 E：进程内子窗关闭改为 QTimer.singleShot(0) 逐只链式执行，需转事件循环收口。
+    _pump(0.5)
 
     # 子窗被关闭并移除；主窗保留
     assert len(shell.instances) == 1
@@ -1207,6 +1209,7 @@ def test_clear_spawned_pets_closes_in_process_children_no_residue(
 
     # 幂等：再跑一遍无残留、不报错
     shell.clear_spawned_pets()
+    _pump(0.2)
     assert len(shell.instances) == 1
     assert shell.instance is primary
     assert primary_marker.exists()
@@ -1253,3 +1256,162 @@ def test_clear_spawned_pets_multi_process_flag_off_no_in_process_children(
     assert not (root / "config-slot-1.json").exists()
     assert len(shell.instances) == 1
     assert shell.instance is shell.instances[0]
+
+
+# --------------------------------------------------------------------------
+# 批 E：清除子肥鱼——进程内子窗 QTimer.singleShot(0) 链式关闭（不冻 UI）
+# --------------------------------------------------------------------------
+def _add_child_instance(shell, tmp_path, config, preferred_slot, monkeypatch):
+    """建一个进程内子窗实例（fake window + 会话打桩），返回 (inst, win)。"""
+    slot_id, handle = slot_manager_mod.acquire_pet_slot(
+        config.dir, preferred_slot=preferred_slot)
+    inst = PetInstance(shell, Config(base=tmp_path, instance_id=f"slot-{slot_id}"),
+                       enable_chat=True, slot_handle=handle, slot_id=slot_id)
+    win = _FakeWindow()
+    win.cfg = inst.config
+    win._single_process_spawn = True
+    inst.win = win
+    shell._instances.append(inst)
+    monkeypatch.setattr(inst.collision_ipc, "stop", lambda: None)
+    monkeypatch.setattr(inst.broker_facade, "shutdown", lambda: None)
+    return inst, win
+
+
+def test_clear_spawned_pets_chained_close_defers_until_event_loop(
+        tmp_path, app, monkeypatch):
+    """批 E：子窗关闭经 QTimer.singleShot(0) 逐只执行——clear_spawned_pets
+    同步返回时尚未触碰任何子窗（每只之间让出事件循环，UI 不冻结/不出黑框），
+    事件循环转起来后才逐只关完，全部关完再执行文件级清理并弹一次结果框。"""
+    shell, config, primary_handle = _make_primary_with_slot(tmp_path)
+    children = [
+        _add_child_instance(shell, tmp_path, config, slot, monkeypatch)
+        for slot in (1, 2)
+    ]
+
+    monkeypatch.setattr(
+        app_mod.QMessageBox, "question",
+        lambda *a, **kw: app_mod.QMessageBox.StandardButton.Yes)
+    infos = []
+    monkeypatch.setattr(
+        app_mod.QMessageBox, "information",
+        lambda *a, **kw: infos.append(a))
+
+    shell.clear_spawned_pets()
+    # 同步返回：关闭被 singleShot(0) 延后，一只都还没关（旧实现同步关 N 只）。
+    assert all(win.calls == [] for _inst, win in children)
+    assert infos == []
+
+    _pump(0.5)
+    for inst, win in children:
+        assert win.calls == ["save", "marker_del", "close"]
+        assert inst not in shell.instances
+        assert inst.slot_handle is None
+    assert len(infos) == 1
+    assert shell.instance is shell.instances[0]
+    slot_manager_mod._unlock_file(primary_handle)
+
+
+def test_clear_spawned_pets_repeat_click_during_chain_is_idempotent(
+        tmp_path, app, monkeypatch):
+    """批 E：链式关闭进行中重复点击「一键清除」→ 忽略（不再确认、不重复关闭）。"""
+    shell, config, primary_handle = _make_primary_with_slot(tmp_path)
+    children = [
+        _add_child_instance(shell, tmp_path, config, slot, monkeypatch)
+        for slot in (1, 2)
+    ]
+
+    questions = []
+    monkeypatch.setattr(
+        app_mod.QMessageBox, "question",
+        lambda *a, **kw: (questions.append(1),
+                          app_mod.QMessageBox.StandardButton.Yes)[1])
+    infos = []
+    monkeypatch.setattr(
+        app_mod.QMessageBox, "information",
+        lambda *a, **kw: infos.append(a))
+
+    shell.clear_spawned_pets()
+    shell.clear_spawned_pets()  # 链式进行中重复点击
+    assert questions == [1], "进行中重复点击不应再次弹确认框"
+
+    _pump(0.5)
+    assert len(infos) == 1, "结果框只弹一次"
+    for _inst, win in children:
+        assert win.calls == ["save", "marker_del", "close"], "每只只关一次"
+    slot_manager_mod._unlock_file(primary_handle)
+
+
+def test_clear_spawned_pets_chain_skips_removed_or_destroyed_child(
+        tmp_path, app, monkeypatch):
+    """批 E：链式过程中子窗已销毁/已关闭（弱引用失效或不在登记表）→ 跳过不报错，
+    其余子窗照常关完，清理与结果框照常收口。"""
+    shell, config, primary_handle = _make_primary_with_slot(tmp_path)
+    gone, gone_win = _add_child_instance(shell, tmp_path, config, 1, monkeypatch)
+    kept, kept_win = _add_child_instance(shell, tmp_path, config, 2, monkeypatch)
+
+    monkeypatch.setattr(
+        app_mod.QMessageBox, "question",
+        lambda *a, **kw: app_mod.QMessageBox.StandardButton.Yes)
+    infos = []
+    monkeypatch.setattr(
+        app_mod.QMessageBox, "information",
+        lambda *a, **kw: infos.append(a))
+
+    shell.clear_spawned_pets()
+    # 链式执行前该子窗已自行关闭（移出登记表）：快照仍在，但存活校验应跳过。
+    shell._instances.remove(gone)
+
+    _pump(0.5)
+    assert gone_win.calls == [], "已销毁/已关闭的子窗不应再被触碰"
+    assert kept_win.calls == ["save", "marker_del", "close"]
+    assert len(infos) == 1
+    assert shell._clear_spawned_pending is False, "收口后必须复位进行中标记"
+
+    if gone.slot_handle is not None:
+        slot_manager_mod._unlock_file(gone.slot_handle)
+        gone.slot_handle = None
+    slot_manager_mod._unlock_file(primary_handle)
+
+
+def test_settings_dialog_clear_button_routes_through_shell_chain(
+        tmp_path, app, monkeypatch):
+    """批 E：设置界面「一键清除」经 win.on_clear_spawned_pets（真实接线 =
+    shell.clear_spawned_pets）走到进程内子窗链式关闭——单进程模式子肥鱼清得掉，
+    对话框自身不再二次确认。"""
+    from PySide6.QtWidgets import QMessageBox, QWidget
+
+    from pet.modern_settings_dialog import ModernSettingsDialog
+
+    shell, config, primary_handle = _make_primary_with_slot(tmp_path)
+    child, child_win = _add_child_instance(shell, tmp_path, config, 1, monkeypatch)
+
+    questions = []
+    monkeypatch.setattr(
+        QMessageBox, "question",
+        lambda *a, **kw: (questions.append(a),
+                          QMessageBox.StandardButton.Yes)[1])
+    monkeypatch.setattr(QMessageBox, "information", lambda *a, **kw: None)
+
+    # 对话框父窗 = 已接线 on_clear_spawned_pets 的 PetWindow（app.py:361 形态）。
+    pet_win = QWidget()
+    pet_win.on_clear_spawned_pets = shell.clear_spawned_pets
+    dialog = ModernSettingsDialog(config, pet_win, include_ai=False)
+    try:
+        dialog.clear_spawned_pets_btn.click()
+        # 只弹 shell 那一次确认（对话框不重复确认）。
+        assert len(questions) == 1
+        # 关闭被 singleShot(0) 延后：点击后同步阶段尚未触碰子窗。
+        assert child_win.calls == []
+        _pump(0.5)
+        assert child_win.calls == ["save", "marker_del", "close"]
+        assert child not in shell.instances
+        assert shell.instance is shell.instances[0]
+    finally:
+        dialog.close()
+        pet_win.close()
+        app.processEvents()
+
+    if child.slot_handle is not None:
+        slot_manager_mod._unlock_file(child.slot_handle)
+        child.slot_handle = None
+    slot_manager_mod._unlock_file(primary_handle)

--- a/tests/test_single_process_spawn.py
+++ b/tests/test_single_process_spawn.py
@@ -1250,10 +1250,10 @@ def test_clear_spawned_pets_multi_process_flag_off_no_in_process_children(
     assert len(shell.instances) == 1
     shell.clear_spawned_pets()
 
-    # 多进程子进程被文件级清理杀/删；主窗保留
+    # 多进程子进程被文件级收尾杀掉；批 F 起 slot 数据保留；主窗保留
     assert terminated == [555]
     assert not v2.exists()
-    assert not (root / "config-slot-1.json").exists()
+    assert (root / "config-slot-1.json").exists()
     assert len(shell.instances) == 1
     assert shell.instance is shell.instances[0]
 

--- a/tests/test_single_process_spawn.py
+++ b/tests/test_single_process_spawn.py
@@ -1240,6 +1240,8 @@ def test_clear_spawned_pets_multi_process_flag_off_no_in_process_children(
 
     terminated = []
     alive = {555}
+    # 批 H：杀前有 exe 身份核验（防 pid 复用误杀），假 pid 打桩为本程序
+    monkeypatch.setattr(cleanup_mod, "_is_pet_process", lambda pid: True)
     monkeypatch.setattr(
         cleanup_mod, "_pid_alive", lambda pid: pid in alive)
 

--- a/tests/test_single_process_spawn.py
+++ b/tests/test_single_process_spawn.py
@@ -1262,7 +1262,7 @@ def test_clear_spawned_pets_multi_process_flag_off_no_in_process_children(
     # 无进程内子窗（flag 关），只有主窗
     assert len(shell.instances) == 1
     shell.clear_spawned_pets()
-    # 批 G：文件级清理移到后台线程（taskkill 不冻 UI），结果经事件循环回弹。
+    # 批 G：文件级清理移到后台线程（taskkill 不冻 UI），完成经事件循环复位。
     _pump(0.5)
 
     # 多进程子进程被文件级收尾杀掉；批 F 起 slot 数据保留；主窗保留
@@ -1271,7 +1271,7 @@ def test_clear_spawned_pets_multi_process_flag_off_no_in_process_children(
     assert (root / "config-slot-1.json").exists()
     assert len(shell.instances) == 1
     assert shell.instance is shell.instances[0]
-    assert len(infos) == 1
+    assert infos == [], "批 I：结果弹窗已移除（结果写日志）"
     assert shell._clear_spawned_pending is False
 
 
@@ -1323,14 +1323,16 @@ def test_clear_spawned_pets_chained_close_defers_until_event_loop(
         assert win.calls == ["save", "marker_del", "close"]
         assert inst not in shell.instances
         assert inst.slot_handle is None
-    assert len(infos) == 1
+    assert infos == [], "批 I：结果弹窗已移除（结果写日志）"
+    assert shell._clear_spawned_pending is False
     assert shell.instance is shell.instances[0]
     slot_manager_mod._unlock_file(primary_handle)
 
 
 def test_clear_spawned_pets_repeat_click_during_chain_is_idempotent(
         tmp_path, app, monkeypatch):
-    """批 E：链式关闭进行中重复点击「一键清除」→ 忽略（不再确认、不重复关闭）。"""
+    """批 E：链式关闭进行中重复点击「一键退出」→ 忽略（不重复关闭）。
+    批 I：确认框已移除（操作不删数据可重新生成），questions 应恒为空。"""
     shell, config, primary_handle = _make_primary_with_slot(tmp_path)
     children = [
         _add_child_instance(shell, tmp_path, config, slot, monkeypatch)
@@ -1349,10 +1351,11 @@ def test_clear_spawned_pets_repeat_click_during_chain_is_idempotent(
 
     shell.clear_spawned_pets()
     shell.clear_spawned_pets()  # 链式进行中重复点击
-    assert questions == [1], "进行中重复点击不应再次弹确认框"
+    assert questions == [], "批 I：无确认框"
 
     _pump(0.5)
-    assert len(infos) == 1, "结果框只弹一次"
+    assert infos == [], "批 I：结果弹窗已移除"
+    assert shell._clear_spawned_pending is False
     for _inst, win in children:
         assert win.calls == ["save", "marker_del", "close"], "每只只关一次"
     slot_manager_mod._unlock_file(primary_handle)
@@ -1381,7 +1384,7 @@ def test_clear_spawned_pets_chain_skips_removed_or_destroyed_child(
     _pump(0.5)
     assert gone_win.calls == [], "已销毁/已关闭的子窗不应再被触碰"
     assert kept_win.calls == ["save", "marker_del", "close"]
-    assert len(infos) == 1
+    assert infos == [], "批 I：结果弹窗已移除"
     assert shell._clear_spawned_pending is False, "收口后必须复位进行中标记"
 
     if gone.slot_handle is not None:
@@ -1437,9 +1440,9 @@ def test_clear_spawned_pets_defers_heavy_teardown_to_reaper_thread(
 
 def test_settings_dialog_clear_button_routes_through_shell_chain(
         tmp_path, app, monkeypatch):
-    """批 E：设置界面「一键清除」经 win.on_clear_spawned_pets（真实接线 =
-    shell.clear_spawned_pets）走到进程内子窗链式关闭——单进程模式子肥鱼清得掉，
-    对话框自身不再二次确认。"""
+    """批 E：设置界面「一键退出」经 win.on_clear_spawned_pets（真实接线 =
+    shell.clear_spawned_pets）走到进程内子窗链式关闭——单进程模式子肥鱼清得掉。
+    批 I：全程无确认框无结果框。"""
     from PySide6.QtWidgets import QMessageBox, QWidget
 
     from pet.modern_settings_dialog import ModernSettingsDialog
@@ -1460,8 +1463,7 @@ def test_settings_dialog_clear_button_routes_through_shell_chain(
     dialog = ModernSettingsDialog(config, pet_win, include_ai=False)
     try:
         dialog.clear_spawned_pets_btn.click()
-        # 只弹 shell 那一次确认（对话框不重复确认）。
-        assert len(questions) == 1
+        assert questions == [], "批 I：无确认框"
         # 关闭被 singleShot(0) 延后：点击后同步阶段尚未触碰子窗。
         assert child_win.calls == []
         _pump(0.5)

--- a/tests/test_slot_and_memory.py
+++ b/tests/test_slot_and_memory.py
@@ -693,6 +693,48 @@ def test_migrate_legacy_spawns_skips_occupied_target_slot(tmp_path):
     sm._unlock_file(h1)
 
 
+def test_list_runtime_marker_files_returns_legacy_and_v2(tmp_path):
+    """批 B：list_runtime_marker_files 同时认旧名与版本化新名 runtime 标记。"""
+    config_dir = tmp_path / APP_DIR_NAME
+    config_dir.mkdir(parents=True, exist_ok=True)
+
+    (config_dir / "runtime-111.json").write_text("{}", encoding="utf-8")
+    (config_dir / "pet-runtime-v2-222-slot-1.json").write_text("{}", encoding="utf-8")
+    (config_dir / "pet-runtime-v2-333-slot-2.json").write_text("{}", encoding="utf-8")
+    (config_dir / "config-slot-1.json").write_text("{}", encoding="utf-8")
+    (config_dir / "sessions-slot-1").mkdir()
+
+    names = {p.name for p in sm.list_runtime_marker_files(config_dir)}
+    # 新旧两种命名都被列出
+    assert {"runtime-111.json",
+            "pet-runtime-v2-222-slot-1.json",
+            "pet-runtime-v2-333-slot-2.json"} <= names
+    # 非 runtime 标记文件不得被误列
+    assert "config-slot-1.json" not in names
+    assert "sessions-slot-1" not in names
+
+
+def test_migrate_legacy_spawns_skips_when_v2_marker_alive(tmp_path):
+    """批 B：migrate_legacy_spawns 检测 v2 版本化 runtime 标记（多进程模式只写
+    新名），发现存活实例时跳过迁移。旧 glob 只认 runtime-*.json 会误放行。"""
+    config_dir = tmp_path / APP_DIR_NAME
+    config_dir.mkdir(parents=True, exist_ok=True)
+
+    old_cfg = config_dir / "config-spawn100x1.json"
+    old_cfg.write_text(json.dumps({"character": "spawn1"}), encoding="utf-8")
+    (config_dir / "sessions-spawn100x1").mkdir(parents=True, exist_ok=True)
+
+    # v2 标记用当前（必然存活）进程 pid
+    v2 = config_dir / f"pet-runtime-v2-{os.getpid()}-slot-1.json"
+    v2.write_text(json.dumps({"pid": os.getpid()}), encoding="utf-8")
+
+    assert sm.migrate_legacy_spawns(config_dir) is False
+    # 旧配置未被迁移（检测到存活实例跳过）
+    assert old_cfg.exists()
+    assert not (config_dir / "config-slot-1.json").exists()
+    assert not (config_dir / "migration-spawns.done").exists()
+
+
 def test_app_main_validates_slot_arg():
     """测试 app.main 校验 --slot 参数范围（0~127）及非法值。"""
     from pet import app as app_mod

--- a/tests/test_throw_egg.py
+++ b/tests/test_throw_egg.py
@@ -3,7 +3,7 @@
 
 覆盖：arm 条件双向（碰撞取消才 arm）、角度四方向、低速碰边界恢复、
 低速碰桌宠恢复、高速不恢复、_stop_physics 兜底、end 幂等与重 arm；
-批 F：恢复阈值提到 400 且按用户要求移除飞行时间硬上限。
+批 F：恢复阈值提到 780 且按用户要求移除飞行时间硬上限。
 """
 from __future__ import annotations
 
@@ -99,13 +99,13 @@ def test_angle_follows_four_directions():
     win = _FakeWin()
     egg = ThrowEggController(win)
     egg.arm()
-    egg.update(500.0, 0.0, False)
+    egg.update(900.0, 0.0, False)
     assert egg.current_angle_deg() == pytest.approx(90.0)
-    egg.update(0.0, 500.0, False)
+    egg.update(0.0, 900.0, False)
     assert egg.current_angle_deg() == pytest.approx(180.0)
-    egg.update(0.0, -500.0, False)
+    egg.update(0.0, -900.0, False)
     assert egg.current_angle_deg() == pytest.approx(0.0)
-    egg.update(-500.0, 0.0, False)
+    egg.update(-900.0, 0.0, False)
     assert egg.current_angle_deg() == pytest.approx(270.0)
 
 
@@ -114,7 +114,7 @@ def test_angle_debounces_below_speed_threshold():
     win = _FakeWin()
     egg = ThrowEggController(win)
     egg.arm()
-    egg.update(500.0, 0.0, False)
+    egg.update(900.0, 0.0, False)
     before = egg.current_angle_deg()
     egg.update(30.0, 0.0, False)
     assert egg.active
@@ -126,7 +126,7 @@ def test_low_speed_touching_boundary_recovers():
     egg = ThrowEggController(win)
     egg.arm()
     # 高速贴边：不恢复，角度仍更新。
-    egg.update(500.0, 0.0, True)
+    egg.update(900.0, 0.0, True)
     assert egg.active
     assert egg.current_angle_deg() == pytest.approx(90.0)
     # 低速贴边：恢复正常姿态。
@@ -148,16 +148,16 @@ def test_high_speed_contact_does_not_recover():
     win = _FakeWin()
     egg = ThrowEggController(win)
     egg.arm()
-    egg.on_pet_contact(500.0)
+    egg.on_pet_contact(900.0)
     assert egg.active
-    egg.update(500.0, 0.0, True)
+    egg.update(900.0, 0.0, True)
     assert egg.active
     assert egg.current_angle_deg() == pytest.approx(90.0)
 
 
-def test_recover_speed_threshold_raised_to_400():
-    """批 F：阈值 240→400（用户实机要求再拉高，且不设时间硬上限）。"""
-    assert THROW_EGG_RECOVER_SPEED == 400.0
+def test_recover_speed_threshold_raised_to_780():
+    """批 F：阈值拉到 780——低速贴地连续碰撞时角度不再快速翻转（用户实机反馈）。"""
+    assert THROW_EGG_RECOVER_SPEED == 780.0
 
 
 def test_speed_above_old_threshold_recovers_at_boundary():
@@ -170,14 +170,14 @@ def test_speed_above_old_threshold_recovers_at_boundary():
     assert egg.current_angle_deg() == 0.0
 
 
-def test_threshold_boundary_recovery_only_below_400():
-    """阈值边界：401 px/s 贴边仍激活，399 px/s 贴边恢复。"""
+def test_threshold_boundary_recovery_only_below_780():
+    """阈值边界：781 px/s 贴边仍激活，779 px/s 贴边恢复。"""
     win = _FakeWin()
     egg = ThrowEggController(win)
     egg.arm()
-    egg.update(401.0, 0.0, True)
+    egg.update(781.0, 0.0, True)
     assert egg.active
-    egg.update(399.0, 0.0, True)
+    egg.update(779.0, 0.0, True)
     assert not egg.active
 
 

--- a/tests/test_throw_egg.py
+++ b/tests/test_throw_egg.py
@@ -1,0 +1,234 @@
+# -*- coding: utf-8 -*-
+"""批 D 彩蛋：边缘探头状态被击飞时飞行整帧旋转跟随速度方向。
+
+覆盖：arm 条件双向（碰撞取消才 arm）、角度四方向、低速碰边界恢复、
+低速碰桌宠恢复、高速不恢复、_stop_physics 兜底、end 幂等与重 arm。
+"""
+from __future__ import annotations
+
+import pytest
+from PySide6.QtCore import QObject, QRect
+from PySide6.QtWidgets import QApplication
+
+from pet.edge_probe import PEEKING, EdgeProbeController
+from pet.throw_egg import ThrowEggController
+
+
+def _qapp():
+    return QApplication.instance() or QApplication([])
+
+
+class _Avail:
+    def availableGeometry(self):
+        return QRect(0, 0, 1000, 800)
+
+
+class _FakeCfg:
+    def get(self, key, default=None):
+        return default
+
+
+class _FakeWin(QObject):
+    """最小窗口替身：只提供控制器需要的公开/半内部方法与 _throw_egg 装配槽位。"""
+
+    def __init__(self):
+        super().__init__()
+        self._x = 0
+        self._y = 100
+        self._w = 400
+        self._h = 300
+        self._updates = 0
+        self.cfg = _FakeCfg()
+        self.anim = "idle"
+        self.idles = ["idle"]
+        self.turns = ["turn"]
+        self._throw_egg = None
+
+    def x(self):
+        return self._x
+
+    def y(self):
+        return self._y
+
+    def move(self, x, y):
+        self._x = int(x)
+        self._y = int(y)
+
+    def update(self):
+        self._updates += 1
+
+    def screen_available(self, *_a):
+        return _Avail()
+
+    def character_local_region(self):
+        return QRect(100, 0, 200, 200)
+
+    def frameGeometry(self):
+        return QRect(self._x, self._y, self._w, self._h)
+
+    def _frame_draw_rect(self):
+        return QRect(0, 0, self._w, self._h)
+
+    def _switch(self, name):
+        self.anim = name
+        return True
+
+    def _pick(self, pool):
+        return pool[0]
+
+    def _cancel_move(self):
+        pass
+
+    def _stop_physics(self):
+        pass
+
+
+def test_arm_activates_and_zeroes_angle():
+    win = _FakeWin()
+    egg = ThrowEggController(win)
+    assert not egg.active
+    egg.arm()
+    assert egg.active
+    assert egg.current_angle_deg() == 0.0
+    assert win._updates > 0
+
+
+def test_angle_follows_four_directions():
+    """屏幕坐标 y 朝下：向右=90°、向下=180°、向上=0°、向左=270°。"""
+    win = _FakeWin()
+    egg = ThrowEggController(win)
+    egg.arm()
+    egg.update(150.0, 0.0, False)
+    assert egg.current_angle_deg() == pytest.approx(90.0)
+    egg.update(0.0, 150.0, False)
+    assert egg.current_angle_deg() == pytest.approx(180.0)
+    egg.update(0.0, -150.0, False)
+    assert egg.current_angle_deg() == pytest.approx(0.0)
+    egg.update(-150.0, 0.0, False)
+    assert egg.current_angle_deg() == pytest.approx(270.0)
+
+
+def test_angle_debounces_below_speed_threshold():
+    """速度低于阈值且未碰边界：保持当前角不更新（防抖）。"""
+    win = _FakeWin()
+    egg = ThrowEggController(win)
+    egg.arm()
+    egg.update(150.0, 0.0, False)
+    before = egg.current_angle_deg()
+    egg.update(30.0, 0.0, False)
+    assert egg.active
+    assert egg.current_angle_deg() == before
+
+
+def test_low_speed_touching_boundary_recovers():
+    win = _FakeWin()
+    egg = ThrowEggController(win)
+    egg.arm()
+    # 高速贴边：不恢复，角度仍更新。
+    egg.update(200.0, 0.0, True)
+    assert egg.active
+    assert egg.current_angle_deg() == pytest.approx(90.0)
+    # 低速贴边：恢复正常姿态。
+    egg.update(60.0, 0.0, True)
+    assert not egg.active
+    assert egg.current_angle_deg() == 0.0
+
+
+def test_low_speed_pet_contact_recovers():
+    win = _FakeWin()
+    egg = ThrowEggController(win)
+    egg.arm()
+    egg.on_pet_contact(60.0)
+    assert not egg.active
+    assert egg.current_angle_deg() == 0.0
+
+
+def test_high_speed_contact_does_not_recover():
+    win = _FakeWin()
+    egg = ThrowEggController(win)
+    egg.arm()
+    egg.on_pet_contact(200.0)
+    assert egg.active
+    egg.update(200.0, 0.0, True)
+    assert egg.active
+    assert egg.current_angle_deg() == pytest.approx(90.0)
+
+
+def test_end_idempotent_and_rearm():
+    win = _FakeWin()
+    egg = ThrowEggController(win)
+    egg.arm()
+    egg.end()
+    assert not egg.active
+    assert egg.current_angle_deg() == 0.0
+    # 幂等：再次 end 不报错、状态不变。
+    egg.end()
+    assert not egg.active
+    assert egg.current_angle_deg() == 0.0
+    # 结束后可重新 arm。
+    egg.arm()
+    assert egg.active
+
+
+def test_update_on_inactive_is_noop():
+    win = _FakeWin()
+    updates_before = win._updates
+    egg = ThrowEggController(win)
+    egg.update(200.0, 0.0, False)
+    egg.on_pet_contact(30.0)
+    assert not egg.active
+    assert win._updates == updates_before
+
+
+def test_arm_wired_into_collision_throw_cancel():
+    """arm 条件正向：探头激活被撞取消 → 彩蛋进入激活。"""
+    _qapp()
+    win = _FakeWin()
+    egg = ThrowEggController(win)
+    win._throw_egg = egg
+    probe = EdgeProbeController(win)
+    probe.enabled = True
+    probe._mode = PEEKING  # 模拟探头处于激活会话
+    probe.cancel("collision_throw", restore=False)
+    assert egg.active
+    assert probe._reentry_armed
+
+
+def test_non_collision_cancel_does_not_arm():
+    """arm 条件反向：非碰撞取消（如拖离）不激活彩蛋。"""
+    _qapp()
+    win = _FakeWin()
+    egg = ThrowEggController(win)
+    win._throw_egg = egg
+    probe = EdgeProbeController(win)
+    probe.enabled = True
+    probe._mode = PEEKING
+    probe.cancel("drag_away", restore=False)
+    assert not egg.active
+    assert not probe._reentry_armed
+
+
+def test_stop_physics_backstop_ends_egg(tmp_path):
+    """落地停稳兜底：window._stop_physics 无条件调用 throw_egg.end()。"""
+    from tests.test_collision_window import FakeCollisionSession, FakeLibrary
+
+    from pet.config import Config
+    from pet.window import PetWindow
+
+    app = _qapp()
+    cfg = Config(str(tmp_path / "cfg.json"))
+    cfg.set("collision_enabled", False)
+    session = FakeCollisionSession("pet_egg_stop")
+    win = PetWindow(FakeLibrary(), cfg, collision_session=session)
+    win.resize(100, 100)
+    win.show()
+    app.processEvents()
+
+    egg = win._throw_egg
+    assert not egg.active
+    egg.arm()
+    assert egg.active
+    win._stop_physics()
+    assert not egg.active
+    assert egg.current_angle_deg() == 0.0
+    win.close()

--- a/tests/test_throw_egg.py
+++ b/tests/test_throw_egg.py
@@ -3,7 +3,7 @@
 
 覆盖：arm 条件双向（碰撞取消才 arm）、角度四方向、低速碰边界恢复、
 低速碰桌宠恢复、高速不恢复、_stop_physics 兜底、end 幂等与重 arm；
-批 E 补：恢复阈值 240、飞行 8 秒硬上限兜底（速度降不下来也不卡死）。
+批 F：恢复阈值提到 400 且按用户要求移除飞行时间硬上限。
 """
 from __future__ import annotations
 
@@ -12,11 +12,7 @@ from PySide6.QtCore import QObject, QRect
 from PySide6.QtWidgets import QApplication
 
 from pet.edge_probe import PEEKING, EdgeProbeController
-from pet.throw_egg import (
-    THROW_EGG_MAX_FLIGHT_SECONDS,
-    THROW_EGG_RECOVER_SPEED,
-    ThrowEggController,
-)
+from pet.throw_egg import THROW_EGG_RECOVER_SPEED, ThrowEggController
 
 
 def _qapp():
@@ -103,13 +99,13 @@ def test_angle_follows_four_directions():
     win = _FakeWin()
     egg = ThrowEggController(win)
     egg.arm()
-    egg.update(300.0, 0.0, False)
+    egg.update(500.0, 0.0, False)
     assert egg.current_angle_deg() == pytest.approx(90.0)
-    egg.update(0.0, 300.0, False)
+    egg.update(0.0, 500.0, False)
     assert egg.current_angle_deg() == pytest.approx(180.0)
-    egg.update(0.0, -300.0, False)
+    egg.update(0.0, -500.0, False)
     assert egg.current_angle_deg() == pytest.approx(0.0)
-    egg.update(-300.0, 0.0, False)
+    egg.update(-500.0, 0.0, False)
     assert egg.current_angle_deg() == pytest.approx(270.0)
 
 
@@ -118,7 +114,7 @@ def test_angle_debounces_below_speed_threshold():
     win = _FakeWin()
     egg = ThrowEggController(win)
     egg.arm()
-    egg.update(300.0, 0.0, False)
+    egg.update(500.0, 0.0, False)
     before = egg.current_angle_deg()
     egg.update(30.0, 0.0, False)
     assert egg.active
@@ -130,7 +126,7 @@ def test_low_speed_touching_boundary_recovers():
     egg = ThrowEggController(win)
     egg.arm()
     # 高速贴边：不恢复，角度仍更新。
-    egg.update(300.0, 0.0, True)
+    egg.update(500.0, 0.0, True)
     assert egg.active
     assert egg.current_angle_deg() == pytest.approx(90.0)
     # 低速贴边：恢复正常姿态。
@@ -152,20 +148,20 @@ def test_high_speed_contact_does_not_recover():
     win = _FakeWin()
     egg = ThrowEggController(win)
     egg.arm()
-    egg.on_pet_contact(300.0)
+    egg.on_pet_contact(500.0)
     assert egg.active
-    egg.update(300.0, 0.0, True)
+    egg.update(500.0, 0.0, True)
     assert egg.active
     assert egg.current_angle_deg() == pytest.approx(90.0)
 
 
-def test_recover_speed_threshold_raised_to_240():
-    """批 E：阈值 120→240，多只桌宠互撞时速度不再长期卡在阈值之上。"""
-    assert THROW_EGG_RECOVER_SPEED == 240.0
+def test_recover_speed_threshold_raised_to_400():
+    """批 F：阈值 240→400（用户实机要求再拉高，且不设时间硬上限）。"""
+    assert THROW_EGG_RECOVER_SPEED == 400.0
 
 
 def test_speed_above_old_threshold_recovers_at_boundary():
-    """批 E 回归：200 px/s 贴边在旧阈值(120)下会卡住，新阈值(240)下应恢复。"""
+    """回归：200 px/s 贴边在旧阈值(120/240)下会卡住，400 阈值下应恢复。"""
     win = _FakeWin()
     egg = ThrowEggController(win)
     egg.arm()
@@ -174,51 +170,15 @@ def test_speed_above_old_threshold_recovers_at_boundary():
     assert egg.current_angle_deg() == 0.0
 
 
-def test_threshold_boundary_recovery_only_below_240():
-    """阈值边界：241 px/s 贴边仍激活，239 px/s 贴边恢复。"""
+def test_threshold_boundary_recovery_only_below_400():
+    """阈值边界：401 px/s 贴边仍激活，399 px/s 贴边恢复。"""
     win = _FakeWin()
     egg = ThrowEggController(win)
     egg.arm()
-    egg.update(241.0, 0.0, True)
+    egg.update(401.0, 0.0, True)
     assert egg.active
-    egg.update(239.0, 0.0, True)
+    egg.update(399.0, 0.0, True)
     assert not egg.active
-
-
-def test_max_flight_seconds_backstop_ends_high_speed_flight(monkeypatch):
-    """批 E：飞行超过 8 秒无条件 end（速度降不下来也不卡死），与是否贴边无关。"""
-    import pet.throw_egg as throw_egg_mod
-
-    clock = {"t": 1000.0}
-    monkeypatch.setattr(throw_egg_mod.time, "monotonic", lambda: clock["t"])
-    win = _FakeWin()
-    egg = ThrowEggController(win)
-    egg.arm()
-    clock["t"] += THROW_EGG_MAX_FLIGHT_SECONDS - 0.1
-    egg.update(1000.0, 0.0, False)
-    assert egg.active, "未到 8 秒硬上限：高速飞行应继续激活"
-    clock["t"] += 0.2
-    egg.update(1000.0, 0.0, False)
-    assert not egg.active, "超过 8 秒硬上限：无条件恢复正常姿态"
-    assert egg.current_angle_deg() == 0.0
-
-
-def test_max_flight_timer_restarts_on_rearm(monkeypatch):
-    """硬上限起点在 arm() 时记录：end 后重新 arm 重新计时。"""
-    import pet.throw_egg as throw_egg_mod
-
-    clock = {"t": 1000.0}
-    monkeypatch.setattr(throw_egg_mod.time, "monotonic", lambda: clock["t"])
-    win = _FakeWin()
-    egg = ThrowEggController(win)
-    egg.arm()
-    clock["t"] += THROW_EGG_MAX_FLIGHT_SECONDS + 1.0
-    egg.update(1000.0, 0.0, False)
-    assert not egg.active
-    egg.arm()
-    clock["t"] += 0.5
-    egg.update(1000.0, 0.0, False)
-    assert egg.active
 
 
 def test_end_idempotent_and_rearm():

--- a/tests/test_throw_egg.py
+++ b/tests/test_throw_egg.py
@@ -2,7 +2,8 @@
 """批 D 彩蛋：边缘探头状态被击飞时飞行整帧旋转跟随速度方向。
 
 覆盖：arm 条件双向（碰撞取消才 arm）、角度四方向、低速碰边界恢复、
-低速碰桌宠恢复、高速不恢复、_stop_physics 兜底、end 幂等与重 arm。
+低速碰桌宠恢复、高速不恢复、_stop_physics 兜底、end 幂等与重 arm；
+批 E 补：恢复阈值 240、飞行 8 秒硬上限兜底（速度降不下来也不卡死）。
 """
 from __future__ import annotations
 
@@ -11,7 +12,11 @@ from PySide6.QtCore import QObject, QRect
 from PySide6.QtWidgets import QApplication
 
 from pet.edge_probe import PEEKING, EdgeProbeController
-from pet.throw_egg import ThrowEggController
+from pet.throw_egg import (
+    THROW_EGG_MAX_FLIGHT_SECONDS,
+    THROW_EGG_RECOVER_SPEED,
+    ThrowEggController,
+)
 
 
 def _qapp():
@@ -98,13 +103,13 @@ def test_angle_follows_four_directions():
     win = _FakeWin()
     egg = ThrowEggController(win)
     egg.arm()
-    egg.update(150.0, 0.0, False)
+    egg.update(300.0, 0.0, False)
     assert egg.current_angle_deg() == pytest.approx(90.0)
-    egg.update(0.0, 150.0, False)
+    egg.update(0.0, 300.0, False)
     assert egg.current_angle_deg() == pytest.approx(180.0)
-    egg.update(0.0, -150.0, False)
+    egg.update(0.0, -300.0, False)
     assert egg.current_angle_deg() == pytest.approx(0.0)
-    egg.update(-150.0, 0.0, False)
+    egg.update(-300.0, 0.0, False)
     assert egg.current_angle_deg() == pytest.approx(270.0)
 
 
@@ -113,7 +118,7 @@ def test_angle_debounces_below_speed_threshold():
     win = _FakeWin()
     egg = ThrowEggController(win)
     egg.arm()
-    egg.update(150.0, 0.0, False)
+    egg.update(300.0, 0.0, False)
     before = egg.current_angle_deg()
     egg.update(30.0, 0.0, False)
     assert egg.active
@@ -125,7 +130,7 @@ def test_low_speed_touching_boundary_recovers():
     egg = ThrowEggController(win)
     egg.arm()
     # 高速贴边：不恢复，角度仍更新。
-    egg.update(200.0, 0.0, True)
+    egg.update(300.0, 0.0, True)
     assert egg.active
     assert egg.current_angle_deg() == pytest.approx(90.0)
     # 低速贴边：恢复正常姿态。
@@ -147,11 +152,73 @@ def test_high_speed_contact_does_not_recover():
     win = _FakeWin()
     egg = ThrowEggController(win)
     egg.arm()
-    egg.on_pet_contact(200.0)
+    egg.on_pet_contact(300.0)
     assert egg.active
-    egg.update(200.0, 0.0, True)
+    egg.update(300.0, 0.0, True)
     assert egg.active
     assert egg.current_angle_deg() == pytest.approx(90.0)
+
+
+def test_recover_speed_threshold_raised_to_240():
+    """批 E：阈值 120→240，多只桌宠互撞时速度不再长期卡在阈值之上。"""
+    assert THROW_EGG_RECOVER_SPEED == 240.0
+
+
+def test_speed_above_old_threshold_recovers_at_boundary():
+    """批 E 回归：200 px/s 贴边在旧阈值(120)下会卡住，新阈值(240)下应恢复。"""
+    win = _FakeWin()
+    egg = ThrowEggController(win)
+    egg.arm()
+    egg.update(200.0, 0.0, True)
+    assert not egg.active
+    assert egg.current_angle_deg() == 0.0
+
+
+def test_threshold_boundary_recovery_only_below_240():
+    """阈值边界：241 px/s 贴边仍激活，239 px/s 贴边恢复。"""
+    win = _FakeWin()
+    egg = ThrowEggController(win)
+    egg.arm()
+    egg.update(241.0, 0.0, True)
+    assert egg.active
+    egg.update(239.0, 0.0, True)
+    assert not egg.active
+
+
+def test_max_flight_seconds_backstop_ends_high_speed_flight(monkeypatch):
+    """批 E：飞行超过 8 秒无条件 end（速度降不下来也不卡死），与是否贴边无关。"""
+    import pet.throw_egg as throw_egg_mod
+
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(throw_egg_mod.time, "monotonic", lambda: clock["t"])
+    win = _FakeWin()
+    egg = ThrowEggController(win)
+    egg.arm()
+    clock["t"] += THROW_EGG_MAX_FLIGHT_SECONDS - 0.1
+    egg.update(1000.0, 0.0, False)
+    assert egg.active, "未到 8 秒硬上限：高速飞行应继续激活"
+    clock["t"] += 0.2
+    egg.update(1000.0, 0.0, False)
+    assert not egg.active, "超过 8 秒硬上限：无条件恢复正常姿态"
+    assert egg.current_angle_deg() == 0.0
+
+
+def test_max_flight_timer_restarts_on_rearm(monkeypatch):
+    """硬上限起点在 arm() 时记录：end 后重新 arm 重新计时。"""
+    import pet.throw_egg as throw_egg_mod
+
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(throw_egg_mod.time, "monotonic", lambda: clock["t"])
+    win = _FakeWin()
+    egg = ThrowEggController(win)
+    egg.arm()
+    clock["t"] += THROW_EGG_MAX_FLIGHT_SECONDS + 1.0
+    egg.update(1000.0, 0.0, False)
+    assert not egg.active
+    egg.arm()
+    clock["t"] += 0.5
+    egg.update(1000.0, 0.0, False)
+    assert egg.active
 
 
 def test_end_idempotent_and_rearm():


### PR DESCRIPTION
## 概述

子肥鱼（生小肥鱼/退出子肥鱼）生命周期的一揽子修复，外加边缘探头被撞飞的修复与彩蛋。共 9 个提交，全部带测试。

## 生小肥鱼：落种统一 + 设置占位

- 落种逻辑收敛到 `slot_manager.seed_slot_config_from_main`（含继承大小/小肥鱼大小/灵动岛策略），删除只剔位置键的旧实现，进程内/多进程两个 spawn 调用点统一接入。
- slot 配置新增 `user_customized`：仅在该子肥鱼自己的设置界面保存过（或右键菜单改过大小）时置位，位置自动保存等后台写盘不置位。
- 生成时三分支：无存档按主设置落种；未置位按主设置刷新；已置位整个跳过。落种/刷新永不写位置键——子肥鱼摆好的位置不再被顶掉。

## 退出子肥鱼（原"清除子肥鱼"）：只退出、不删数据、不卡、不漏、不误杀

功能语义改为"一键退出所有子肥鱼"：不再删除子肥鱼的配置/会话/待办数据，设置全部保留，下次生成原样恢复。

- **主鱼保护**：入口只挂主肥鱼（子鱼进程的 pid 自保护只跳过自己，从子鱼触发会把主鱼当子鱼 taskkill——实机事故）；清理逻辑兜底跳过 v2 标记里的 slot-0。
- **漏清修复**：runtime 标记此前只在保存位置时写，未拖动过的新生小肥鱼无标记会被漏枚举；现 showEvent 启动即登记，另加 slots/slot-*.lock 作第二枚举源。
- **pid 复用误杀防护**：杀前用 exe 路径核验身份（陈旧标记的 pid 被无关进程复用时不再误杀/打不动受保护进程）。
- **探活误判修复（根因）**：OpenProcess 对"已死但父进程仍持有句柄"的子进程仍可打开，杀成功却被误判存活、白等重试还误报；改 GetExitCodeProcess==STILL_ACTIVE 判定，附真实子进程回归测试。
- **性能**：两段式杀法（先全杀再统一确认）；每窗重资源回收（writer/agent/碰撞停止）挪后台 reaper 线程；UI 线程不再冻结、半透明窗不再出黑框。
- **静默化**：移除确认框与结果弹窗；taskkill 加 CREATE_NO_WINDOW 不再弹空白控制台窗口。杀失败的 pid 保留标记并写日志供重试。
- 设置界面按钮与右键菜单统一走 AppShell 入口（此前设置按钮绕过进程内关窗前置于）。

## 边缘探头：被撞飞修复 + 彩蛋

- 修复：真实撞击进入飞行前取消探头会话（`cancel("collision_throw", restore=False)`），消除撞飞后动画降级、点击被旧会话拦截闪回边缘两个问题；撞飞落定停稳 5 秒后若静止于屏幕边缘可重新进入探头吸附（倒计时内拖拽作废）。
- 彩蛋：探头状态被击飞时，飞行中整帧旋转使头部跟随速度方向（复用 window_effects 旋转管线）；速度低于 780px/s 且触碰边界/桌宠后回正，`_stop_physics` 兜底。彩蛋期间动画锁 idle/turn 防穿帮，非探头撞飞行为不变。

## 验证

- 全量测试 1424 passed / 7 skipped（本机仅有的 3 个失败为环境既有项：symlink 权限、120Hz 计时、DPR 信号，与本改动无关）。
- 新增/更新测试覆盖：落种三分支、占位置位时机、双模式清理、链式关闭不冻 UI、僵尸句柄探活回归、pid 复用防护、slot-0 保护、彩蛋角度/恢复/兜底等。
- 真机验收（Windows）：多进程三开与单进程多开两种模式下，生成/调设置/退出/再生全链路通过；探头撞飞彩蛋表现正常。
- 行数预算按 tests/test_architecture.py 约定随实测校准（window.py 4369、modern_settings_dialog.py 2018，均带日期理由注释）。
