### PR TITLE
fix: PR57 功能层遗留修复——联动气泡时钟域/429 双提醒/预热死键/回归测试补回

### DIFF
--- a/pet/agent_link.py
+++ b/pet/agent_link.py
@@ -2942,7 +2942,11 @@ class AgentLinkManager(QObject):
             # 兼容旧路径：审批等一直挂着的气泡优先
             return
         busy_until = getattr(self.win, "_bubble_busy_until", 0.0)
-        if time.time() < busy_until:
+        # window.hold_bubble 以 time.monotonic() 写入 _bubble_busy_until，这里必须
+        # 用同一时钟域比较——曾误用 time.time()（epoch 秒），在真实桌宠上恒判
+        # "未被占用"，让位/重试门禁失效（普通气泡顶掉识屏占位、重要气泡不排队
+        # 重试直接覆盖）。同步修正于 PR57 合并后审计（F1）。
+        if time.monotonic() < busy_until:
             if not important or _retried >= 4:
                 return
             QTimer.singleShot(2500, self,
@@ -3551,7 +3555,10 @@ class AgentLinkManager(QObject):
             return
         payload = payload if isinstance(payload, dict) else {}
         name = self.AGENT_NAMES.get(agent_key, agent_key)
-        # 若该 session 有活跃的 429 提醒，不再重复弹通用失败横幅（避免双重通知）
+        # 若该 session 有活跃的 429 提醒，不再重复弹通用失败横幅（避免双重通知）。
+        # 抑制条件从「429 距上次触发 8s cooldown 内」收紧为「存在未 dismiss 的活跃
+        # 429 提醒」：429 alert 展示 15s > cooldown 8s，turn/end 的 execution/failed
+        # 常在 8~15s 窗口到达（同一次限流的终局），旧条件会绕过抑制造成双弹（F2）。
         session_key = str(payload.get("sessionId") or agent_key)
         active_429 = self._429_cache.get(session_key)
         error_code = str(payload.get("errorCode") or "").strip().upper()
@@ -3561,8 +3568,8 @@ class AgentLinkManager(QObject):
         retry_exhausted = bool(payload.get("retryExhausted"))
         source = str(payload.get("source") or "").strip()
         suppress_as_429 = is_rate_limit_failure or (retry_exhausted and source != "tool" and not error_code)
-        if active_429 and not active_429.get("_dismissed") and \
-                self._clock() - active_429.get("_ts", 0) < self._429_COOLDOWN_S and suppress_as_429:
+        if active_429 and not active_429.get("_dismissed") and suppress_as_429:
+            # 429 提醒仍挂起：同一次失败的终局结论已由限流提醒表达，通用失败横幅让路。
             return
         # 失败动画（若角色素材有）；没有就保持当前动作，仅弹气泡
         anim = self._pick_fail_anim()

--- a/pet/config.py
+++ b/pet/config.py
@@ -604,7 +604,6 @@ class Config:
             "throw_strength": "standard",  # gentle / standard / strong / crazy
             "idle_low_fps_enabled": False,  # 闲置降帧（灰度默认关）：长时间无交互时动画隔帧呈现
             "idle_low_fps_threshold": 30.0,  # 闲置阈值（秒）：超过该时长无交互且窗口可见才降帧
-            "animation_prewarm_enabled": True,  # 动画素材后台预热开关
             "click_show_balance": False,   # 点击显示 DeepSeek 余额
             "click_show_self_talk": False, # 点击随机显示自定义自言自语
             "balance_refresh_minutes": 0,  # DeepSeek 余额自动刷新间隔（分钟，0=关闭）
@@ -814,7 +813,6 @@ class Config:
             "collision_mass_scale", "collision_impulse_cap",
             "collision_sound_enabled", "collision_sound_volume",
             "media_prewarm",
-            "animation_prewarm_enabled",
             "first_frame_cache_max_mb",
             "predict_prewarm_lead_ms",
             "ffmpeg_recycle_minutes",

--- a/tests/test_agent_link.py
+++ b/tests/test_agent_link.py
@@ -32,6 +32,7 @@ from pet.agent_link import (
     CustomAgentMonitor,
     DshMonitor,
     normalize_event_state,
+    opencode_event_state,
 )
 from pet.config import Config
 from pet.config import _clean_agent_link_data, _clean_custom_agents
@@ -1105,9 +1106,13 @@ class TestAgentLinkBubbles:
 
     def test_bubble_busy_until_occupancy(self, tmp_path, monkeypatch):
         """7. _show_link_bubble 在 win._bubble_busy_until 为未来时间时：
-        important=False 直接丢弃；important=True 时不立即弹（走 QTimer.singleShot 延后重试，测试里只需断言没有立即调用 show_bubble）。"""
+        important=False 直接丢弃；important=True 时不立即弹（走 QTimer.singleShot 延后重试，测试里只需断言没有立即调用 show_bubble）。
+
+        回归锚点（F1）：hold_bubble 写 time.monotonic() 域（真实 window 行为），
+        _show_link_bubble 必须用同域比较——曾误用 time.time()（epoch 秒）导致
+        门禁恒失效。stub 以 monotonic 未来时刻模拟占用。"""
         mgr, win, bubbles, clock = self._make_mgr(tmp_path)
-        win._bubble_busy_until = time.time() + 100.0
+        win._bubble_busy_until = time.monotonic() + 100.0
 
         # important=False 丢弃
         mgr._show_link_bubble("普通消息", important=False)
@@ -1159,6 +1164,36 @@ class TestAgentLinkBubbles:
         switched_before = len(win2.switched)
         mgr2._fire_done("claude")
         assert len(win2.switched) == switched_before  # 没有切回待机
+
+    def test_opencode_step_finish_tool_calls_no_done(self, tmp_path):
+        """回归（PR57 合并时丢失的 main 侧用例）：opencode step-finish
+        (reason=tool-calls)（派 task 子代理后主代理停笔等待）不触发完成确认——
+        不产出 idle 状态 → 800ms 确认不排程；step-finish(reason=stop) 才是
+        真结束 → 排程并出完成气泡。产品逻辑（opencode_event_state 的
+        tool-calls→""）仍存在，恢复端到端守卫。"""
+        import json as j
+
+        mgr, win, bubbles, clock = self._make_mgr(tmp_path)
+        mgr._on_agent_state("dsh", "working")
+
+        # 子代理长跑期间：tool-calls 维持现状，确认窗口不排程
+        state = opencode_event_state("message.part.updated.1",
+                                     j.dumps({"part": {"type": "step-finish", "reason": "tool-calls"}}))
+        assert state == ""
+        if state:  # 与 agent_link._poll 的空状态跳过逻辑一致
+            mgr._on_agent_state("dsh", state)
+        clock[0] += 3.0
+        assert "dsh" not in mgr._done_pending
+        assert bubbles == []
+
+        # 子代理回注、整轮真结束：stop → idle → 排程 → 完成气泡恰一次
+        state = opencode_event_state("message.part.updated.1",
+                                     j.dumps({"part": {"type": "step-finish", "reason": "stop"}}))
+        assert state == "idle"
+        mgr._on_agent_state("dsh", state)
+        assert "dsh" in mgr._done_pending
+        mgr._fire_done("dsh")
+        assert any("已完成" in b for b in bubbles), f"应弹完成气泡: {bubbles}"
 
 
 class TestAgentLinkSounds:
@@ -1281,6 +1316,25 @@ class TestInstallErrorSummary:
         assert json.loads(manifest.read_text(encoding="utf-8"))["dsh"]["profile"]["bundles"] == [
             agent_link.DSH_PLUGIN_NAME
         ]
+
+    def test_find_pnpm_cli_accepts_homebrew_javascript_symlink(self, tmp_path, monkeypatch):
+        """回归（PR57 合并时丢失的 main 侧用例）：homebrew 的 pnpm 是
+        bin/pnpm → lib/node_modules/pnpm/bin/pnpm.cjs 的符号链接，
+        _find_pnpm_cli 必须经 resolve() 落到真实 JS CLI。
+        注：Windows 无管理员权限创建 symlink 会失败（WinError 1314），
+        该用例在 Linux/macOS CI 执行；本地 Windows 跳过。"""
+        try:
+            cli = tmp_path / "lib" / "node_modules" / "pnpm" / "bin" / "pnpm.cjs"
+            cli.parent.mkdir(parents=True)
+            cli.write_text("", encoding="utf-8")
+            shim = tmp_path / "bin" / "pnpm"
+            shim.parent.mkdir()
+            shim.symlink_to(cli)
+        except OSError:
+            pytest.skip("symlink 权限不可用（Windows 无管理员）")
+        monkeypatch.delenv("DSH_PNPM_BIN", raising=False)
+        monkeypatch.setattr(agent_link, "_which", lambda name: str(shim) if name == "pnpm" else None)
+        assert agent_link._find_pnpm_cli() == str(cli)
 
     def test_extract_err_pnpm_line(self):
         output = """
@@ -2918,6 +2972,28 @@ class TestRateLimitAlert:
                                          "retryExhausted": True})
         assert len(mgr.win.alerts) == before, "429 活跃时抑制通用失败横幅"
 
