### PR TITLE
fix: DLC/换角色场景加固——缺失动画守卫、启动回退默认角色、台词绑定支持外部素材目录

### DIFF
--- a/pet/agent_link.py
+++ b/pet/agent_link.py
@@ -33,7 +33,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
 
-from PySide6.QtCore import QObject, QTimer, Signal
+from PySide6.QtCore import QCoreApplication, QObject, QTimer, Signal
 from PySide6.QtWidgets import QMessageBox
 
 from .click_sound import play_sound, resolve_builtin_sound
@@ -1521,6 +1521,9 @@ class AgentLinkManager(QObject):
         self._shutdown = False
         self._respond_threads: set[threading.Thread] = set()
         self._respond_threads_lock = threading.Lock()
+        # 后台回写/控制 worker 的取消信号：shutdown 时置位，让 30s 阻塞轮询的
+        # 控制 worker 立刻退出，保证 join 在预算内完成、worker 不比 manager 活得久。
+        self._worker_cancel = threading.Event()
         _LIVE_AGENT_LINK_MANAGERS.add(self)
         self._install_token = 0
         self._install_pending: dict[str, int] = {}
@@ -1886,6 +1889,7 @@ class AgentLinkManager(QObject):
     def shutdown(self) -> None:
         """窗口销毁/角色切换时停止所有 monitor worker，且作废安装回调。"""
         self._shutdown = True
+        self._worker_cancel.set()
         self._install_pending.clear()
         self._install_token += 1
         for mon in self.monitors.values():
@@ -1907,6 +1911,29 @@ class AgentLinkManager(QObject):
                 break
             if worker is not threading.current_thread() and worker.is_alive():
                 worker.join(remaining)
+        # 停掉 manager 自带的全部单发定时器（完成确认/429 收起/LLM 错误收起）：
+        # 下方会把 Python 持有的 manager 过继给 QApplication，对象将存活到进程
+        # 退出——若不停表，滞留定时器会在后续无关时刻触发槽函数。
+        for timer_dict in (self._done_pending, self._429_timers, self._llm_error_timers):
+            for timer in timer_dict.values():
+                try:
+                    timer.stop()
+                except RuntimeError:
+                    pass
+            timer_dict.clear()
+        # parent=None（测试桩/多窗代理）时 C++ 对象是 Python 持有的：wrapper 经
+        # 信号连接/闭包成环，只能等循环 GC——而 GC 可能在任意线程（含 monitor
+        # worker 线程）触发，跨线程删除带 QTimer 子对象/信号连接的 QObject 会
+        # 腐化 Qt 事件队列（CI Windows 在 conftest processEvents access
+        # violation、macOS bus error 的根因）。过继给 QApplication（主线程、
+        # 与进程同寿）后，C++ 侧不再随 wrapper 的 GC 删除，wrapper 何时何线程
+        # 回收都只是空壳析构。真窗口场景由父链销毁在先，RuntimeError 兜底跳过。
+        try:
+            app = QCoreApplication.instance()
+            if self.parent() is None and app is not None and self.thread() is app.thread():
+                self.setParent(app)
+        except RuntimeError:
+            pass
 
     @classmethod
     def _shutdown_live_for_tests(cls) -> None:
@@ -2826,7 +2853,10 @@ class AgentLinkManager(QObject):
         except Exception as exc:  # noqa: BLE001 —— 后台线程绝不允许把异常带进 Qt 事件循环
             ok, detail = False, str(exc)
         try:
-            self._respond_result.emit(ok, detail)
+            # shutdown 后不再投递结果：结果气泡已无意义，且此时 manager 可能
+            # 已进入事件循环销毁流程。
+            if not self._shutdown:
+                self._respond_result.emit(ok, detail)
         except Exception:
             pass
         finally:
@@ -3230,12 +3260,15 @@ class AgentLinkManager(QObject):
                 context=self._exploration_control_context(payload),
                 timeout=self._EXPLORATION_CONTROL_TIMEOUT_S,
                 alert_id=self._exploration_control_alert_id(session_key),
+                cancel=self._worker_cancel,
             )
         except Exception as exc:  # noqa: BLE001 —— 后台线程不得把异常带进 Qt 事件循环
             ok, detail = False, f"control-request-error:{exc}"
         try:
