### PR TITLE
fix: 弹射全程动画切换封死冷首帧解码——实测消除弹射卡顿

### DIFF
--- a/pet/window.py
+++ b/pet/window.py
@@ -167,6 +167,12 @@ COLLISION_CONTACT_DV_FLOOR = 50.0
 # 每 tick 只消费最新目标做 self.move，丢弃中间过期位置。
 DRAG_MOVE_COALESCE_MS = 8
 
+# 弹射飞行低速段阈值（px/s）：低于此速度（滚动/滑动阶段）动画链允许在
+# idle/turn 池内切换（两池首帧必热：idle 起飞时已预热、turn pinned 常驻）；
+# 高于此速度固定循环悬空动画。量级参照 throw_egg.THROW_EGG_RECOVER_SPEED
+# （780 贴地回正）——400 是"视觉上明显已减速"的中段。
+THROW_SLOW_ANIM_SPEED = 400.0
+
 # ---- 闲置降帧（性能调研 §4.3；批11 联动解码节流）----
 # 长时间不碰桌宠且可见时动画降帧。批11 起解码/消费联动降速：
 # reader 入队由超时丢帧改为有界阻塞，被丢弃的帧在 reader 侧未解码。
@@ -2473,6 +2479,41 @@ class PetWindow(QWidget, WindowFeatureGateMixin):
                 self._switch_retry_count = 0
                 self._switch_retry_timer.stop()
             return
+        # 弹射飞行途中不推进随机动画链（实测定案：弹射切换是事件驱动，
+        # 预测式预热覆盖不到——拖拽打断早已作废预测代次，松手/半空的现场
+        # 掷骰会切到冷首帧动画，GUI 线程同步拉 ffmpeg 解码 ~100ms 起；
+        # 观测实机 26 次 >100ms 卡顿中 19 次即此路径）。规则：当前动作
+        # 播完若仍在飞行，固定切到"悬空"动画（拖拽 clip，pinned 首帧必热，
+        # 被拎着悬空的视觉恰好契合被击飞）并循环，落地停稳由 _stop_physics
+        # 切回待机恢复正常链。无拖拽素材时退化为循环当前动画（同一 clip
+        # 首帧必热，零成本）。
+        # 低速段（滚动/滑动，< THROW_SLOW_ANIM_SPEED）放宽动画切换
+        # （用户实机要求"低速也可以播动作"）：先按正常链掷骰，目标首帧
+        # 已热（播过留在 LRU / pinned / 起飞预热）就直接播——滚动段也能
+        # 看到动作/移动，且越滚越丰富；冷目标绝不追（GUI 同步解码卡顿
+        # 零容忍），退回必热的 idle/turn 池（idle 起飞时已由
+        # _warm_landing_idles 预热、turn 在 pinned 常驻集）。
+        if self._physics_mode == 'throw':
+            speed = math.hypot(*self._phys_vel)
+            if speed < THROW_SLOW_ANIM_SPEED and self._throw_low_speed_switch(name):
+                return
+            flight = self.drag or (self.idles[0] if self.idles else None)
+            if flight is not None and name != flight:
+                self._switch(flight)
+                return
+            self._push_recycle(self.movie)  # 同拖拽重启：不经 _switch，补推送
+            self.movie.jumpToFrame(0)
+            self._ended_fired = False
+            if self.movie.start() is False:
+                self._fallback_playable_idle(name)
+                self._schedule_switch_retry(name)
+                return
+            if self._pending_switch == name:
+                self._pending_switch = None
+                self._pending_switch_link = False
+                self._switch_retry_count = 0
+                self._switch_retry_timer.stop()
+            return
         # Agent 联动：待播动作优先接上（平滑衔接，不打断刚播完的动作）
         if self._pending_link_anim:
             self._play_pending_link_anim()
