### PR TITLE
fix: 余额多币种响应盲取首条导致显示在 0 与真实值间跳动

### DIFF
--- a/pet/balance.py
+++ b/pet/balance.py
@@ -51,6 +51,28 @@ class BalanceError(RuntimeError):
     pass
 
 
+def _pick_balance_info(infos):
+    """多币种 balance_infos 挑选：优先有余额的一条，同分优先 CNY，全为 0 退回首条。
+
+    官方 GET /user/balance 可能返回多条记录（如 CNY + USD）且顺序不保证；
+    盲目取 infos[0] 会在 USD 排前时把 0.00 当成余额（issue #106）。
+    """
+    if not isinstance(infos, list):
+        return infos
+
+    def _rank(item):
+        if not isinstance(item, dict):
+            return (False, False)
+        try:
+            positive = float(item.get('total_balance') or 0) > 0
+        except (TypeError, ValueError):
+            positive = False
+        cny = str(item.get('currency', '')).upper() == 'CNY'
+        return (positive, cny)
+
+    return max(infos, key=_rank)
+
+
 def fetch_balance(base_url: str, api_key: str, timeout: float = 10.0,
                   verify_ssl: bool = True) -> dict:
     """查询余额。
@@ -84,7 +106,7 @@ def fetch_balance(base_url: str, api_key: str, timeout: float = 10.0,
     infos = data.get('balance_infos') if isinstance(data, dict) else None
     if not infos:
         raise BalanceError('响应中没有余额信息')
-    info = infos[0] if isinstance(infos, list) else infos
+    info = _pick_balance_info(infos)
     return {
         'is_available': bool(data.get('is_available', True)),
         'total': str(info.get('total_balance', '')),

--- a/tests/test_balance.py
+++ b/tests/test_balance.py
@@ -84,6 +84,32 @@ def test_fetch_balance_errors(monkeypatch):
         balance.fetch_balance("https://api.deepseek.com", "sk-x")
 
 
+def test_fetch_balance_multi_currency_picks_positive_cny(monkeypatch):
+    """issue #106：balance_infos 多币种且顺序不保证时，不得盲取首条。"""
+    cny = {"currency": "CNY", "total_balance": "66.47",
+           "granted_balance": "0.00", "topped_up_balance": "66.47"}
+    usd = {"currency": "USD", "total_balance": "0.00",
+           "granted_balance": "0.00", "topped_up_balance": "0.00"}
+
+    def run_with(infos):
+        body = json.dumps({"is_available": True, "balance_infos": infos}).encode()
+        monkeypatch.setattr(balance.urllib.request, "urlopen",
+                            lambda req, *a, **k: io.BytesIO(body))
+        return balance.fetch_balance("https://api.deepseek.com", "sk-test")
+
+    # USD 排前（复现原 bug：旧实现取 infos[0] 得到 0.00）
+    assert run_with([usd, cny])["total"] == "66.47"
+    # CNY 排前不回归
+    assert run_with([cny, usd])["total"] == "66.47"
+    # 全为 0：退回首条
+    assert run_with([usd, {**cny, "total_balance": "0.00"}])["total"] == "0.00"
+    # 首条非法/非数值：仍选有余额的一条
+    bad = {"currency": "USD", "total_balance": None}
+    assert run_with([bad, cny])["total"] == "66.47"
+    # 非 list 的 balance_infos（单条 dict）原样兼容
+    assert run_with(cny)["total"] == "66.47"
+
+
 def test_balance_percent_and_event_index():
     # 余额 20 元 → 未消耗 0%；10 元 → 50%；0/负数 → 100%；非法 → None
     assert balance.balance_percent("20") == 0


### PR DESCRIPTION
## 问题

`GET /user/balance` 可能返回多条 `balance_infos`（如 CNY + USD 两条）且**顺序不保证**。`fetch_balance` 旧实现直接取 `infos[0]`：当 USD 记录排到前面时，取到的 `total_balance` 是 `"0.00"`，导致右键余额在 **¥0.00 与真实值之间来回跳**；灵动岛余额档位动画用的是同一个 `info['total']`，会跟着错。缓存文件旁证见 #106。

Fixes #106

## 修复

新增 `_pick_balance_info()`：优先取**有余额**的一条，同分优先 **CNY**，全为 0 退回首条（保持原行为）；非 dict / 非数值条目防御跳过。

改动只涉及 `pet/balance.py` 一个函数 + 调用点一行。

附带说明（未采纳项）：issue 里提到的「`¥` 符号写死」未动——不影响 CNY 账户，将来若要支持纯 USD 账户可再议。

## 验证

- 新增 5 条用例覆盖：USD 排前（稳定复现原 bug）/ CNY 排前不回归 / 全 0 回首条 / 非法值跳过 / 非 list 单条兼容
- `tests/test_balance.py` 13 条全绿；全量 pytest 1912 passed 无回归