-            self._exploration_control_result.emit(
-                session_key, operation, bool(ok), str(detail))
+            # shutdown 后不再投递结果（manager 可能已进入事件循环销毁流程）。
+            if not self._shutdown:
+                self._exploration_control_result.emit(
+                    session_key, operation, bool(ok), str(detail))
         except Exception:
             pass
         finally:

--- a/pet/app.py
+++ b/pet/app.py
@@ -1061,7 +1061,7 @@ class AppShell:
         self._dsh_state_tracker.start()
         character_id = str(self.config.get('character', catalog.DEFAULT_CHARACTER))
         logging.info('当前形象: %s', character_id)
-        self.instance._create_ui(character_id)
+        self._create_ui_with_character_fallback(character_id)
         # 批5.2a：进程级共享全屏 watcher 在主窗就绪后启动（自省任一窗是否需要，
         # 无需窗——环则空转）；flag 关时 _shared 为 None，no-op。
         if self._shared is not None:
@@ -1073,6 +1073,20 @@ class AppShell:
         self._sync_todo_service()
         QTimer.singleShot(3500, self.instance._check_autostart_wanted)
         QTimer.singleShot(4000, self._maybe_autostart_harness)
+
+    def _create_ui_with_character_fallback(self, character_id: str) -> None:
+        """启动路径创建主窗；配置记住的角色素材目录已被删/搬走（如 DLC 卸载）
+        时回退默认角色重试一次，而不是直接弹错退出。默认角色也缺素材则照常
+        抛出，由上层弹启动错误。"""
+        try:
+            self.instance._create_ui(character_id)
+        except FileNotFoundError:
+            if character_id == catalog.DEFAULT_CHARACTER:
+                raise
+            logging.warning('角色 %s 素材缺失，回退默认角色 %s', character_id, catalog.DEFAULT_CHARACTER)
+            character_id = catalog.DEFAULT_CHARACTER
+            self.config.set('character', character_id)
+            self.instance._create_ui(character_id)
 
     def _maybe_autostart_harness(self) -> None:
         """「随桌宠启动 dsh 服务」：主窗就绪后拉起 dsh web（只起服务，全程静默）。

--- a/pet/click_talk_dialog.py
+++ b/pet/click_talk_dialog.py
@@ -6,8 +6,6 @@
 """
 from __future__ import annotations
 
-from pathlib import Path
-
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QDialog,
@@ -23,11 +21,16 @@ from . import catalog
 
 
 def _discover_click_names(character_id: str) -> list[str]:
-    """从素材目录发现当前角色的点击动画名；目录缺失时回退 catalog 常量。"""
-    base = Path(__file__).resolve().parent.parent / "assets" / "characters"
-    click_dir = base / str(character_id) / "videos" / "click"
+    """从当前角色的有效素材目录发现点击动画名；目录缺失时回退 catalog 常量。
+
+    走 catalog.resolve_character_video_dir（外部 DLC 目录 > 内置 webm >
+    内置 gif），不读死内置路径；webm/gif 都识别。"""
+    click_dir = catalog.resolve_character_video_dir(str(character_id)) / "click"
     if click_dir.is_dir():
-        names = sorted(p.stem for p in click_dir.glob("*.webm"))
+        names = sorted(
+            {p.stem for p in click_dir.glob("*.webm")}
+            | {p.stem for p in click_dir.glob("*.gif")}
+        )
         if names:
             return names
     return list(catalog.CLICKS)

--- a/pet/dsh_control.py
+++ b/pet/dsh_control.py
@@ -51,7 +51,7 @@ def _log_event(base_dir: str, event: str, **fields) -> None:
 
 def request(operation: str, session_id: str, text: str = "", ports: list[int] | None = None,
             *, goal: str = "", context: str = "", provider: str = "", model: str = "",
-            timeout: float = TIMEOUT_S, alert_id: str = "") -> tuple[bool, str]:
+            timeout: float = TIMEOUT_S, alert_id: str = "", cancel=None) -> tuple[bool, str]:
     del ports  # retained for compatibility; bridge discovery is file based
     if not session_id or session_id.startswith("turn:"):
         return False, "missing-session-id"
