### PR TITLE
fix: 启动即同步可选服务——修复重启后 Agent 联动须手动展开菜单才生效 (#99)

### DIFF
--- a/pet/window.py
+++ b/pet/window.py
@@ -747,7 +747,12 @@ class PetWindow(QWidget, WindowFeatureGateMixin):
             self._arm_screen_restore_retry()
 
         self.attach_collision_session(collision_session)
-        self._install_effect_services()
+        # 启动即按配置装配/同步可选服务（主动识屏、Agent 联动、效果控制器）。
+        # 不能只调 _install_effect_services()：AgentLinkManager 是懒创建的，
+        # 监视器真正启动靠 apply_config()，此前启动路径无人调用，导致重启后
+        # 已开启的 Agent 联动必须手工展开一次菜单/开关设置对话框才生效（#99）。
+        # sync_optional_services() 自身以 _install_effect_services() 收尾。
+        self.sync_optional_services()
 
     @property
     def click_sound_enabled(self) -> bool:

--- a/tests/test_feature_gating.py
+++ b/tests/test_feature_gating.py
@@ -98,6 +98,29 @@ def test_petwindow_lazy_ensure_creates_optional_services(tmp_path):
         app.processEvents()
 
 
+def test_petwindow_agent_link_enabled_at_startup_constructs_manager(tmp_path):
+    """回归（#99）：agent_link 已开启时，启动路径必须创建 AgentLinkManager。
+
+    此前 __init__ 收尾只调 _install_effect_services()，没人调
+    sync_optional_services()/apply_config()——重启后已开启的 Agent 联动
+    必须手工展开一次联动菜单或开关一次设置对话框才生效。
+    """
+    from tests.test_collision_window import FakeLibrary
+
+    app = _qapp()
+    cfg = _disabled_config(tmp_path)
+    cfg.set("agent_link", {"dsh": True})
+    win = PetWindow(FakeLibrary(), cfg)
+    try:
+        assert win.agent_link_manager is not None
+    finally:
+        mgr = win.agent_link_manager
+        if mgr is not None:
+            mgr.shutdown()
+        win.close()
+        app.processEvents()
+
+
 def test_petwindow_proactive_toggle_creates_watcher(tmp_path, monkeypatch):
     from tests.test_collision_window import FakeLibrary
 


### PR DESCRIPTION
Closes #99

## 问题

`config.json` 已开启 `agent_link.dsh/claude/cursor/opencode`（或 `custom_agents`）时，重启桌宠后联动完全不工作（不切动作、不冒气泡），日志没有 `Agent 监视器 [...] 已启动`；必须手工展开一次「Agent 联动」子菜单或开关一次设置对话框才恢复。四个内置 Agent 与 custom_agents 全受影响。

## 根因

`AgentLinkManager` 是懒创建的，监视器真正启动靠 `apply_config()`。全工程唯一调用 `sync_optional_services()` 的地方是 `refresh_pet_settings()`（设置对话框关闭路径，`app.py:754`），而 `PetWindow.__init__` 收尾只有 `_install_effect_services()`——启动路径没人按配置启动 Agent 监视器。

已在最新 main 上运行时复现：`agent_link.dsh=true` 启动后 `agent_link_manager is None`；手动 `refresh_pet_settings()` 后才创建。

## 修复

`__init__` 收尾的 `_install_effect_services()` 换成 `sync_optional_services()`（其自身以 `_install_effect_services()` 收尾，效果控制器装配行为不变），启动即按配置装配主动识屏 / Agent 联动 / 效果控制器。window.py 净增 5 行注释（4360 行，预算 4369 内）。

## 测试

- `tests/test_feature_gating.py` 新增回归用例：`agent_link` 开启时 PetWindow 启动即创建 manager（修复前实测为 None）；既有「关闭时不构造」「懒创建」用例保持通过。
- 聚焦测试 240 passed（feature_gating / agent_link / agent_link_threads / architecture / single_process_spawn）。
- 本地全量 1711 passed / 8 skipped。

## 顺带发现（与本 PR 无关，不在此修）

本地（Windows，~165Hz 屏）全量下 `test_collision_window.py::test_move_event_submits_throttled_not_forced` 在纯 origin/main 上也必挂：该用例 monkeypatch 的是 `pet.window.time` 的 SimpleNamespace 时钟缝，但真实节流路径在 `collision_client.py`（直接 `import time`），用例隐含假设 20 次 move 在 50ms 真实节流窗口内跑完；本机已达到 ~63ms 而第二提交漏过。CI 上绿灯。如需要可以后续给 collision_client 也接时钟缝。