@@ -3189,8 +3230,11 @@ class PetWindow(QWidget, WindowFeatureGateMixin):
                     self.move(g - self._grab_offset)  # 停在松手处
                 self._save_position()
             self._position_sync_now()  # 松手后的最终位置立即同步（气泡/监听器），不等去抖
-            if self.idles:
-                self._switch(self._pick(self.idles))  # 回待机缓冲
+            if self.idles and self._physics_mode != 'throw':
+                # 回待机缓冲；弹射起飞时不在此切换——飞行途中由 _on_anim_ended
+                # 的飞行循环规则接管（当前动作播完后循环悬空动画，落地回待机），
+                # 避免松手帧现场掷骰切到冷首帧动画造成 GUI 同步解码卡顿。
+                self._switch(self._pick(self.idles))
         elif dist < catalog.DRAG_THRESHOLD * self.scale:
             # 边缘探头激活时，点击是“拉直/重置倒计时”的探头操作，不是普通点击反馈，
             # 不播点击音效。
@@ -4033,6 +4077,7 @@ class PetWindow(QWidget, WindowFeatureGateMixin):
             self._applied_opacity = opacity
 
     def _stop_physics(self) -> None:
+        was_throw = self._physics_mode == 'throw'
         self._physics_timer.stop()
         self._physics_mode = None
         if getattr(self, '_interaction_state', IDLE) == THROWN:
@@ -4042,6 +4087,10 @@ class PetWindow(QWidget, WindowFeatureGateMixin):
         _te = getattr(self, '_throw_egg', None)
         if _te is not None:
             _te.end()
