### PR TITLE
fix: 开机即按配置装配可选服务——Agent 联动不再等展开菜单/开关设置才启动

### DIFF
--- a/docs/CHANGELOG-DEV-SINCE-v4.1.0-2026-09-09.md
+++ b/docs/CHANGELOG-DEV-SINCE-v4.1.0-2026-09-09.md
@@ -155,6 +155,7 @@
 14. **显示/缩放**：跨 DPI 屏/系统缩放变化画面不重建（Qt 信号驱动重建）；squash 期间命中 mask 重建限频（收势帧强制同步）；素材原地替换后旧帧残留。
 15. **全屏隐藏误判**：工具窗口/输入法候选框不再视为全屏；截图覆盖层进程级排除。
 16. 其它健壮性（三方盲审批次 17 项等）：畸形碰撞消息不抛异常、更新检查线程收口+重入防护、`>7 天 pet-*.log` 启动清理、SSE 空心跳行跳过、设置 Esc 关闭也落盘、图标解码 30s 超时逃生、菜单树释放 3s 总上限、`shiboken6.isValid` 守卫消 RuntimeWarning 等。
+17. **Agent 联动/主动识屏开机不生效**：`PetWindow.__init__` 收尾只调了 `_install_effect_services()`，没有走 `sync_optional_services()`——config.json 里已开启的 Agent 联动（DSH/Claude/Cursor/OpenCode 与 `custom_agents` 通道）和主动识屏要等用户展开「Agent 联动」菜单或开关一次设置对话框才真正启动（日志里看不到「Agent 监视器 [...] 已启动」）。修复：末尾等价替换为 `sync_optional_services()`（其内部以 `_install_effect_services` 收尾，净增 0 行，window.py 行数预算不变），开机即按配置装配。**行为变化**：已开启主动识屏的用户重启后不再需要打开一次设置对话框，识屏按配置直接生效（隐私红线不变：仍受 `proactive_screen.enabled` 与白名单/上限/冷却约束）。回归断言：`tests/test_feature_gating.py::test_petwindow_startup_applies_configured_optional_services`。
 
 ---
 

--- a/pet/window.py
+++ b/pet/window.py
@@ -747,7 +747,7 @@ class PetWindow(QWidget, WindowFeatureGateMixin):
             self._arm_screen_restore_retry()
 
         self.attach_collision_session(collision_session)
-        self._install_effect_services()
+        self.sync_optional_services()  # 开机即按配置装配可选服务（含效果控制器）
 
     @property
     def click_sound_enabled(self) -> bool:

--- a/tests/test_feature_gating.py
+++ b/tests/test_feature_gating.py
@@ -98,6 +98,28 @@ def test_petwindow_lazy_ensure_creates_optional_services(tmp_path):
         app.processEvents()
 
 
+def test_petwindow_startup_applies_configured_optional_services(tmp_path):
+    """开机即按配置装配可选服务（不触碰任何菜单/设置对话框）。
+
+    回归：监视器实例由 AgentLinkManager.__init__ 装配，但真正启动靠
+    apply_config()；构造末尾若只调 _install_effect_services()，配置里
+    已开启的 Agent 联动（含 custom_agents 通道）与主动识屏要等用户展开
+    「Agent 联动」菜单或开关一次设置对话框才会启动。
+    """
+    from tests.test_collision_window import FakeLibrary
+
+    app = _qapp()
+    cfg = _disabled_config(tmp_path)
+    cfg.set("agent_link", {"opencode": True})
+    win = PetWindow(FakeLibrary(), cfg)
+    try:
+        assert win.agent_link_manager is not None
+        assert win.agent_link_manager.monitors["opencode"]._running
+    finally:
+        win.close()
+        app.processEvents()
+
+
 def test_petwindow_proactive_toggle_creates_watcher(tmp_path, monkeypatch):
     from tests.test_collision_window import FakeLibrary
 


### PR DESCRIPTION
根因：Agent 监视器实例由 AgentLinkManager.__init__ 装配，但真正启动靠 apply_config()；全工程此前只有两条路径会创建管理器并调用它——右键菜单
勾选项被 QAction.setChecked()（菜单被构建/展开）与设置对话框关闭后的
refresh_pet_settings()。PetWindow.__init__ 收尾只调 _install_effect_services()， config.json 已开启的 Agent 联动（DSH/Claude/Cursor/OpenCode 与 custom_agents 通道）与主动识屏开机不生效，要等用户展开「Agent 联动」菜单或开关一次
设置对话框才启动（日志里看不到「Agent 监视器 [xxx] 已启动」）。

修复：把 __init__ 收尾的 _install_effect_services() 等价替换为 sync_optional_services()（其内部以 _install_effect_services 收尾）， 净增 0 行，window.py 行数预算不变。顺带修掉同类问题：主动识屏与
_edge_probe 也按配置开机装配；已开启主动识屏的用户重启后不再需要打开
一次设置对话框（隐私红线不变：仍受 proactive_screen.enabled 与
白名单/上限/冷却约束）。

回归断言：tests/test_feature_gating.py::test_petwindow_startup_applies_ configured_optional_services（构建窗口后不触碰任何菜单/设置，断言
agent_link_manager 非空且 monitors['opencode']._running）。