### PR TITLE
fix: 气泡行尾字被 label 右边界切掉——label 宽度改用真正绘制的行计算

### DIFF
--- a/pet/speech_bubble.py
+++ b/pet/speech_bubble.py
@@ -40,11 +40,15 @@ from PySide6.QtWidgets import (
 
 # 批6-2 拆分后纯函数区 re-export（维持既有 import 兼容；外部调用点本批不改）
 from .speech_bubble_text import (
+    BUBBLE_TEXT_COLUMN,
+    BUBBLE_TEXT_SLACK,
     SELF_TALK_IMAGE_SUFFIXES,
     breath_bubble_size_for_anchor,
     breath_bubble_size_for_scale,
+    bubble_label_size,
     bubble_max_lines,
     bubble_rect_for_anchor,
+    bubble_wrap_width,
     elide_bubble_text,
     list_self_talk_images,
     normalize_bubble_text,
@@ -52,12 +56,16 @@ from .speech_bubble_text import (
 )
 
 __all__ = [
+    "BUBBLE_TEXT_COLUMN",
+    "BUBBLE_TEXT_SLACK",
     "SELF_TALK_IMAGE_SUFFIXES",
     "BUBBLE_STYLE_PRESETS",
     "breath_bubble_size_for_anchor",
     "breath_bubble_size_for_scale",
+    "bubble_label_size",
     "bubble_max_lines",
     "bubble_rect_for_anchor",
+    "bubble_wrap_width",
     "elide_bubble_text",
     "list_self_talk_images",
     "normalize_bubble_text",
@@ -402,6 +410,7 @@ class PetSpeechBubble(QFrame):
         else:
             self.label.show()
             self.label.setPixmap(QPixmap())
+            self.label.ensurePolished()
             self.label.setText(elide_bubble_text(
                 QFontMetrics(self.label.font()),
                 self._raw_text,
@@ -525,6 +534,10 @@ class PetSpeechBubble(QFrame):
             self._subtitle_label.setText("")
             self._subtitle_label.hide()
         self.label.show()
+        # 量文本前必须先让 label 落到最终字体上：样式表里的 font-size 只在
+        # polish 时写进 label.font()，若此时量到的还是旧字体，换行与绘制就
+        # 用了两套度量（行尾字会被 label 右边界切掉）。这里显式 polish 兜底。
+        self.label.ensurePolished()
         metrics = QFontMetrics(self.label.font())
         if interactive:
             # 交互气泡：不自动消失 + 显示按钮 + 临时关闭鼠标穿透
@@ -539,7 +552,7 @@ class PetSpeechBubble(QFrame):
             # 长文本分页：每页不超过 bubble_max_lines 行，自动翻页直到全文展示完，
             # 底部显示「1/3」页码指示。总时长按页数扩展，保证每页可读完。
             pages = paginate_bubble_text(
-                metrics, text, 248, bubble_max_lines(text)
+                metrics, text, bubble_wrap_width(), bubble_max_lines(text)
             )
             display_text = pages[0] if pages else ""
             if len(pages) > 1 and not sticky and not interactive:
@@ -556,20 +569,9 @@ class PetSpeechBubble(QFrame):
                 self._reset_paging()
             self.label.setPixmap(QPixmap())
             self.label.setText(display_text)
-            # 固定尺寸必须按所有页的最大测量值计算：后续页可能出现更宽的行，
-            # 若只按第一页设置，翻页后 wordWrap=False 会把后续页文本裁掉。
-            max_width = 0
-            max_height = 0
-            for page in pages:
-                page_bounds = metrics.boundingRect(
-                    QRect(0, 0, 248, 600), Qt.TextFlag.TextWordWrap, page
-                )
-                max_width = max(max_width, page_bounds.width())
-                max_height = max(max_height, page_bounds.height())
-            self.label.setFixedSize(
-                max(96, min(248, max_width + 3)),
-                max(20, max_height + 2),
-            )
+            # 固定尺寸按真正会绘制的行计算（所有页里最长的一行 + 行数最多的一页），
+            # 翻页后 wordWrap=False 也不会裁字；详见 bubble_label_size 的说明。
+            self.label.setFixedSize(bubble_label_size(metrics, pages))
         self.adjustSize()
         self._place(anchor_rect)
         self.show()

--- a/pet/speech_bubble_text.py
+++ b/pet/speech_bubble_text.py
@@ -23,6 +23,17 @@ SELF_TALK_IMAGE_SUFFIXES = {
     ".png", ".jpg", ".jpeg", ".webp", ".bmp", ".gif", ".tif", ".tiff",
 }
 
+# 气泡文本列的最大像素宽（气泡整体宽度上限的由来），以及 label 矩形相对
+# 最长行的余量。换行预算必须是 ``列宽 - 余量``：整型 horizontalAdvance 累加
+# 与绘制时的自然（分数）宽度有亚像素差，余量同时吸收这个差，行尾才不会切字。
+BUBBLE_TEXT_COLUMN = 248
+BUBBLE_TEXT_SLACK = 4
+
+
+def bubble_wrap_width(column: int = BUBBLE_TEXT_COLUMN, slack: int = BUBBLE_TEXT_SLACK) -> int:
+    """Text wrapping budget: always leaves ``slack`` px inside the column."""
+    return max(1, int(column) - int(slack))
+
 
 def breath_bubble_size_for_anchor(anchor_rect: QRect) -> QSize:
     """Scale the decorative water bubble with the pet's visible silhouette.
@@ -100,6 +111,34 @@ def elide_bubble_text(
     if current:
         lines.append(current)
     return "\n".join(lines[:max_lines])
+
+
+def bubble_label_size(
+    metrics: QFontMetrics,
+    pages: list[str],
+    column: int = BUBBLE_TEXT_COLUMN,
+    slack: int = BUBBLE_TEXT_SLACK,
+    min_width: int = 96,
+    min_height: int = 20,
+) -> QSize:
+    """Return the label rect that holds **every line that will be painted**.
+
+    必须用与换行相同的度量、并直接量真正的行宽，不能再用
+    ``QFontMetrics.boundingRect(..., TextWordWrap)`` 二次排版来推宽度：
+    那次排版按自然（分数）宽度断行，而 ``paginate_bubble_text`` 按整型
+    ``horizontalAdvance`` 累加，两者可以差一个字；label 一旦比真实行窄，
+    QLabel（wordWrap=False）就会把行尾那个字切在边界上，看起来像被气泡挡掉。
+
+    宽度按所有页里最长的一行 + ``slack`` 计算（页间切换不再改 label 尺寸）；
+    高度按行数 × ``lineSpacing`` 计算（所有页里行数最多的一页决定）。
+    """
+    lines = [line for page in pages for line in page.split("\n")] or [""]
+    widest = max(metrics.horizontalAdvance(line) for line in lines)
+    line_count = max((len(page.split("\n")) for page in pages), default=1)
+    return QSize(
+        max(min_width, min(column, widest + slack)),
+        max(min_height, line_count * metrics.lineSpacing() + 2),
+    )
 
 
 def paginate_bubble_text(

--- a/tests/test_speech_bubble.py
+++ b/tests/test_speech_bubble.py
@@ -8,8 +8,11 @@ from PySide6.QtGui import QFont, QFontMetrics
 from PySide6.QtWidgets import QApplication
 
 from pet.speech_bubble import (
+    BUBBLE_TEXT_COLUMN,
+    BUBBLE_TEXT_SLACK,
     FlowLayout,
     PetSpeechBubble,
+    bubble_label_size,
     bubble_max_lines,
     elide_bubble_text,
     normalize_bubble_text,
@@ -186,6 +189,120 @@ def test_sticky_bubble_dismiss_emits_hidden_signal():
     bubble.show_text("审批", QRect(0, 0, 120, 120), 3200, sticky=True)
     bubble.dismiss()
     assert len(hidden_log) == 1
+
+
+# ============================================================================
+# 文本行必须完整落在 label 矩形内（行尾字被气泡切掉的回归）
+# ============================================================================
+
+# 用户截图里的原句（鲸鱼娘女仆模式的 start 台词）及其带空格变体：
+# 换行按整型 horizontalAdvance 累加，而 label 宽度过去是用
+# QFontMetrics.boundingRect(..., TextWordWrap) 二次排版量的，两者可以差一个字，
+# label 比真实行窄时 QLabel（wordWrap=False）就把行尾那个字切在边界上。
+CLIPPING_TEXTS = [
+    "主人～DSH开始干活啦，人家会帮您盯着它的～",
+    "主人～ DSH 开始干活啦，人家会帮您盯着它的～",
+    "主人～DSH开始干活啦，人家会帮您盯 着它的～",
+    "主人～DSH开始干活啦，人家会帮您盯着它 的～",
+    "主人，DSH 正在读取 dsh-pet-indesktop/pet/speech_bubble.py，人家也帮您瞄两眼～",
+]
+
+
+def _rendered_metrics(bubble):
+    bubble.label.ensurePolished()
+    return QFontMetrics(bubble.label.font())
+
+
+def _overflow_lines(bubble, lines) -> list[tuple[str, int, int]]:
+    """返回 (行文本, 行宽度, label 宽度) 中放不进 label 的行。"""
+    metrics = _rendered_metrics(bubble)
+    width = bubble.label.width()
+    return [
+        (line, metrics.horizontalAdvance(line), width)
+        for line in lines
+        if metrics.horizontalAdvance(line) > width
+    ]
+
+
+def test_displayed_lines_fit_label_rect():
+    """回归：真正绘制的每一行都必须放得进 label 矩形。
+
+    过去 label 宽度由 boundingRect(TextWordWrap) 决定，而显示的是
+    paginate_bubble_text 按整型 advance 逐字折出来的行；两套折行差一个字时，
+    行尾最后一个字被 label 右边界切掉半个（截图里 '盯着它' 的 '它' 只剩一条边，
+    下一行从 '的～' 开始）。
+    """
+    _get_app()
+    for text in CLIPPING_TEXTS:
+        bubble = PetSpeechBubble(style_id="classic_top")
+        bubble.show_text(text, QRect(0, 0, 120, 120), 3200, sticky=True)
+        assert bubble.label.wordWrap() is False
+        assert _overflow_lines(bubble, bubble.label.text().split("\n")) == [], text
+        bubble.dismiss()
+
+
+def test_every_page_line_fits_label_width():
+    """分页文本的每一页、每一行都必须放得进 label 矩形（宽度按所有页定死）。"""
+    _get_app()
+    bubble = PetSpeechBubble(style_id="classic_top")
+    # 长度取得足够大：任何平台的字体都会超过单页 6 行上限（不赌字体度量），
+    # 保证这条用例在 Windows/Linux/macOS CI 上都真的走到分页分支。
+    text = "主人～DSH开始干活啦，人家会帮您盯着它的～" * 20
+    bubble.show_text(text, QRect(0, 0, 120, 120), 40000)
+    assert bubble._pages, f"长文本应进入分页展示（{len(text)} 字）"
+    assert len(bubble._pages) > 1
+
+    for page in bubble._pages:
+        assert _overflow_lines(bubble, page.split("\n")) == [], page
+
+
+def test_bubble_label_stays_inside_painted_surface():
+    """文本 label 必须落在气泡绘制区内（右侧留白足够，字不会被边框压住）。"""
+    _get_app()
+    bubble = PetSpeechBubble(style_id="classic_top")
+    bubble.show_text(
+        "主人～DSH开始干活啦，人家会帮您盯着它的～",
+        QRect(0, 0, 120, 120),
+        3200,
+        sticky=True,
+    )
+    surface = bubble._surface_rect
+    assert bubble.label.geometry().left() >= surface.left()
+    assert bubble.label.geometry().right() <= surface.right()
+    assert bubble.label.geometry().top() >= surface.top()
+    assert bubble.label.geometry().bottom() <= surface.bottom()
+
+
+def test_bubble_label_size_measures_painted_lines():
+    """bubble_label_size 的宽度取“最长的那一行”，高度取“行数最多的一页”。
+
+    用假的 metrics 固定度量，避免依赖平台字体：宽度必须是行宽 + 余量（而不是
+    二次排版的结果），高度按所有页里最多行数算，翻页时 label 不会变。
+    """
+    class _StubMetrics:
+        def __init__(self, per_char: int, spacing: int):
+            self.per_char = per_char
+            self.spacing = spacing
+
+        def horizontalAdvance(self, text: str) -> int:
+            return self.per_char * len(text)
+
+        def lineSpacing(self) -> int:
+            return self.spacing
+
+    metrics = _StubMetrics(per_char=40, spacing=16)
+    size = bubble_label_size(metrics, ["一二三\n四五", "六七"])
+    assert size.width() == 3 * 40 + BUBBLE_TEXT_SLACK
+    assert size.height() == 2 * 16 + 2
+
+    # 宽度不超过内容列上限
+    wide = bubble_label_size(_StubMetrics(per_char=20, spacing=16), ["一" * 30])
+    assert wide.width() <= BUBBLE_TEXT_COLUMN
+
+    # 短文本仍受最小尺寸约束
+    tiny = bubble_label_size(metrics, [])
+    assert tiny.width() == 96
+    assert tiny.height() == 20
 
 
 # ============================================================================


### PR DESCRIPTION
## 现象

鲸鱼娘女仆模式下，联动 agent 的长台词偶发「一行里有一个字被气泡遮住」：截图第一行行尾只剩一条字边，第二行从 的～ 开始。

## 根因

文本折行与 label 宽度用了两套互不相干的度量：折行由 `paginate_bubble_text` 按整型 `horizontalAdvance` 逐字累加（预算 248px）；label 宽度由 `QFontMetrics.boundingRect(..., TextWordWrap)` 二次排版推算，而这次排版按自然（分数）宽度断行——两者可以差一个字。

label 比真实绘制的行窄时，QLabel（`wordWrap=False`）把行尾那个字切在边界上；切点距气泡右边框还有 13px 布局边距 + 4px 绘制内缩，所以看起来像被气泡挡掉。

Windows/YaHei 实测 `主人～DSH开始干活啦，人家会帮您盯着它的～`：折行 248px vs label 239px，被切的正是 `它`，下一行从 `的～` 开始。女仆模式 111 条台词里 30 条（27%）命中——这就是「有时候」。

## 修复

- `pet/speech_bubble_text.py`：新增纯函数 `bubble_label_size`（宽度 = 所有页最长行 + slack，高度 = 最多行数 × lineSpacing），不再做第二次排版；新增 `bubble_wrap_width`（折行预算 = 列宽 − slack，余量吸收整型与自然宽度的亚像素差）。
- `pet/speech_bubble.py`：`show_text` 改用它算 label 尺寸，并在量文本前 `ensurePolished()`，保证换行度量与实际绘制字体同一个；breath 气泡 elide 路径同样加 polish 兜底。

气泡最大宽度不变（label ≤ 248 → 气泡 ≤ 274），贴近边界时提早一个字换行。

## 验证

- 先红后绿：修复前 offscreen `label=237 line=247`、Windows `label=239 line=248` 溢出；修复后 16 项全绿。
- 新增 4 项回归测试（绘制行放得进 label、分页每页每行、label 落在绘制区内、`bubble_label_size` 纯函数）。
- 女仆模式全量台词 218 行溢出 0（修复前 30/111 条有切字）；emoji、分页长文本、三种 pet_scale 的 breath 气泡均无裁字；真实 Windows 字体渲染成图确认。
- 本地门禁：ruff 通过；全量 `pytest -q` → 1712 passed, 8 skipped。
