### PR TITLE
fix: 修复 main 上 CI Windows/macOS 原生崩溃——parent=None 的 manager 跨线程 GC 销毁

### DIFF
--- a/pet/agent_link.py
+++ b/pet/agent_link.py
@@ -33,7 +33,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
 
-from PySide6.QtCore import QObject, QTimer, Signal
+from PySide6.QtCore import QCoreApplication, QObject, QTimer, Signal
 from PySide6.QtWidgets import QMessageBox
 
 from .click_sound import play_sound, resolve_builtin_sound
@@ -1521,6 +1521,9 @@ class AgentLinkManager(QObject):
         self._shutdown = False
         self._respond_threads: set[threading.Thread] = set()
         self._respond_threads_lock = threading.Lock()
+        # 后台回写/控制 worker 的取消信号：shutdown 时置位，让 30s 阻塞轮询的
+        # 控制 worker 立刻退出，保证 join 在预算内完成、worker 不比 manager 活得久。
+        self._worker_cancel = threading.Event()
         _LIVE_AGENT_LINK_MANAGERS.add(self)
         self._install_token = 0
         self._install_pending: dict[str, int] = {}
@@ -1886,6 +1889,7 @@ class AgentLinkManager(QObject):
     def shutdown(self) -> None:
         """窗口销毁/角色切换时停止所有 monitor worker，且作废安装回调。"""
         self._shutdown = True
+        self._worker_cancel.set()
         self._install_pending.clear()
         self._install_token += 1
         for mon in self.monitors.values():
@@ -1907,6 +1911,29 @@ class AgentLinkManager(QObject):
                 break
             if worker is not threading.current_thread() and worker.is_alive():
                 worker.join(remaining)
+        # 停掉 manager 自带的全部单发定时器（完成确认/429 收起/LLM 错误收起）：
+        # 下方会把 Python 持有的 manager 过继给 QApplication，对象将存活到进程
+        # 退出——若不停表，滞留定时器会在后续无关时刻触发槽函数。
+        for timer_dict in (self._done_pending, self._429_timers, self._llm_error_timers):
+            for timer in timer_dict.values():
+                try:
+                    timer.stop()
+                except RuntimeError:
+                    pass
+            timer_dict.clear()
+        # parent=None（测试桩/多窗代理）时 C++ 对象是 Python 持有的：wrapper 经
+        # 信号连接/闭包成环，只能等循环 GC——而 GC 可能在任意线程（含 monitor
+        # worker 线程）触发，跨线程删除带 QTimer 子对象/信号连接的 QObject 会
+        # 腐化 Qt 事件队列（CI Windows 在 conftest processEvents access
+        # violation、macOS bus error 的根因）。过继给 QApplication（主线程、
+        # 与进程同寿）后，C++ 侧不再随 wrapper 的 GC 删除，wrapper 何时何线程
+        # 回收都只是空壳析构。真窗口场景由父链销毁在先，RuntimeError 兜底跳过。
+        try:
+            app = QCoreApplication.instance()
+            if self.parent() is None and app is not None and self.thread() is app.thread():
+                self.setParent(app)
+        except RuntimeError:
+            pass
 
     @classmethod
     def _shutdown_live_for_tests(cls) -> None:
@@ -2826,7 +2853,10 @@ class AgentLinkManager(QObject):
         except Exception as exc:  # noqa: BLE001 —— 后台线程绝不允许把异常带进 Qt 事件循环
             ok, detail = False, str(exc)
         try:
-            self._respond_result.emit(ok, detail)
+            # shutdown 后不再投递结果：结果气泡已无意义，且此时 manager 可能
+            # 已进入事件循环销毁流程。
+            if not self._shutdown:
+                self._respond_result.emit(ok, detail)
         except Exception:
             pass
         finally:
@@ -3230,12 +3260,15 @@ class AgentLinkManager(QObject):
                 context=self._exploration_control_context(payload),
                 timeout=self._EXPLORATION_CONTROL_TIMEOUT_S,
                 alert_id=self._exploration_control_alert_id(session_key),
+                cancel=self._worker_cancel,
             )
         except Exception as exc:  # noqa: BLE001 —— 后台线程不得把异常带进 Qt 事件循环
             ok, detail = False, f"control-request-error:{exc}"
         try:
-            self._exploration_control_result.emit(
-                session_key, operation, bool(ok), str(detail))
+            # shutdown 后不再投递结果（manager 可能已进入事件循环销毁流程）。
+            if not self._shutdown:
+                self._exploration_control_result.emit(
+                    session_key, operation, bool(ok), str(detail))
         except Exception:
             pass
         finally:

--- a/pet/dsh_control.py
+++ b/pet/dsh_control.py
@@ -51,7 +51,7 @@ def _log_event(base_dir: str, event: str, **fields) -> None:
 
 def request(operation: str, session_id: str, text: str = "", ports: list[int] | None = None,
             *, goal: str = "", context: str = "", provider: str = "", model: str = "",
-            timeout: float = TIMEOUT_S, alert_id: str = "") -> tuple[bool, str]:
+            timeout: float = TIMEOUT_S, alert_id: str = "", cancel=None) -> tuple[bool, str]:
     del ports  # retained for compatibility; bridge discovery is file based
     if not session_id or session_id.startswith("turn:"):
         return False, "missing-session-id"