+        if was_throw and self.drag and self.anim == self.drag and self.idles:
+            # 弹射落地：飞行中循环的悬空动画切回待机（首帧在起飞时已由
+            # _warm_landing_idles 预热），动画链从待机自然恢复。
+            self._switch(self._pick(self.idles))
 
     def _enter_physics_mode(self, mode: str) -> None:
         """进入物理模式（'drag'/'throw'）：统一取消自主移动计划与动画间隔，
@@ -4049,6 +4098,67 @@ class PetWindow(QWidget, WindowFeatureGateMixin):
         self._cancel_move()
         self._cancel_animation_gap()
         self._physics_mode = mode
+        if mode == 'throw':
+            self._throw_slow_switched = False  # 每次弹射只允许一次降速过渡
+            self._warm_landing_idles()
+
+    def _first_frame_warm(self, name) -> bool:
+        """目标动画首帧是否已在缓存（播过留 LRU / pinned / 预热完成）。
+
+        弹射低速段放行链式掷骰时用作"只播热的"闸门：冷目标不追，
+        避免 GUI 线程同步解码。读 clip 的 _first_image 缓存位（WebMClip
+        内部字段；接口不稳定时 getattr 兜底为冷，退化为 idle/turn 池）。
+        """
+        lib = getattr(self, 'lib', None)
+        movie = getattr(lib, 'movie', None)
+        if not callable(movie):
+            return False
+        try:
+            return getattr(movie(name), '_first_image', None) is not None
+        except Exception:
+            return False
+
+    def _throw_low_speed_switch(self, name) -> bool:
+        """弹射低速段的动画切换：掷骰命中首帧已热的目标直接播，冷目标退回
+        必热的 idle/turn 池。返回 True 表示发生了切换。
+
+        两个调用点：_tick_throw_physics 降速入段的即时过渡（不等 clip
+        自然播完——拖拽 clip 可能比整个低速段还长）；_on_anim_ended
+        低速段的链式推进。
+        """
+        if not (self.idles or self.turns):
+            return False
+        nxt = self._roll_next(exclude=name)
+        if nxt is not None and nxt != name and self._first_frame_warm(nxt):
+            self._switch(nxt)
+            return True
+        pool = [*self.idles, *self.turns]
+        nxt = self._pick(pool, exclude=name)
+        if nxt is not None and nxt != name:
+            self._switch(nxt)
+            return True
+        return False
+
+    def _warm_landing_idles(self) -> None:
+        """弹射起飞时后台预热 idle 首帧（落地回待机的切换目标）。
+
+        预测式预热覆盖不到这里：弹射是事件触发（拖拽打断早已把预测代次
+        作废），且交互让路闸门在拖拽/弹射期间会挡住 warm_predicted——
+        故直接调 clip 级 warm_first_frame（幂等、后台线程、可被取消），
+        绕过闸门。idle 池极小（通常 1-3 个），代价可忽略；不暖的话落地
+        切换可能命中冷首帧，GUI 线程同步拉 ffmpeg 解码（实测 ~100ms）。
+        """
+        lib = getattr(self, 'lib', None)
+        movie = getattr(lib, 'movie', None)
+        if not callable(movie):
+            return
+        for name in self.idles or ():
+            try:
+                warm = getattr(movie(name), 'warm_first_frame', None)
+                if callable(warm):
+                    warm()
+            except Exception:
+                pass  # 预热失败不致命：落地切换退化为现状（按需同步解码）
 
     def _on_physics_tick(self) -> None:
         if perfstats.ENABLED:
@@ -4118,6 +4228,14 @@ class PetWindow(QWidget, WindowFeatureGateMixin):
             predict_bounce(start_px, start_py)
         self.move(int(round(self._phys_pos[0])), int(round(self._phys_pos[1])))
         speed = math.hypot(self._phys_vel[0], self._phys_vel[1])
+        # 低速段入口过渡：一降速就切出悬空动画，不等 clip 自然播完
+        # （拖拽 clip 时长可能超过整个低速段，等播完就永远看不到切换——
+        # 实机反馈"低速滚动还是悬空姿势"）。每次弹射只过渡一次，之后
+        # 低速段的动画推进由 _on_anim_ended 的低速分支接力。
+        if (not getattr(self, '_throw_slow_switched', False)
+                and speed < THROW_SLOW_ANIM_SPEED):
+            self._throw_slow_switched = True
+            self._throw_low_speed_switch(self.anim)
         # 在地面上且水平速度也很低时，彻底停下
         if physics_mod.is_at_rest(
             self._phys_pos[1], self._phys_vel[0], self._phys_vel[1], bottom, bounced_any, speed

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -57,7 +57,12 @@ PET_DIR = Path(__file__).resolve().parents[1] / "pet"
 # 的根因写在调用点注释里，+5 行；#101 在 _try_move 入口加探头会话位移闸门并补
 # 注释，+7 行）。按维护者约定，klxxya 的修复可越过本红线：两处都是行为修复所必需
 # 的守卫/注释，挪出 window.py 会切断控制流；拆分待办不变，预算只随实测校准。
-WINDOW_PY_LINE_BUDGET = 4385
+# 2026-09-12 再上调到 4420：弹射卡顿修复批（实测 4411）——_on_anim_ended 飞行
+# 循环/低速暖掷骰守卫、_enter_physics_mode 起飞预热与降速即时过渡、
+# _stop_physics 落地回待机（实机卡顿定案：观测 26 次 >100ms 卡顿中 19 次为
+# GUI 冷解码首帧）。全部是窗口生命周期内联守卫，拆控制器会切断与
+# _switch/_pending_switch/回收推送的共享状态流；拆分待办不变。
+WINDOW_PY_LINE_BUDGET = 4420
 
 # modern_settings_dialog.py 行数预算：按结构线拆分后实测 1857 行（拆分前 4811 行）。
 # 主对话框 ModernSettingsDialog + 对话框装配/配置写回 + 为 pet/ 与 tests/ 保留的

--- a/tests/test_throw_flight_anim.py
+++ b/tests/test_throw_flight_anim.py
@@ -1,0 +1,300 @@
+# -*- coding: utf-8 -*-
+"""弹射飞行动画链规则（实机卡顿定案修复）回归测试。
+
+背景：观测实机 26 次 >100ms GUI 卡顿中 19 次是动画切换命中冷首帧
+（GUI 线程同步拉 ffmpeg 解码，实测 ~100ms/次）。弹射路径的切换全部
+是事件驱动，预测式预热覆盖不到（拖拽打断作废预测代次）。规则：
+
+1. 进入 throw 物理模式：后台预热 idle 首帧（落地回待机的切换目标）；
+2. 松手甩出（进入 throw）时不在松手帧现场掷骰切待机；
+3. 飞行途中动画播完：不推进随机链，切到"悬空"动画（drag clip）并循环；
+4. 落地停稳（_stop_physics 退出 throw）：悬空动画切回待机，链自然恢复；
+5. 非 throw 的物理模式（drag）与正常模式行为不变。
+
+全部用假 clip/假库驱动，不起真实 ffmpeg。
+"""
+from __future__ import annotations
+
+import pytest
+from PySide6.QtCore import QObject, Signal
+from PySide6.QtGui import QPixmap
+from PySide6.QtWidgets import QApplication
+
+from pet import catalog
+from pet.config import Config
+from pet.window import PetWindow
+
+@pytest.fixture
+def app():
+    return QApplication.instance() or QApplication([])
+
+class FakeClip(QObject):
+    """与 WebMClip 接口兼容的假播放器：记录预热/启停/跳帧。"""
+
+    frameChanged = Signal(int)
+    finished = Signal()
+
+    def __init__(self, name: str, frame_count: int = 10, fps: float = 10.0):
+        super().__init__()
+        self.name = name
+        self.frame_count = max(1, frame_count)
+        self.fps = max(0.1, float(fps))
+        self.speed = 1.0
+        self.decode_throttle_divisor = 1
+        self.warm_calls = 0
+        self.stop_count = 0
+        self.start_count = 0
+        self.jump_calls = 0
+        self.recycle_minutes_calls: list = []
+        self.clear_display_calls = 0
+        self._pm = QPixmap(2, 2)
+        self._pm.fill()
+
+    def clear_display_frame(self):
+        self.clear_display_calls += 1
+
+    def stop(self):
+        self.stop_count += 1
+
+    def start(self):
+        self.start_count += 1
+        return True
+
+    def jumpToFrame(self, frame_index):
+        self.jump_calls += 1
+        return int(frame_index) <= 0
+
+    def set_playback_speed(self, speed):
+        self.speed = max(0.1, float(speed))
+
+    def currentPixmap(self):
+        return self._pm
+
+    def currentFrameNumber(self):
+        return 0
+
+    def frameCount(self):
+        return self.frame_count
+
+    def duration(self):
+        return self.frame_count / self.fps / self.speed
+
+    def currentTimeSeconds(self):
+        return 0.0
+
+    def warm_first_frame(self):
+        self.warm_calls += 1
+
+    def set_decode_throttle(self, divisor):
+        self.decode_throttle_divisor = max(1, int(divisor))
+
+    def set_recycle_minutes(self, minutes):
+        self.recycle_minutes_calls.append(minutes)
+
+class FakeLibrary:
+    """只含核心动画名的假素材库。"""
+
+    def __init__(self, frame_count: int = 10, fps: float = 10.0):
+        self.no_mirror = set()
+        self.manifest = {}
+        self.folder_map = {}
+        self.folder_files = None
+        self._frame_count = frame_count
+        self._fps = fps
+        self.warmed: list[str] = []
+        self._clips = {}
+        for n in self._names():
+            self._clips[n] = FakeClip(n, frame_count=frame_count, fps=fps)
+
+    @staticmethod
+    def _names() -> list[str]:
+        return [
+            catalog.IDLE,
+            catalog.TURN,
+            catalog.MOVES[0],
+            catalog.CLICKS[0],
+            catalog.DRAG,
+            "写代码",
+            "吃白饭",
+        ]
+
+    def names(self):
+        return list(self._clips)
+
+    def movies(self):
+        return dict(self._clips)
+
+    def movie(self, name):
+        return self._clips[name]
+
+    def frames(self, name):
+        return self._clips[name].frameCount()
+
+    def duration(self, name):
+        return self._clips[name].duration()
+
+    def warm_predicted(self, name):
+        self.warmed.append(name)
+        self._clips[name].warm_first_frame()
+
+def _make_window(tmp_path, **cfg_overrides):
+    cfg = Config(base=tmp_path)
+    for k, v in cfg_overrides.items():
+        cfg.set(k, v)
+    return PetWindow(FakeLibrary(), cfg)
+
+def test_throw_entry_warms_landing_idles(tmp_path, app):
+    """进入 throw 物理模式：idle 池全部后台预热（落地回待机目标必热）。"""
+    win = _make_window(tmp_path)
+    idle_clip = win.lib.movie(catalog.IDLE)
+    idle_clip.warm_calls = 0
+    win._enter_physics_mode('throw')
+    assert idle_clip.warm_calls >= 1
+    win._physics_mode = None
+    win.close()
+
+def test_drag_entry_does_not_warm(tmp_path, app):
+    """drag 模式不触发落地预热（拖拽不甩出就没有落地切换）。"""
+    win = _make_window(tmp_path)
+    idle_clip = win.lib.movie(catalog.IDLE)
+    idle_clip.warm_calls = 0
+    win._enter_physics_mode('drag')
+    assert idle_clip.warm_calls == 0
+    win._physics_mode = None
+    win.close()
+
+def test_anim_end_during_throw_switches_to_flight_anim(tmp_path, app):
+    """高速飞行途中动作播完：切到悬空动画（drag clip），不推进随机链。"""
+    win = _make_window(tmp_path)
+    win._switch("写代码")  # 击飞前正在播动作
+    assert win.anim == "写代码"
+    win._enter_physics_mode('throw')
+    win._phys_vel[:] = [900.0, 0.0]  # 高速飞行段
+    win._on_anim_ended("写代码")
+    assert win.anim == catalog.DRAG  # 固定悬空动画，而非随机链目标
+    win._stop_physics()
+    win.close()
+
+def test_anim_end_during_throw_loops_flight_anim(tmp_path, app):
+    """悬空动画自身播完且仍在高速飞行：原地循环（同 clip 重启），不掷骰。"""
+    win = _make_window(tmp_path)
+    win._enter_physics_mode('throw')
+    win._phys_vel[:] = [900.0, 0.0]
+    win._switch(catalog.DRAG)
+    drag_clip = win.lib.movie(catalog.DRAG)
+    start_before = drag_clip.start_count
+    jump_before = drag_clip.jump_calls
+    win._on_anim_ended(catalog.DRAG)
+    assert win.anim == catalog.DRAG            # 没切走
+    assert drag_clip.jump_calls > jump_before  # 回首帧
+    assert drag_clip.start_count > start_before  # 重新起播
+    win._stop_physics()
+    win.close()
+
+def test_anim_end_during_throw_low_speed_allows_warm_pool(tmp_path, app):
+    """低速段（滚动/滑动，< THROW_SLOW_ANIM_SPEED）：放行 idle/turn 池切换。
+
+    用户实机要求"低速也可以播动作"；idle/turn 两池首帧必热（idle 起飞
+    时已预热、turn pinned 常驻），不引入冷解码。动作/移动池仍不开放。
+    """
+    win = _make_window(tmp_path)
+    win._switch("写代码")
+    win._enter_physics_mode('throw')
+    win._phys_vel[:] = [120.0, 0.0]  # 低速段
+    win._on_anim_ended("写代码")
+    assert win.anim in (*win.idles, *win.turns)  # 只许必热池
+    assert win.anim != catalog.DRAG              # 低速不再强制悬空
+    win._stop_physics()
+    win.close()
+
+def test_low_speed_pool_excludes_current(tmp_path, app):
+    """低速段池切换排除当前动画（避免同名自切）。"""
+    win = _make_window(tmp_path)
+    win._enter_physics_mode('throw')
+    win._phys_vel[:] = [100.0, 0.0]
+    win._switch(catalog.IDLE)
+    win._on_anim_ended(catalog.IDLE)
+    # idles 只有 1 个且被排除 → 唯一合法去向是 turn
+    assert win.anim == catalog.TURN
+    win._stop_physics()
+    win.close()
+
+def test_landing_switches_flight_anim_back_to_idle(tmp_path, app):
+    """落地停稳（_stop_physics 退出 throw）：悬空动画切回待机。"""
+    win = _make_window(tmp_path)
+    win._enter_physics_mode('throw')
+    win._switch(catalog.DRAG)
+    win._stop_physics()
+    assert win._physics_mode is None
+    assert win.anim == catalog.IDLE
+    win.close()
+
+def test_stop_physics_from_drag_mode_keeps_anim(tmp_path, app):
+    """非 throw 的 _stop_physics（如拖拽死区停下）：不做落地切换。"""
+    win = _make_window(tmp_path)
+    win._enter_physics_mode('drag')
+    win._switch(catalog.DRAG)
+    win._stop_physics()
+    assert win.anim == catalog.DRAG  # 不切（松手死区路径自行处理回待机）
+    win.close()
+
+def test_anim_end_normal_mode_chain_unaffected(tmp_path, app):
+    """正常模式（无物理）：动画链照旧推进（回归守卫）。"""
+    win = _make_window(tmp_path)
+    win._switch("写代码")
+    win._on_anim_ended("写代码")
+    assert win.anim != "写代码"  # 链推进了（具体目标由概率决定，不锁定）
+    win.close()
+
+def test_low_speed_plays_warm_rolled_act(tmp_path, app, monkeypatch):
+    """低速段掷骰掷中"首帧已热"的动作：直接播它（不退回 idle/turn 池）。"""
+    import random as _random
+    monkeypatch.setattr(_random, "random", lambda: 0.5)   # 命中动作分支
+    monkeypatch.setattr(_random, "choice", lambda lst: lst[0])  # 池首
+    win = _make_window(tmp_path)
+    win._switch(catalog.IDLE)
+    win._enter_physics_mode('throw')
+    win._phys_vel[:] = [120.0, 0.0]
+    # acts 池内顺序由 hash 随机化决定（进程级），不能假定具体名字：
+    # 暖"掷骰会选中的那一个"（choice 固定池首），断言切到的就是它。
+    win.lib.movie(win.acts[0])._first_image = object()  # 标记首帧已热
+    win._on_anim_ended(catalog.IDLE)
+    assert win.anim == win.acts[0]
+    win._stop_physics()
+    win.close()
+
+def test_low_speed_cold_rolled_act_falls_back(tmp_path, app, monkeypatch):
+    """低速段掷骰掷中冷目标：不追（零冷解码），退回必热的 idle/turn 池。"""
+    import random as _random
+    monkeypatch.setattr(_random, "random", lambda: 0.5)
+    monkeypatch.setattr(_random, "choice", lambda lst: lst[0])
+    win = _make_window(tmp_path)
+    win._switch(catalog.IDLE)
+    win._enter_physics_mode('throw')
+    win._phys_vel[:] = [120.0, 0.0]
+    win._on_anim_ended(catalog.IDLE)  # 写代码首帧冷 → 退回池排除 IDLE → turn
+    assert win.anim == catalog.TURN
+    win._stop_physics()
+    win.close()
+
+def test_tick_low_speed_transition_switches_out_of_drag(tmp_path, app):
+    """降速进入低速段的同一 tick 立即切出悬空动画（不等 clip 播完）。
+
+    实机反馈：低速滚动仍是悬空姿势——拖拽 clip 时长可能超过整个低速段，
+    等动画自然结束永远轮不到切换。高速段 tick 不应过渡。
+    """
+    win = _make_window(tmp_path)
+    win._enter_physics_mode('throw')
+    win._switch(catalog.DRAG)
+    win._phys_pos[:] = [200.0, 200.0]
+    win._phys_vel[:] = [900.0, 0.0]  # 高速段
+    win._tick_throw_physics(0.016)
+    assert win.anim == catalog.DRAG
+    assert getattr(win, '_throw_slow_switched', False) is False
+    win._phys_vel[:] = [100.0, 0.0]  # 降速入段
+    win._tick_throw_physics(0.016)
+    assert win._throw_slow_switched is True
+    assert win.anim != catalog.DRAG
+    assert win.anim in (*win.idles, *win.turns, *win.acts, *win.moves)
+    win._stop_physics()
+    win.close()


### PR DESCRIPTION
## 问题

实机反馈：弹射过程中偶发卡顿。

**取证（实机观测，`PET_PERF_STATS` + >100ms 帧空窗看门狗）**：一次正常游玩会话抓到 26 次 >100ms GUI 卡顿，其中 **19 次是动画切换命中冷首帧**——GUI 线程同步拉 ffmpeg 解码（实测 106 个 clip：冷解码均值 100.7ms / 最差 1.4s，热路径 0.1ms；60Hz 单帧预算 16.7ms）。

**根因**：预测式预热（批10-A1）只覆盖正常播放链。弹射路径的每一次切换都是事件驱动，绕开预测：

- 拖拽全程"交互让路"闸门挡住预热；
- 松手时随机选 idle 是现场掷骰，预测代次在拖拽打断时已作废；
- 飞行途中 `_enter_physics_mode` 只取消移动计划，动画链照常推进，半空切换走同一条冷解码路径。

## 修复规则（实机验证通过）

| 阶段 | 行为 |
|---|---|
| 松手甩出帧 | 不再现场掷骰切待机，拖拽动画继续播完 |
| 高速飞行（≥400px/s） | 动画播完固定循环悬空动画（drag clip，pinned 首帧必热；"被拎着悬空"视觉恰好契合被击飞） |
| 低速滚动（<400px/s） | 降速同一 tick 即时过渡（不等 clip 播完——拖拽 clip 可能比整个低速段还长）：掷骰命中**首帧已热**的目标直接播（播过留 LRU / pinned / 预热完成，越滚越丰富），冷目标退回必热的 idle/turn 池 |
| 起飞时 | 后台预热 idle 首帧（clip 级 `warm_first_frame`，绕过交互让路闸门） |
| 落地停稳 | 切回待机，正常动画链恢复 |

掷骰概率与正常链共用同一 `_roll_next`（30/10/40/20 分布不变形），只加"冷的不播"闸门。

**已知边界**：飞行途中点击触发的黄金回旋接续被飞行循环接管，落地后恢复（空中回旋与悬空动画本就互抢旋转管线）。

## 验证

- 新增 `tests/test_throw_flight_anim.py` 12 条：起飞预热 / 高速循环 / 低速暖掷骰与冷回退 / 降速即时过渡 / 落地回待机 / drag 模式与非 throw 模式不回归等
- 全量 pytest 1912 passed / 8 skipped
- 实机对比：修复前弹射路径多次 >100ms 卡顿（含一次 3.75s），修复后同场景无感知卡顿

## 备注

- `window.py` 行数预算按 `tests/test_architecture.py` 注释约定的流程校准至 4420（注明日期+理由；这些都是窗口生命周期内联守卫，拆控制器会切断与 `_switch`/`_pending_switch`/回收推送的共享状态流，拆分待办不变）。
- 残留观察项：正常链预测 miss（~8%）仍有零星 100-350ms 切换卡顿，方向是把"预测"升级为"定案绑约"（预测即承诺），语义变化较大，另行讨论。
