### PR TITLE
fix: 边缘探头会话期间禁止移动位移——防止挂着探头姿态被平移出屏幕边缘

### DIFF
--- a/pet/edge_probe.py
+++ b/pet/edge_probe.py
@@ -3,7 +3,9 @@
 
 状态机由 PetWindow 侧控制器持有，随窗口生命周期存在。隐藏时 pause() 冻结
 当前状态与倒计时，恢复后 resume() 从原进度继续。探头会话期间只允许待机/
-转向动画，由 WindowFeatureGateMixin._effects_on_switch 在窗口 _switch 入口过滤。
+转向动画，由 WindowFeatureGateMixin._effects_filter_switch 在窗口 _switch
+入口过滤；位移（自动/手动移动）由 PetWindow._try_move 入口的
+_effects_probe_active 闸门整体拦截，防止挂着探头姿态被平移出屏幕边缘。
 """
 from __future__ import annotations
 

--- a/pet/window.py
+++ b/pet/window.py
@@ -2608,12 +2608,19 @@ class PetWindow(QWidget, WindowFeatureGateMixin):
         """计划一次朝 facing 方向的移动；返回 False 表示未建立移动计划。
 
         name 给定时使用指定动画（手动触发），否则随机选一个移动姿态。
-        返回 False 的两种情况：屏幕空间不够（目标动画未尝试）；或移动动画
-        start() 被拒——此时 _switch 已回退到可播放动画并安排重试，移动计划
-        绝不建立（B7 审查 P1-1 / 复审 R2）。
+        边缘探头会话激活时直接返回 False（不建立位移计划，防止挂着探头
+        姿态被平移出屏幕边缘）。返回 False 的两种情况：屏幕空间不够（目标
+        动画未尝试）；或移动动画 start() 被拒——此时 _switch 已回退到可播放
+        动画并安排重试，移动计划绝不建立（B7 审查 P1-1 / 复审 R2）。
         """
         if (self._physics_mode is not None
                 or self._interaction_state in (THROWN, DRAGGING)):
+            return False
+        # 边缘探头会话期间禁止位移：移动动画虽会被效果闸门降级为待机/转向
+        # （_effects_filter_switch），但移动计划一旦建立就会把窗口从屏幕
+        # 边缘平移出去——挂着探头姿态滑走。这里整体拦住自动/手动移动。
+        probe_active = getattr(self, '_effects_probe_active', None)
+        if callable(probe_active) and probe_active():
             return False
         if self._move_plan is not None:
             return True  # 已在移动/已计划

--- a/tests/test_effects_integration.py
+++ b/tests/test_effects_integration.py
@@ -2,6 +2,7 @@
 """黄金回旋/边缘探头在右键菜单与设置页中的集成测试。"""
 from __future__ import annotations
 
+from PySide6.QtCore import QRect
 from PySide6.QtGui import QPixmap
 from PySide6.QtWidgets import QApplication, QMenu
 
@@ -222,6 +223,59 @@ def test_real_window_direct_golden_spin_on_click_accumulates(tmp_path):
         # 真实 paint/mask 路径带旋转调用不应抛错（角度是否已推进取决于定时器调度）。
         win.grab()
         spin.cancel()
+    finally:
+        win.close()
+        app.processEvents()
+
+
+def test_real_window_move_blocked_during_edge_probe(tmp_path, monkeypatch):
+    """回归：边缘探头会话期间自动/手动移动都不得建立位移计划。
+
+    之前 _try_move 不检查探头状态：掷骰掷中移动（或右键菜单手动触发）时，
+    移动动画被 _effects_filter_switch 降级为待机且 _switch 返回 True，于是
+    移动计划照常建立，窗口挂着探头姿态被平移出屏幕边缘。
+    """
+    from tests.test_collision_window import FakeLibrary
+
+    from pet.edge_probe import OFF, PEEKING
+    from pet.window import PetWindow
+
+    class _Scr:
+        def availableGeometry(self):
+            return QRect(0, 0, 1920, 1080)
+
+        def devicePixelRatio(self):
+            return 1.0
+
+    app = _qapp()
+    cfg = Config(tmp_path)
+    cfg.set("auto_hide_fullscreen", False)
+    cfg.set("collision_enabled", False)
+    cfg.set("edge_probe_enabled", True)
+    win = PetWindow(FakeLibrary(), cfg)
+    try:
+        assert win.moves, "FakeLibrary 应提供移动动画"
+        monkeypatch.setattr(win, "_screen_available", lambda: _Scr())
+        win.facing = "right"
+        win.move(400, 300)
+        win._edge_probe._mode = PEEKING  # 探头稳态（直接置位，跳过进入过渡）
+
+        # 自动掷骰路径：必须直接拒绝，不建位移计划。
+        assert win._try_move() is False
+        assert win._move_plan is None
+        assert not win._move_timer.isActive()
+        # 手动触发（右键菜单“移动”）同样不得位移。
+        win._trigger_move(win.moves[0])
+        assert win._move_plan is None
+        assert not win._move_timer.isActive()
+
+        # 退出探头会话后移动恢复可用（正向对照，证明上面是闸门拦的，
+        # 而非环境本身放不下）。
+        win._edge_probe._mode = OFF
+        win._edge_probe._side = None
+        assert win._try_move() is True
+        assert win._move_plan is not None
+        win._cancel_move()
     finally:
         win.close()
         app.processEvents()


### PR DESCRIPTION
## 问题

用户反馈：桌宠挂在屏幕边缘（边缘探头）时，动画链掷骰掷中移动（每轮 20% 概率）或右键菜单手动触发移动，窗口会保持 45° 探头姿态平移滑出屏幕边缘，且不会自己回去。

触发条件与朝向有关（实测补充）：移动方向取 facing，挂在左边缘且 facing=left（脸朝外）时目标点在屏幕外，被边界检查拦死、看起来"没有反应"；facing 朝内时边界放行，才会平移滑走。探头会话期间转向动画不翻转朝向（`_effects_skip_turn_facing`），朝向取决于进入会话前的状态，约一半概率命中。

## 根因

探头会话只在**动画层**做了约束：`_effects_filter_switch` 把非待机/转向的动画请求降级为随机待机。但位移是**另一路**：

1. `_play_roll` 掷中移动 → `_try_move` → `_switch(移动动画)`；
2. 移动动画被闸门降级为待机，**播放成功、返回 True**；
3. facing 朝内、边界检查通过时，`_try_move` 据此照常建立 `_move_plan` 并启动位置插值定时器（33ms）；
4. PEEKING 稳态下 probe 自身的定时器是停的（稳态不需要 timer），没有任何代码把位置拉回——窗口就这样挂着探头姿态滑走。

手动触发（右键菜单"移动" → `_trigger_move` → 同一个 `_try_move`）在朝内时表现相同。

## 修复

`_try_move` 入口检查 `_effects_probe_active()`：探头会话激活时直接返回 False（在边界检查之前，两种朝向一并拦截），自动掷骰与手动触发共用此路。会话结束后（拖走/关闭探头）移动自动恢复，无需额外开关。

顺手修正 `edge_probe.py` 模块注释中不存在的方法引用（`_effects_on_switch` → `_effects_filter_switch`）并补充位移拦截说明。

## 测试

- `tests/test_effects_integration.py` 新增回归用例：真实 PetWindow 置于 PEEKING 稳态，自动（`_try_move`）与手动（`_trigger_move`）路径均断言不建立位移计划、位移定时器未启动；退出探头会话后 `_try_move` 恢复可用（正向对照，排除环境干扰）。
- 本地全量 1708 passed / 8 skipped（另有 1 个拖拽合并定时器用例断言 8ms 间隔，在本机 ~165Hz 高刷屏下算出 6ms 而失败，属环境相关的既有问题，CI 60Hz 环境不受影响）。