@@ -88,6 +88,10 @@ def request(operation: str, session_id: str, text: str = "", ports: list[int] | 
     deadline = time.monotonic() + max(1.0, float(timeout))
     try:
         while time.monotonic() < deadline:
+            # 可取消等待：pet 侧 shutdown 时置位 cancel，30s 轮询立刻退出，
+            # 保证 worker 能在 shutdown 的 join 预算内结束。
+            if cancel is not None and cancel.is_set():
+                return False, "cancelled"
             try:
                 with open(response_path, "r", encoding="utf-8") as handle:
                     result = json.load(handle)
@@ -95,7 +99,11 @@ def request(operation: str, session_id: str, text: str = "", ports: list[int] | 
                     return True, json.dumps(result, ensure_ascii=False)
                 return False, str(result.get("error") or "bridge-control-rejected")
             except (FileNotFoundError, PermissionError, json.JSONDecodeError):
-                time.sleep(POLL_S)
+                if cancel is not None:
+                    if cancel.wait(POLL_S):
+                        return False, "cancelled"
+                else:
+                    time.sleep(POLL_S)
     finally:
         for path in (request_path, response_path):
             try:

--- a/tests/test_agent_link_threads.py
+++ b/tests/test_agent_link_threads.py
@@ -459,3 +459,68 @@ class TestOpenCodeDbRotation:
         db.close()
         mon._poll()
         assert "thinking" in received
+
+
+class TestManagerDeterministicTeardown:
+    """PR91 回归：Python 持有所有权（parent=None）的 manager 在 shutdown 后必须
+    脱离「GC 在任意线程回收 C++ 对象」的命运，且控制 worker 可被取消、不超活。
+
+    根因链：parent=None 时 C++ 对象随 wrapper 被循环 GC 回收，而 GC 可能在任意
+    线程（含 monitor worker 线程）触发——跨线程删除带 QTimer 子对象/信号连接的
+    QObject 会腐化 Qt 事件队列，崩溃点在后续测试的 processEvents 漂移
+    （CI Windows access violation / macOS bus error）。修复：shutdown 把
+    parentless 的 manager 过继给 QApplication（与进程同寿、主线程销毁），
+    停掉自带定时器，并以 _worker_cancel 取消 30s 阻塞轮询的控制 worker。"""
+
+    def test_shutdown_reparents_python_owned_manager_to_app(self, tmp_path, app):
+        """parent=None 的 manager：shutdown 后过继给 QApplication，C++ 不再随
+        wrapper 的 GC 被回收（何时何地回收都只是空壳析构）。"""
+        mgr = AgentLinkManager(None, Config(base=tmp_path))
+        assert mgr.parent() is None  # Python 持有所有权
+        mgr.shutdown()
+        assert mgr.parent() is QApplication.instance(), "shutdown 后应过继给 QApplication"
+        # 过继后 wrapper 被 GC 也只是空壳回收：C++ 侧由 app 持有，不受影响
+        import shiboken6
+        assert shiboken6.isValid(mgr)
+
+    def test_shutdown_stops_manager_timers(self, tmp_path, app):
+        """过继后 manager 存活到进程退出：自带单发定时器必须全部停掉，
+        否则滞留定时器会在后续无关时刻触发槽函数。"""
+        mgr = AgentLinkManager(None, Config(base=tmp_path))
+        mgr._schedule_done_check("dsh")
+        timer = mgr._done_pending.get("dsh")
+        assert timer is not None and timer.isActive()
+        mgr.shutdown()
+        assert not timer.isActive(), "shutdown 必须停掉完成确认定时器"
+        assert mgr._done_pending == {}
+
+    def test_shutdown_is_idempotent_after_reparent(self, tmp_path, app):
+        """重复 shutdown（conftest 收口会再次调用）：幂等，不报错。"""
+        mgr = AgentLinkManager(None, Config(base=tmp_path))
+        mgr.shutdown()
+        mgr.shutdown()
+        assert mgr.parent() is QApplication.instance()
+
+    def test_shutdown_cancels_control_worker_promptly(self, tmp_path, app, monkeypatch):
+        """控制 worker 的 30s 桥接轮询必须可被取消：shutdown 后 worker 立即退出，
+        不超活到 manager 销毁之后。"""
+        import pet.dsh_control as dsh_control_mod
+
+        # 桥接目录指到空临时目录：真实走 request 的轮询循环（无人应答），
+        # 不碰真实 %APPDATA% 桥接目录。
+        monkeypatch.setattr(dsh_control_mod, "_bridge_dir", lambda: str(tmp_path / "bridge"))
+        mgr = AgentLinkManager(None, Config(base=tmp_path))
+        payload = {"session_id": "sess-x", "goal": "", "reasons": [], "steps": []}
+        mgr._request_exploration_control("replan", "sess-x", payload)
+        with mgr._respond_threads_lock:
+            workers = list(mgr._respond_threads)
+        assert workers, "控制请求应已创建后台线程"
+        t0 = time.monotonic()
+        mgr.shutdown()
+        elapsed = time.monotonic() - t0
+        assert elapsed < 3.0, f"取消后 join 耗时 {elapsed:.2f}s（应远小于 30s 轮询超时）"
+        assert all(not w.is_alive() for w in workers), "shutdown 后控制 worker 必须已退出"
+        # request 的 finally 应清理请求/响应文件（取消路径同样清理）
+        bridge_dir = tmp_path / "bridge"
+        leftovers = list(bridge_dir.glob("watchdog-*.json")) if bridge_dir.exists() else []
+        assert leftovers == [], f"取消后残留桥接临时文件: {leftovers}"

--- a/tests/test_watchdog_control_wiring.py
+++ b/tests/test_watchdog_control_wiring.py
@@ -277,7 +277,8 @@ class TestControlRequestThreading:
         calls = threading.Event()
 
         def fake_request(operation, session_id, text="", ports=None, *, goal="",
-                         context="", provider="", model="", timeout=30.0, alert_id=""):
+                         context="", provider="", model="", timeout=30.0, alert_id="",
+                         cancel=None):
             captured.append({
                 "operation": operation, "session_id": session_id, "goal": goal,
                 "context": context, "alert_id": alert_id, "timeout": timeout,
@@ -326,7 +327,8 @@ class TestControlRequestThreading:
         started = threading.Event()
 
         def fake_request(operation, session_id, text="", ports=None, *, goal="",
-                         context="", provider="", model="", timeout=30.0, alert_id=""):
+                         context="", provider="", model="", timeout=30.0, alert_id="",
+                         cancel=None):
             started.set()
             release.wait(5.0)
             return True, '{"ok": true, "phase": "replanned"}'
@@ -349,7 +351,8 @@ class TestControlRequestThreading:
         count = []
 
         def fake_request(operation, session_id, text="", ports=None, *, goal="",
-                         context="", provider="", model="", timeout=30.0, alert_id=""):
+                         context="", provider="", model="", timeout=30.0, alert_id="",
+                         cancel=None):
             count.append(operation)
             release.wait(5.0)
             return True, '{"ok": true, "phase": "cancelled"}'


### PR DESCRIPTION
## 问题

#91 合入后 main 的 windows CI 在 8% 处原生崩溃（`conftest.py:150` `_close_qt_top_level_widgets` 的 `app.processEvents()` 处 access violation），macOS 之前也在 92% 处 bus error。崩溃帧固定但触发点漂移，本地默认环境全绿，属于弱核调度下才暴露的竞态。

## 根因

`AgentLinkManager` 在 `parent=None`（测试桩 / 多窗代理）时，C++ 对象随 Python wrapper 被循环 GC 回收，而 **GC 可能在任意线程（含监视器 worker 线程）触发**。跨线程删除带 QTimer 子对象 / 信号连接的 QObject 是未定义行为，会静默腐化 Qt 事件队列，崩溃点随后在任意测试的 `processEvents` 漂移出现。

复现与定位证据：

- Python 3.11 + 双核亲和性（模拟 CI runner 弱核调度）下，`test_agent_link.py` + `test_agent_link_threads.py` + `test_alert_queue.py` 组合：合入后代码崩溃率 33-60%（15 轮崩 5-9 次），合入前基线（8421db9）20/20 全绿。
- 单独回退 `pet/agent_link.py` 到合入前：0/12 原生崩溃（其余文件保持新代码），锁定触发面。
- GC 高压对照（`gc.set_threshold(5)`）：新旧代码均零崩溃——GC 时序就是开关，与上述根因链吻合。

另外发现测试环境的一个既有盲区：没有运行中的事件循环时 `deleteLater + processEvents` 并不会真正销毁对象（DeferredDelete 不被投递），所以这类生命周期问题在 CI 上被放大。

## 修复

- `AgentLinkManager.shutdown()` 末尾把 parentless 的 manager **过继给 QCoreApplication**（与进程同寿、主线程销毁）：C++ 侧不再随 wrapper 的 GC 被删除，之后 wrapper 在何时何线程回收都只是空壳析构。真窗口场景由父链销毁在先，此路径不触发。
- 过继前停掉 manager 自带的全部单发定时器（完成确认 / 429 收起 / LLM 错误收起）：过继后对象存活到进程退出，不能让滞留定时器在无关时刻触发槽函数。
- 控制 worker 的 30s 桥接轮询改为**可取消**：`dsh_control.request` 新增 `cancel` 参数，`shutdown()` 置位 `_worker_cancel` 后 worker 立即退出，join 在既有 2s 预算内收编（此前控制 worker 必然超活过 manager）。
- 两个后台 worker 发射结果信号前检查 `_shutdown`，shutdown 后不再投递。

## 验证

- 复现组合（3 文件）双核亲和性 ×20：**零崩溃**（修复前 33-60%）。
- 全量套件：Python 3.11 双核亲和性 ×3 + 本机 3.13 ×1，全绿（1637 passed, 8 skipped，含新增 4 个回归测试）。
- `ruff check pet/ tests/` 通过。
- 新增回归测试 `TestManagerDeterministicTeardown`（4 个）：过继、定时器收口、幂等、控制 worker 取消及时性。