+    def test_execution_failed_suppressed_beyond_cooldown_while_429_alive(self, tmp_path):
+        """F2 回归：429 提醒展示 15s > 合并冷却 8s，turn/end 的 execution/failed 常
+        在 8~15s 窗口到达——只要 429 提醒仍未 dismiss，通用失败横幅必须继续抑制
+        （旧实现按 8s cooldown 判断会绕过抑制造成双弹）。dismiss 后新失败正常提醒。"""
+        mgr = self._make_mgr(tmp_path)
+        now = [1000.0]
+        mgr._clock = lambda: now[0]
+        mgr._on_rate_limit("dsh", {"sessionId": "sess-f2",
+                                   "errorCode": "RATE_LIMIT", "consecutiveRetryCount": 1})
+        assert len(mgr.win.alerts) == 1
+        now[0] += 10.0  # 超出 8s cooldown，仍在 15s 展示寿命内
+        mgr._on_execution_failed("dsh", {"sessionId": "sess-f2", "source": "model_request",
+                                         "retryExhausted": True, "retries": 5,
+                                         "errorCode": "RATE_LIMIT"})
+        assert len(mgr.win.alerts) == 1, "429 提醒存活期间不得二次弹通用失败横幅"
+        # 收起 429 后：新的（非限流）失败应正常提醒
+        mgr._dismiss_429_alert("sess-f2")
+        mgr._on_execution_failed("dsh", {"sessionId": "sess-f2", "source": "tool",
+                                         "retryExhausted": False, "retries": 0,
+                                         "errorCode": ""})
+        assert len(mgr.win.alerts) == 2, "429 已收起后工具失败应正常提醒"
+
 
 class TestSessionNameTruthfulness:
     """{sessionName} 只注入真实会话显示名，绝不把 sessionId 截短占位冒充（字段真实性）。
@@ -2980,3 +3056,201 @@ class TestSessionNameTruthfulness:
         mgr._dialogue = lambda key, fallback, **kw: (captured.update(kw), fallback)[1]
         mgr._show_429_alert("session-abcdef12", 1)
         assert "sessionName" not in captured, "429 无会话元数据时不得注入 sessionName"
+
+
+class TestInstallFinishedGuard:
+    """安装后台线程完成回调不得越过 manager 生命周期：窗口关闭/角色切换
+    （shutdown）或重新禁用后，迟到的 install_finished 不得写配置/启动
+    监视器/弹气泡（daemon 安装线程本身无法被取消，只能拦完成回调）。"""
+
+    def _make_manager(self, tmp_path, bubbles, monkeypatch, release):
+        cfg = Config(base=tmp_path)
+
+        class Win:
+            def show_bubble(self, text, duration_ms=3000):
+                bubbles.append(text)
+
+            def isVisible(self):
+                return True
+
+        mgr = AgentLinkManager(Win(), cfg)
+        monkeypatch.setattr(
+            QMessageBox, "question",
+            lambda *a, **kw: QMessageBox.StandardButton.Yes,
+        )
+        monkeypatch.setattr(
+            DshMonitor, "uninstall_bridge", classmethod(lambda cls: True),
+        )
+
+        def fake_install():
+            assert release.wait(timeout=5.0), "测试释放信号未到达"
+            return (True, "ok")
+
+        monkeypatch.setattr(
+            DshMonitor, "install_bridge", classmethod(lambda cls: fake_install()),
+        )
+        return cfg, mgr
+
+    def _install_thread(self):
+        return next(
+            t for t in threading.enumerate() if t.name == "dsh-bridge-install"
+        )
+
+    def test_late_completion_after_shutdown_is_dropped(self, tmp_path, monkeypatch):
+        """安装完成发生在 shutdown（窗口关闭/角色切换）之后 → 完成回调被
+        丢弃：配置不写回、监视器不启动、无完成气泡。"""
+        app = QApplication.instance() or QApplication([])
+        bubbles = []
+        release = threading.Event()
+        cfg, mgr = self._make_manager(tmp_path, bubbles, monkeypatch, release)
+        mgr.set_enabled("dsh", True)
+        install_thread = self._install_thread()
+        assert "dsh" in mgr._install_pending
+        assert bubbles == ["正在为 DSH 安装通信桥。"]  # persona legacy: bridge.install.pending
+        mgr.shutdown()   # 安装完成前 manager 被关闭（窗口 close / 角色切换）
+        release.set()    # 安装此刻才完成
+        install_thread.join(timeout=5.0)
+        app.processEvents()
+        app.processEvents()
+        assert cfg.data["agent_link"]["dsh"] is False
+        assert not mgr.monitors["dsh"]._running
+        assert bubbles == ["正在为 DSH 安装通信桥。"], "不得弹完成气泡"
+
+    def test_queued_completion_dispatched_after_shutdown_is_dropped(self, tmp_path, monkeypatch):
+        """emit→dispatch 竞态：信号在 shutdown 前已 emit 入队（worker 已
+        完成），但回调在 shutdown 之后才被派发 → 同样必须丢弃（完成回调
+        在 GUI 线程的权威校验兜住该窗口）。"""
+        app = QApplication.instance() or QApplication([])
+        bubbles = []
+        release = threading.Event()
+        cfg, mgr = self._make_manager(tmp_path, bubbles, monkeypatch, release)
+        mgr.set_enabled("dsh", True)
+        install_thread = self._install_thread()
+        release.set()                 # 安装完成 → worker emit（queued 入队）
+        install_thread.join(timeout=5.0)
+        # 未跑 processEvents：queued 回调仍躺在 GUI 事件队列里
+        mgr.shutdown()                # 关闭发生在回调派发之前
+        app.processEvents()           # 迟到的 queued 回调此刻才派发 → 丢弃
+        app.processEvents()
+        assert cfg.data["agent_link"]["dsh"] is False
+        assert not mgr.monitors["dsh"]._running
+        assert bubbles == ["正在为 DSH 安装通信桥。"], "不得弹完成气泡"
+
+    def test_late_completion_after_redisable_is_dropped(self, tmp_path, monkeypatch):
+        """用户重新关闭联动（安装进行中）→ 在途安装作废，完成回调被丢弃，
+        不得反向把配置写回 True / 启动监视器。"""
+        app = QApplication.instance() or QApplication([])
+        bubbles = []
+        release = threading.Event()
+        cfg, mgr = self._make_manager(tmp_path, bubbles, monkeypatch, release)
+        mgr.set_enabled("dsh", True)
+        install_thread = self._install_thread()
+        assert "dsh" in mgr._install_pending
+        mgr.set_enabled("dsh", False)  # 用户重新关闭联动 → 在途安装作废
+        assert "dsh" not in mgr._install_pending
+        release.set()
+        install_thread.join(timeout=5.0)
+        app.processEvents()
+        app.processEvents()
+        assert cfg.data["agent_link"]["dsh"] is False
+        assert not mgr.monitors["dsh"]._running
+        assert bubbles == ["正在为 DSH 安装通信桥。"], "不得弹完成气泡"
+
+    def test_stale_queued_completion_must_not_consume_reinstalled_pending(self, tmp_path, monkeypatch):
+        """B9 复审 P1：disable→re-enable 两代安装交错。安装 A 完成信号已
+        queued 入队但未派发时，用户关闭联动并再次开启、登记安装 B（新代次）；
+        A 的旧回调随后派发时不得消费 B 的 pending（不得写配置/启动监视器/
+        弹完成气泡），B 的真实回调随后正常生效。完成信号必须携带并校验
+        安装代次，仅凭 agent key 无法区分两代安装。"""
+        app = QApplication.instance() or QApplication([])
+        bubbles = []
+        cfg = Config(base=tmp_path)
+
+        class Win:
+            def show_bubble(self, text, duration_ms=3000):
+                bubbles.append(text)
+
+            def isVisible(self):
+                return True
+
+        mgr = AgentLinkManager(Win(), cfg)
+        monkeypatch.setattr(
+            QMessageBox, "question",
+            lambda *a, **kw: QMessageBox.StandardButton.Yes,
+        )
+        monkeypatch.setattr(
+            DshMonitor, "uninstall_bridge", classmethod(lambda cls: True),
+        )
+
+        release_a, release_b = threading.Event(), threading.Event()
+        queue = [release_a, release_b]
+
+        def fake_install():
+            ev = queue.pop(0)
+            assert ev.wait(timeout=5.0), "测试释放信号未到达"
+            return (True, "ok")
+
+        monkeypatch.setattr(
+            DshMonitor, "install_bridge", classmethod(lambda cls: fake_install()),
+        )
+
+        def install_thread():
+            return next(
+                t for t in threading.enumerate() if t.name == "dsh-bridge-install"
+            )
+
+        # 第一代安装 A：等它完成并 emit（queued 入队），但先不派发
+        mgr.set_enabled("dsh", True)
+        thread_a = install_thread()
+        release_a.set()
+        thread_a.join(timeout=5.0)
+        assert not thread_a.is_alive()
+        assert "dsh" in mgr._install_pending   # A 的 pending 尚未被消费
+        # 未跑 processEvents：A 的 queued 回调仍躺在 GUI 事件队列里
+        mgr.set_enabled("dsh", False)          # 关闭联动：作废在途安装
+        assert "dsh" not in mgr._install_pending
+        mgr.set_enabled("dsh", True)           # 再次开启：登记安装 B（新代次）
+        assert "dsh" in mgr._install_pending
+        thread_b = install_thread()
+        # 此刻派发 A 的旧 queued 回调：不得消费 B 的 pending
+        app.processEvents()
+        app.processEvents()
+        assert "dsh" in mgr._install_pending           # B 的 pending 必须仍在
+        assert cfg.data["agent_link"]["dsh"] is False  # 配置不得被 A 写回
+        assert not mgr.monitors["dsh"]._running        # 监视器不得被 A 启动
+        assert not any("安装完成" in b for b in bubbles), f"不得弹完成气泡: {bubbles}"
+        # B 的真实回调随后派发：正常生效（写配置、启动监视器、弹气泡）
+        release_b.set()
+        thread_b.join(timeout=5.0)
+        deadline = time.monotonic() + 3.0
+        while time.monotonic() < deadline:
+            app.processEvents()
+            if cfg.data["agent_link"]["dsh"]:
+                break
+            time.sleep(0.01)
+        assert cfg.data["agent_link"]["dsh"] is True
+        assert mgr.monitors["dsh"]._running
+        assert any("安装完成" in b for b in bubbles), f"应有 B 的完成气泡: {bubbles}"
+
+    def test_normal_completion_still_applies(self, tmp_path, monkeypatch):
+        """正常路径回归：安装完成后回调照常生效（写配置、启动监视器、
+        弹完成气泡）。"""
+        app = QApplication.instance() or QApplication([])
+        bubbles = []
+        release = threading.Event()
+        cfg, mgr = self._make_manager(tmp_path, bubbles, monkeypatch, release)
+        mgr.set_enabled("dsh", True)
+        install_thread = self._install_thread()
+        release.set()
+        install_thread.join(timeout=5.0)
+        deadline = time.monotonic() + 3.0
+        while time.monotonic() < deadline:
+            app.processEvents()
+            if cfg.data["agent_link"]["dsh"]:
+                break
+            time.sleep(0.01)
+        assert cfg.data["agent_link"]["dsh"] is True
+        assert mgr.monitors["dsh"]._running
+        assert any("安装完成" in b for b in bubbles), f"应有完成气泡，实际: {bubbles}"
+        mgr.set_enabled("dsh", False)
+        assert cfg.data["agent_link"]["dsh"] is False

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -48,7 +48,6 @@ RELOAD_WHITELIST_SNAPSHOT = frozenset({
     "dynamic_island", "edge_probe_enabled", "facing",
     "golden_spin_on_click", "golden_spin_direct",
     "idle_low_fps_enabled", "idle_low_fps_threshold", "lock_position",
-    "animation_prewarm_enabled",
     "dialogue_mode", "dialogue_phrases",
     "menu_easter_egg", "media_prewarm", "first_frame_cache_max_mb", "predict_prewarm_lead_ms", "ffmpeg_recycle_minutes",
     "modern_chat_background", "modern_chat_background_fill",


### PR DESCRIPTION
## 背景

PR #57（dba82eb）合并后审计产出遗留项清单。本 PR 修复其中 **4 个功能层面问题**（test-first，红→绿验证）；非功能层面（文案/UX/运行确认 N1–N9）另开清单待产品确认，不在此 PR。

## 改动内容

### F1 联动气泡让位门禁时钟域不一致（真实功能 bug）
`_show_link_bubble` 用 `time.time()`（epoch 秒）比较 `window.hold_bubble` 写入 `_bubble_busy_until` 的 `time.monotonic()` 值——真实桌宠上恒判未被占用，导致普通联动气泡顶掉识屏占位、重要气泡不排队重试直接覆盖。改为同域 `time.monotonic()`；测试 stub 原来同样错用 `time.time()` 自洽掩盖 bug，一并修正。

### F2 429 → execution/failed 双提醒
429 alert 展示 15s > 同 session 合并冷却 8s，bridge 在 turn/end 发 `execution/failed` 常落在 8~15s 窗口——旧抑制条件（冷却窗口内）会绕过抑制造成同一失败弹两次。收紧为「存在未 dismiss 的活跃 429 提醒即抑制通用失败横幅」；429 收起后新失败仍正常提醒。含边界回归测试。

### F3 移除 `animation_prewarm_enabled` 残留死键
main（#76/#85）已将该键并入省电模式并明示删除；PR57 合并把键加回 config 默认值 / reload 白名单 / schema 快照，全仓零消费。三处同步删除（对齐 SETTINGS-CHANGE-GATES）。

### F4 补回 PR57 合并时丢失的回归测试
- `TestInstallFinishedGuard` 5 用例（shutdown / 重新禁用后迟到 install_finished 被丢弃、stale queued 不消费新 pending、正常完成仍生效）——产品 token 守卫逻辑仍在，仅测试在合并中丢失；
- opencode `step-finish(reason=tool-calls)` 不触发完成确认的端到端用例；
- pnpm homebrew symlink 解析用例（Windows 无权限自动 skip）。
文案断言适配 persona 预设当前文案（原断言锚定 main 时代内联文案）。

## 验证

- ruff check 全绿；
- 受影响域全绿：`test_agent_link.py` 157 passed + 1 skip（symlink 权限）、`test_config_schema.py` 等 config 域 59、`test_single_process_shared.py` + `test_desktop_pet_features.py` + persona 域 123、跨域（behavior/stuck/alert/settings/proactive/window）150、architecture/file_eater 18；
- 本地全量 pytest 在已知 Qt offscreen 原生崩溃/挂起 flake 处停滞（干净基线同现，AGENTS 已记录），以 CI 三平台为最终门。

## 备注

非功能层面遗留项（per-Agent thinking UI 移除确认、三检测器连环弹窗 UX、expression_style_text 死代码/文案承诺、legacy/whale_maid 预设文案差异、余额气泡默认文案被预设改写、动画间隔语义、closeEvent 触碰面、直播捕获运行确认、陈旧 docstring/README）待确认清单已整理，确认后另开 PR。