@@ -88,6 +88,10 @@ def request(operation: str, session_id: str, text: str = "", ports: list[int] | 
     deadline = time.monotonic() + max(1.0, float(timeout))
     try:
         while time.monotonic() < deadline:
+            # 可取消等待：pet 侧 shutdown 时置位 cancel，30s 轮询立刻退出，
+            # 保证 worker 能在 shutdown 的 join 预算内结束。
+            if cancel is not None and cancel.is_set():
+                return False, "cancelled"
             try:
                 with open(response_path, "r", encoding="utf-8") as handle:
                     result = json.load(handle)
@@ -95,7 +99,11 @@ def request(operation: str, session_id: str, text: str = "", ports: list[int] | 
                     return True, json.dumps(result, ensure_ascii=False)
                 return False, str(result.get("error") or "bridge-control-rejected")
             except (FileNotFoundError, PermissionError, json.JSONDecodeError):
-                time.sleep(POLL_S)
+                if cancel is not None:
+                    if cancel.wait(POLL_S):
+                        return False, "cancelled"
+                else:
+                    time.sleep(POLL_S)
     finally:
         for path in (request_path, response_path):
             try:

--- a/pet/window.py
+++ b/pet/window.py
@@ -1583,6 +1583,12 @@ class PetWindow(QWidget, WindowFeatureGateMixin):
         filter_switch = getattr(self, '_effects_filter_switch', None)
         if callable(filter_switch):
             name = filter_switch(name)
+        if name not in self.lib.names():
+            # DLC/同路径换角色守卫：目标动画名不在当前素材库（写死名直传路径
+            # 的兜底，如余额档位/唱歌动画）。判失败返回，绝不让 lib.movie(name)
+            # 的 KeyError 崩进 GUI 线程；池化消费路径本就预过滤，不受影响。
+            logger.warning("动画 %r 不在当前角色素材库，跳过本次切换", name)
+            return False
         prev_anim = self.anim
         prev_movie = self.movie
         prev_click_hold = self._click_hold

--- a/tests/test_agent_link_threads.py
+++ b/tests/test_agent_link_threads.py
@@ -459,3 +459,68 @@ class TestOpenCodeDbRotation:
         db.close()
         mon._poll()
         assert "thinking" in received
+
+
+class TestManagerDeterministicTeardown:
+    """PR91 回归：Python 持有所有权（parent=None）的 manager 在 shutdown 后必须
+    脱离「GC 在任意线程回收 C++ 对象」的命运，且控制 worker 可被取消、不超活。
+
+    根因链：parent=None 时 C++ 对象随 wrapper 被循环 GC 回收，而 GC 可能在任意
+    线程（含 monitor worker 线程）触发——跨线程删除带 QTimer 子对象/信号连接的
+    QObject 会腐化 Qt 事件队列，崩溃点在后续测试的 processEvents 漂移
+    （CI Windows access violation / macOS bus error）。修复：shutdown 把
+    parentless 的 manager 过继给 QApplication（与进程同寿、主线程销毁），
+    停掉自带定时器，并以 _worker_cancel 取消 30s 阻塞轮询的控制 worker。"""
+
+    def test_shutdown_reparents_python_owned_manager_to_app(self, tmp_path, app):
+        """parent=None 的 manager：shutdown 后过继给 QApplication，C++ 不再随
+        wrapper 的 GC 被回收（何时何地回收都只是空壳析构）。"""
+        mgr = AgentLinkManager(None, Config(base=tmp_path))
+        assert mgr.parent() is None  # Python 持有所有权
+        mgr.shutdown()
+        assert mgr.parent() is QApplication.instance(), "shutdown 后应过继给 QApplication"
+        # 过继后 wrapper 被 GC 也只是空壳回收：C++ 侧由 app 持有，不受影响
+        import shiboken6
+        assert shiboken6.isValid(mgr)
+
+    def test_shutdown_stops_manager_timers(self, tmp_path, app):
+        """过继后 manager 存活到进程退出：自带单发定时器必须全部停掉，
+        否则滞留定时器会在后续无关时刻触发槽函数。"""
+        mgr = AgentLinkManager(None, Config(base=tmp_path))
+        mgr._schedule_done_check("dsh")
+        timer = mgr._done_pending.get("dsh")
+        assert timer is not None and timer.isActive()
+        mgr.shutdown()
+        assert not timer.isActive(), "shutdown 必须停掉完成确认定时器"
+        assert mgr._done_pending == {}
+
+    def test_shutdown_is_idempotent_after_reparent(self, tmp_path, app):
+        """重复 shutdown（conftest 收口会再次调用）：幂等，不报错。"""
+        mgr = AgentLinkManager(None, Config(base=tmp_path))
+        mgr.shutdown()
+        mgr.shutdown()
+        assert mgr.parent() is QApplication.instance()
+
+    def test_shutdown_cancels_control_worker_promptly(self, tmp_path, app, monkeypatch):
+        """控制 worker 的 30s 桥接轮询必须可被取消：shutdown 后 worker 立即退出，
+        不超活到 manager 销毁之后。"""
+        import pet.dsh_control as dsh_control_mod
+
+        # 桥接目录指到空临时目录：真实走 request 的轮询循环（无人应答），
+        # 不碰真实 %APPDATA% 桥接目录。
+        monkeypatch.setattr(dsh_control_mod, "_bridge_dir", lambda: str(tmp_path / "bridge"))
+        mgr = AgentLinkManager(None, Config(base=tmp_path))
+        payload = {"session_id": "sess-x", "goal": "", "reasons": [], "steps": []}
+        mgr._request_exploration_control("replan", "sess-x", payload)
+        with mgr._respond_threads_lock:
+            workers = list(mgr._respond_threads)
+        assert workers, "控制请求应已创建后台线程"
+        t0 = time.monotonic()
+        mgr.shutdown()
+        elapsed = time.monotonic() - t0
+        assert elapsed < 3.0, f"取消后 join 耗时 {elapsed:.2f}s（应远小于 30s 轮询超时）"
+        assert all(not w.is_alive() for w in workers), "shutdown 后控制 worker 必须已退出"
+        # request 的 finally 应清理请求/响应文件（取消路径同样清理）
+        bridge_dir = tmp_path / "bridge"
+        leftovers = list(bridge_dir.glob("watchdog-*.json")) if bridge_dir.exists() else []
+        assert leftovers == [], f"取消后残留桥接临时文件: {leftovers}"

--- a/tests/test_app_startup_fallback.py
+++ b/tests/test_app_startup_fallback.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""启动路径角色素材缺失回退的回归测试。
+
+配置记住的角色素材目录被删/搬走（如 DLC 卸载）时，启动不得直接弹错退出，
+应回退默认角色重试一次；默认角色也缺素材才报错。
+"""
+from __future__ import annotations
+
+import pytest
+
+from pet import catalog
+from pet.app import AppShell
+from pet.config import Config
+
+
+class _StubInstance:
+    """记录 _create_ui 调用序列，可按角色注入 FileNotFoundError。"""
+
+    def __init__(self, failing: set[str]):
+        self.failing = set(failing)
+        self.created: list[str] = []
+
+    def _create_ui(self, character_id: str) -> None:
+        self.created.append(character_id)
+        if character_id in self.failing:
+            raise FileNotFoundError(f"角色素材目录不存在: {character_id}")
+
+
+def _make_shell(tmp_path, character: str, failing: set[str]):
+    cfg = Config(base=tmp_path)
+    cfg.set("character", character)
+    shell = AppShell.__new__(AppShell)  # 绕开重型 __init__，只挂本方法用到的字段
+    shell.config = cfg
+    shell.instance = _StubInstance(failing)
+    return shell
+
+
+def test_missing_character_falls_back_to_default(tmp_path):
+    """DLC 角色素材缺失：回退默认角色并重试成功，配置同步纠正。"""
+    shell = _make_shell(tmp_path, "deleted-dlc-char", failing={"deleted-dlc-char"})
+    shell._create_ui_with_character_fallback("deleted-dlc-char")
+    assert shell.instance.created == ["deleted-dlc-char", catalog.DEFAULT_CHARACTER]
+    assert shell.config.get("character") == catalog.DEFAULT_CHARACTER
+
+
+def test_missing_default_character_raises(tmp_path):
+    """默认角色也缺素材：不再回退，原样抛出（由上层弹启动错误）。"""
+    shell = _make_shell(tmp_path, catalog.DEFAULT_CHARACTER, failing={catalog.DEFAULT_CHARACTER})
+    with pytest.raises(FileNotFoundError):
+        shell._create_ui_with_character_fallback(catalog.DEFAULT_CHARACTER)
+    assert shell.instance.created == [catalog.DEFAULT_CHARACTER]
+
+
+def test_other_errors_do_not_fallback(tmp_path):
+    """非素材缺失的异常不触发回退（不掩盖真实缺陷）。"""
+    shell = _make_shell(tmp_path, "any-char", failing=set())
+
+    def boom(character_id):
+        raise RuntimeError("别的启动缺陷")
+
+    shell.instance._create_ui = boom
+    with pytest.raises(RuntimeError):
+        shell._create_ui_with_character_fallback("any-char")

--- a/tests/test_click_talk_dialog.py
+++ b/tests/test_click_talk_dialog.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""点击动画台词绑定对话框的素材发现回归测试。
+
+_discover_click_names 必须走 catalog.resolve_character_video_dir（外部 DLC
+目录优先），并同时识别 webm/gif——不能只认内置目录（否则 DLC 角色在绑定
+对话框里看到的是别的角色的动画名，绑定写到不存在的键上静默失效）。
+"""
+from __future__ import annotations
+
+from pet import catalog
+from pet.click_talk_dialog import _discover_click_names
+
+
+def test_discovers_from_external_dlc_dir(tmp_path, monkeypatch):
+    """外部 DLC 角色：从外部目录读点击动画名，webm/gif 都识别。"""
+    click_dir = tmp_path / "mydlc" / "videos" / "click"
+    click_dir.mkdir(parents=True)
+    (click_dir / "点击-开心.webm").write_bytes(b"")
+    (click_dir / "点击-生气.gif").write_bytes(b"")
+    monkeypatch.setattr(catalog, "external_character_dirs", lambda: [tmp_path])
+    names = _discover_click_names("mydlc")
+    assert names == ["点击-开心", "点击-生气"]
+
+
+def test_missing_dir_falls_back_to_catalog_constant(tmp_path, monkeypatch):
+    """目录完全不存在时回退 catalog.CLICKS（保持旧兜底行为）。"""
+    monkeypatch.setattr(catalog, "external_character_dirs", lambda: [tmp_path])
+    names = _discover_click_names("no-such-character")
+    assert names == list(catalog.CLICKS)
+
+
+def test_builtin_character_discovers_real_names():
+    """内置角色（shenshen）：读到真实素材名而非过期常量——
+    守住「catalog.CLICKS 字面量与磁盘真实文件名已漂移」的回归。"""
+    names = _discover_click_names(catalog.DEFAULT_CHARACTER)
+    click_dir = catalog.resolve_character_video_dir(catalog.DEFAULT_CHARACTER) / "click"
+    expected = sorted(
+        {p.stem for p in click_dir.glob("*.webm")} | {p.stem for p in click_dir.glob("*.gif")}
+    )
+    assert names == expected
+    assert names, "内置角色必须有点击动画"

--- a/tests/test_music_sing_timer.py
+++ b/tests/test_music_sing_timer.py
@@ -42,6 +42,10 @@ class SingingLibrary(FakeLibrary):
         from tests.test_window_pause import FakeClip
         self._clips[SING_ANIM] = FakeClip()
 
+    def names(self):
+        # names() 必须与 _clips 一致：真实素材库收录了唱歌动画，names 就该报告它
+        return super().names() + [SING_ANIM]
+
 
 def test_music_sing_starts_immediately_when_visible(app, tmp_path, monkeypatch):
     """回归 issue #69-1：窗口可见且检测到音乐时应尽快进入唱歌，而不是等 4s 轮询。"""

--- a/tests/test_switch_start_failure_window.py
+++ b/tests/test_switch_start_failure_window.py
@@ -466,3 +466,29 @@ def test_link_idle_keeps_non_link_retry(app, tmp_path):
 
     win.close()
     app.processEvents()
+
+
+def test_switch_unknown_animation_name_is_refused_safely(app, tmp_path):
+    """DLC 守卫：目标动画名不在素材库时 _switch 判失败且不崩溃、不换动画。
+
+    换角色（同路径替换素材）后，写死名的直传路径（余额档位/唱歌等）可能
+    请求当前角色没有的动画；lib.movie(name) 的 KeyError 绝不能崩进 GUI 线程。
+    """
+    lib = FakeLibrary()
+    win = _make_win(tmp_path, lib)
+    assert win.anim == catalog.IDLE
+    assert win.movie._running is True
+
+    ok = win._switch("这个角色根本没有的动画")
+    assert ok is False
+    assert win.anim == catalog.IDLE, "缺失动画不得改变当前动画"
+    assert win.movie is lib.movie(catalog.IDLE)
+    assert win.movie._running is True
+
+    # 联动直传路径（余额档位动画入口）同样安全
+    win.request_link_anim("余额-钱袋满溢")
+    app.processEvents()
+    assert win.anim == catalog.IDLE
+
+    win.close()
+    app.processEvents()

--- a/tests/test_watchdog_control_wiring.py
+++ b/tests/test_watchdog_control_wiring.py
@@ -277,7 +277,8 @@ class TestControlRequestThreading:
         calls = threading.Event()
 
         def fake_request(operation, session_id, text="", ports=None, *, goal="",
-                         context="", provider="", model="", timeout=30.0, alert_id=""):
+                         context="", provider="", model="", timeout=30.0, alert_id="",
+                         cancel=None):
             captured.append({
                 "operation": operation, "session_id": session_id, "goal": goal,
                 "context": context, "alert_id": alert_id, "timeout": timeout,
@@ -326,7 +327,8 @@ class TestControlRequestThreading:
         started = threading.Event()
 
         def fake_request(operation, session_id, text="", ports=None, *, goal="",
-                         context="", provider="", model="", timeout=30.0, alert_id=""):
+                         context="", provider="", model="", timeout=30.0, alert_id="",
+                         cancel=None):
             started.set()
             release.wait(5.0)
             return True, '{"ok": true, "phase": "replanned"}'
@@ -349,7 +351,8 @@ class TestControlRequestThreading:
         count = []
 
         def fake_request(operation, session_id, text="", ports=None, *, goal="",
-                         context="", provider="", model="", timeout=30.0, alert_id=""):
+                         context="", provider="", model="", timeout=30.0, alert_id="",
+                         cancel=None):
             count.append(operation)
             release.wait(5.0)
             return True, '{"ok": true, "phase": "cancelled"}'


### PR DESCRIPTION
## 背景

为后续 DLC/同路径替换素材换角色做准备，先清掉「新角色素材不全时会直接崩」的硬点。审计发现池化消费路径（联动轮换、焦急/失败挑选、吃文件）全部有存在性过滤、缺失时安全降级；真正危险的是两条绕过池子直传写死动画名的路径，外加两处 DLC 体验问题。

## 修复内容

1. **`PetWindow._switch` 中央存在性守卫**：目标动画名不在当前素材库（`lib.names()`）时判失败返回，不再让 `lib.movie(name)` 的 KeyError 崩进 GUI 线程。一次性守住两条直传路径：
   - 余额档位动画（`balance.py` 的六个 `余额-*` 名，shenshen 专属素材，新角色大概率没有）；
   - 音乐唱歌动画（`SING_ANIM='悠闲哼歌'`，`window_alerts.check_music_sing` 每秒轮询直传）。
   池化消费路径本就预过滤存在性，行为不变。
2. **启动路径回退**：配置记住的角色素材目录缺失（如 DLC 卸载）时，回退默认角色重试一次，不再直接弹错退出；默认角色也缺则照常报错。
3. **点击台词绑定对话框**：`_discover_click_names` 改走 `catalog.resolve_character_video_dir`（外部 DLC 目录优先），并同时识别 webm/gif——不再只读内置目录、不再回退到与磁盘真实文件名已漂移的 `catalog.CLICKS` 旧常量。

## 测试

- 新增 7 个回归测试：`_switch` 缺失动画守卫（含联动直传入口）、启动回退（回退成功/默认也缺则抛出/非缺失异常不回退）、点击名发现（外部 DLC 目录、gif 识别、回退路径、内置角色读真实名）。
- `test_music_sing_timer` 的 `SingingLibrary` 测试桩补齐 `names()` 与 `_clips` 一致性（真实素材库收录的动画 `names()` 必须报告；这是新守卫要求的测试桩真实性修复）。
- 全量套件：Python 3.11 全绿（1640 passed, 8 skipped）；ruff 通过。

## 依赖说明

本分支叠在 #93 之上（含其修复 commit）：#93 修复的 teardown 竞态在本分支新增测试的 GC 布局偏移下会于 3.13 全量套件本地复现崩溃，叠上后全绿。#93 合并后本 PR 的 diff 自动只剩 DLC 部分。
