### PR TITLE
fix: 探头/头槌体验三连修 + 气泡分页避头尾与翻页体验优化

### DIFF
--- a/pet/collision_client.py
+++ b/pet/collision_client.py
@@ -371,16 +371,24 @@ class CollisionClient(QObject):
         if egg is not None and egg.active:
             egg.on_pet_contact(math.hypot(*win._phys_vel))
         if abs(dx) > 1e-9 or abs(dy) > 1e-9:
-            win._cancel_move()
-            win._cancel_animation_gap()
-            clamped_x, clamped_y = win._collision_clamp_pos(win.x() + dx, win.y() + dy)
-            left, top = win._collision_clamp_pos(float('-inf'), float('-inf'))
-            right, bottom = win._collision_clamp_pos(float('inf'), float('inf'))
-            win.move(
-                min(max(int(round(clamped_x)), math.ceil(left)), math.floor(right)),
-                min(max(int(round(clamped_y)), math.ceil(top)), math.floor(bottom)),
-            )
-            win._phys_pos[:] = [float(win.x()), float(win.y())]
+            # 边缘探头会话期间位置归探头控制器管（PEEKING 稳态无 timer，
+            # 被位移顶偏后不会自动归位，会"卡"在错误的露出量上），软撞的
+            # 分离位移直接丢弃；真实撞击下方会进入 throw 并取消探头会话，
+            # 位移照常应用。
+            probe_holds_pose = bool(
+                getattr(getattr(win, '_edge_probe', None), 'active', False)
+            ) and not (is_real_hit and not contact_deviation)
+            if not probe_holds_pose:
+                win._cancel_move()
+                win._cancel_animation_gap()
+                clamped_x, clamped_y = win._collision_clamp_pos(win.x() + dx, win.y() + dy)
+                left, top = win._collision_clamp_pos(float('-inf'), float('-inf'))
+                right, bottom = win._collision_clamp_pos(float('inf'), float('inf'))
+                win.move(
+                    min(max(int(round(clamped_x)), math.ceil(left)), math.floor(right)),
+                    min(max(int(round(clamped_y)), math.ceil(top)), math.floor(bottom)),
+                )
+                win._phys_pos[:] = [float(win.x()), float(win.y())]
         if has_velocity_impulse:
             win._just_dragged = True
             QTimer.singleShot(120, win, win._clear_just_dragged)

--- a/pet/speech_bubble.py
+++ b/pet/speech_bubble.py
@@ -23,13 +23,17 @@ log = logging.getLogger(__name__)
 from math import ceil
 from pathlib import Path
 
-from PySide6.QtCore import QPoint, QPointF, QRect, QRectF, QSize, Qt, QTimer, Signal
+from PySide6.QtCore import (
+    QPoint, QPointF, QPropertyAnimation, QRect, QRectF, QSize, Qt, QTimer,
+    Signal,
+)
 from PySide6.QtGui import (
     QColor, QFontMetrics, QGuiApplication, QPainter, QPainterPath, QPen,
     QPixmap, QTransform,
 )
 from PySide6.QtWidgets import (
     QFrame,
+    QGraphicsOpacityEffect,
     QLabel,
     QLayout,
     QPushButton,
@@ -42,6 +46,10 @@ from PySide6.QtWidgets import (
 from .speech_bubble_text import (
     BUBBLE_TEXT_COLUMN,
     BUBBLE_TEXT_SLACK,
+    PAGE_DWELL_MAX_MS,
+    PAGE_DWELL_MIN_MS,
+    PAGE_FADE_IN_MS,
+    PAGE_FADE_OUT_MS,
     SELF_TALK_IMAGE_SUFFIXES,
     breath_bubble_size_for_anchor,
     breath_bubble_size_for_scale,
@@ -52,12 +60,16 @@ from .speech_bubble_text import (
     elide_bubble_text,
     list_self_talk_images,
     normalize_bubble_text,
+    page_dots,
+    page_dwell_ms,
     paginate_bubble_text,
 )
 
 __all__ = [
     "BUBBLE_TEXT_COLUMN",
     "BUBBLE_TEXT_SLACK",
+    "PAGE_DWELL_MAX_MS",
+    "PAGE_DWELL_MIN_MS",
     "SELF_TALK_IMAGE_SUFFIXES",
     "BUBBLE_STYLE_PRESETS",
     "breath_bubble_size_for_anchor",
@@ -69,6 +81,8 @@ __all__ = [
     "elide_bubble_text",
     "list_self_talk_images",
     "normalize_bubble_text",
+    "page_dots",
+    "page_dwell_ms",
     "paginate_bubble_text",
     "PetSpeechBubble",
 ]
@@ -278,15 +292,18 @@ class PetSpeechBubble(QFrame):
         self._layout.addWidget(self._button_row)
         self._interactive_active = False
         self._interactive_buttons: list[QPushButton] = []
-        # 长文本分页状态：页列表 + 当前页 + 自动翻页定时器。
+        # 长文本分页状态：页列表 + 当前页 + 逐页停留表 + 自动翻页定时器。
         # 气泡对鼠标全透明（WA_TransparentForMouseEvents），无法靠点击翻页，
-        # 因此采用「每页停留一小段后自动翻下一页」的方式保证全文可读完。
+        # 因此采用「每页按字数停留一段后自动翻下一页」的方式保证全文可读完。
         self._pages: list[str] = []
         self._page_index = 0
-        self._page_interval_ms = 0
+        self._page_dwells: list[int] = []
         self._page_timer = QTimer(self)
         self._page_timer.setSingleShot(True)
         self._page_timer.timeout.connect(self._on_page_timeout)
+        # 翻页淡入淡出：当前动画句柄 + 懒创建的 label 透明度效果。
+        self._page_fade: QPropertyAnimation | None = None
+        self._label_opacity: QGraphicsOpacityEffect | None = None
         self._style_id = ""
         self._preset = BUBBLE_STYLE_PRESETS["classic_top"]
         self._anchor_rect = QRect()
@@ -550,20 +567,20 @@ class PetSpeechBubble(QFrame):
             self._configure_breath_content(anchor_rect, pet_scale)
         else:
             # 长文本分页：每页不超过 bubble_max_lines 行，自动翻页直到全文展示完，
-            # 底部显示「1/3」页码指示。总时长按页数扩展，保证每页可读完。
+            # 底部显示圆点页码（● ○ ○）。每页停留按该页字数自适应，总时长相应扩展。
             pages = paginate_bubble_text(
                 metrics, text, bubble_wrap_width(), bubble_max_lines(text)
             )
             display_text = pages[0] if pages else ""
             if len(pages) > 1 and not sticky and not interactive:
-                per_page = max(2200, min(5000, duration_ms // len(pages)))
-                total_ms = max(duration_ms, per_page * len(pages))
+                dwells = [page_dwell_ms(page) for page in pages]
+                total_ms = max(duration_ms, sum(dwells))
                 self._pages = pages
                 self._page_index = 0
-                self._page_interval_ms = per_page
-                self._page_indicator.setText(f"1/{len(pages)}")
+                self._page_dwells = dwells
+                self._page_indicator.setText(page_dots(0, len(pages)))
                 self._page_indicator.show()
-                self._page_timer.start(per_page)
+                self._page_timer.start(dwells[0])
                 duration_ms = total_ms
             else:
                 self._reset_paging()
@@ -698,17 +715,66 @@ class PetSpeechBubble(QFrame):
     def hideEvent(self, event) -> None:  # noqa: N802 (Qt 命名)
         """气泡被隐藏（超时 / dismiss / 父窗口隐藏）时通知上层。"""
         super().hideEvent(event)
+        self._stop_page_fade()
         self._teardown_interactive()
         self.hidden_signal.emit()
 
     def _reset_paging(self) -> None:
         """停止自动翻页并隐藏页码指示（单页内容/图片/换内容时调用）。"""
         self._page_timer.stop()
+        self._stop_page_fade()
         self._pages = []
         self._page_index = 0
-        self._page_interval_ms = 0
+        self._page_dwells = []
         self._page_indicator.setText("")
         self._page_indicator.hide()
+
+    def _label_opacity_effect(self) -> QGraphicsOpacityEffect:
+        """懒创建 label 透明度效果（仅分页翻页时用到，单页气泡零开销）。"""
+        if self._label_opacity is None:
+            self._label_opacity = QGraphicsOpacityEffect(self.label)
+            self._label_opacity.setOpacity(1.0)
+            self.label.setGraphicsEffect(self._label_opacity)
+        return self._label_opacity
+
+    def _stop_page_fade(self) -> None:
+        """打断进行中的翻页动画并把透明度复位（隐藏/换内容/连翻时兜底）。"""
+        anim, self._page_fade = self._page_fade, None
+        if anim is not None:
+            anim.stop()  # stop() 不触发 finished，换字回调不会执行
+        if self._label_opacity is not None:
+            self._label_opacity.setOpacity(1.0)
+
+    def _flip_to_page(self, index: int) -> None:
+        """翻到指定页：短淡出 → 换文本与页码 → 淡入。"""
+        self._stop_page_fade()
+        effect = self._label_opacity_effect()
+        fade_out = QPropertyAnimation(effect, b"opacity", self)
+        fade_out.setDuration(PAGE_FADE_OUT_MS)
+        fade_out.setStartValue(1.0)
+        fade_out.setEndValue(0.0)
+
+        def _swap_and_fade_in() -> None:
+            if self._page_fade is not fade_out:
+                return  # 已被 _stop_page_fade 打断
+            self.label.setText(self._pages[index])
+            self._page_indicator.setText(page_dots(index, len(self._pages)))
+            fade_in = QPropertyAnimation(effect, b"opacity", self)
+            fade_in.setDuration(PAGE_FADE_IN_MS)
+            fade_in.setStartValue(0.0)
+            fade_in.setEndValue(1.0)
+
+            def _fade_in_done() -> None:
+                if self._page_fade is fade_in:
+                    self._page_fade = None
+
+            fade_in.finished.connect(_fade_in_done)
+            self._page_fade = fade_in
+            fade_in.start(QPropertyAnimation.DeletionPolicy.DeleteWhenStopped)
+
+        fade_out.finished.connect(_swap_and_fade_in)
+        self._page_fade = fade_out
+        fade_out.start(QPropertyAnimation.DeletionPolicy.DeleteWhenStopped)
 
     def _on_page_timeout(self) -> None:
         """自动翻到下一页；最后一页展示完后由 _hide_timer 收尾隐藏。"""
@@ -717,11 +783,9 @@ class PetSpeechBubble(QFrame):
             return
         self._page_index += 1
         if self._content_kind == "text":
-            self.label.setText(self._pages[self._page_index])
-            self._page_indicator.setText(
-                f"{self._page_index + 1}/{len(self._pages)}"
-            )
-            self._page_timer.start(self._page_interval_ms)
+            self._flip_to_page(self._page_index)
+            if self._page_index < len(self._page_dwells):
+                self._page_timer.start(self._page_dwells[self._page_index])
 
     def show_image(
         self,

--- a/pet/speech_bubble_text.py
+++ b/pet/speech_bubble_text.py
@@ -84,6 +84,39 @@ def bubble_max_lines(text: str) -> int:
     return 3 if len(normalize_bubble_text(text)) <= 40 else 6
 
 
+# 避头尾（kinsoku）行首禁则字符：闭标点不允许出现在行首。逐字换行时若
+# 新行的首字符落在本集合内，就把上一行的末字符拉下来陪它——否则长句
+# 末尾的 "！" 会独占一行，分页时变成一个标点符号撑起一整页（孤字页）。
+# 开引号（" ' “ ‘）不在此列：它们出现在行首是合法的。
+LINE_START_FORBIDDEN = frozenset(
+    "，。、；：？！…·～）】》」』”’"
+    ",.;:!?)]}"
+)
+
+
+def _wrap_bubble_lines(
+    metrics: QFontMetrics, value: str, width: int
+) -> list[str]:
+    """Wrap ``value`` char-by-char into lines within ``width`` px (kinsoku-aware)."""
+    lines: list[str] = []
+    current = ""
+    for char in value:
+        candidate = current + char
+        if current and metrics.horizontalAdvance(candidate) > width:
+            if char in LINE_START_FORBIDDEN and len(current) > 1:
+                # 行首禁则：上一行末字符下沉，与闭标点同行，避免标点孤字行。
+                lines.append(current[:-1])
+                current = current[-1] + char
+            else:
+                lines.append(current)
+                current = char
+        else:
+            current = candidate
+    if current:
+        lines.append(current)
+    return lines
+
+
 def elide_bubble_text(
     metrics: QFontMetrics,
     text: str,
@@ -94,23 +127,14 @@ def elide_bubble_text(
     value = normalize_bubble_text(text)
     if not value:
         return ""
-    lines: list[str] = []
-    current = ""
-    for index, char in enumerate(value):
-        candidate = current + char
-        if current and metrics.horizontalAdvance(candidate) > width:
-            lines.append(current)
-            if len(lines) >= max_lines:
-                lines[-1] = metrics.elidedText(
-                    current + value[index:], Qt.TextElideMode.ElideRight, width
-                )
-                return "\n".join(lines)
-            current = char
-        else:
-            current = candidate
-    if current:
-        lines.append(current)
-    return "\n".join(lines[:max_lines])
+    lines = _wrap_bubble_lines(metrics, value, width)
+    if len(lines) > max_lines:
+        remainder = "".join(lines[max_lines:])
+        lines = lines[:max_lines]
+        lines[-1] = metrics.elidedText(
+            lines[-1] + remainder, Qt.TextElideMode.ElideRight, width
+        )
+    return "\n".join(lines)
 
 
 def bubble_label_size(
@@ -157,23 +181,18 @@ def paginate_bubble_text(
     value = normalize_bubble_text(text)
     if not value:
         return []
-    lines: list[str] = []
-    current = ""
-    for index, char in enumerate(value):
-        candidate = current + char
-        if current and metrics.horizontalAdvance(candidate) > width:
-            lines.append(current)
-            current = char
-        else:
-            current = candidate
-    if current:
-        lines.append(current)
+    lines = _wrap_bubble_lines(metrics, value, width)
     if len(lines) <= max_lines:
         return ["\n".join(lines)]
-    return [
-        "\n".join(lines[start : start + max_lines])
+    pages = [
+        lines[start : start + max_lines]
         for start in range(0, len(lines), max_lines)
     ]
+    if len(pages) >= 2 and len(pages[-1]) == 1 and len(pages[-2]) > 1:
+        # 孤行控制：最后一页只剩一行时，从前一页匀一行过来（3+1 → 2+2），
+        # 避免末页只有零星几个字、看起来像气泡被截断。
+        pages[-2], pages[-1] = pages[-2][:-1], [pages[-2][-1]] + pages[-1]
+    return ["\n".join(page) for page in pages]
 
 
 def bubble_rect_for_anchor(

--- a/pet/speech_bubble_text.py
+++ b/pet/speech_bubble_text.py
@@ -3,7 +3,8 @@
 
 批6-2 从 pet/speech_bubble.py 整体迁出（纯搬移，逻辑/默认值零改动）：
 - 文本规整与行数上限（normalize_bubble_text / bubble_max_lines）；
-- 省略与分页（elide_bubble_text / paginate_bubble_text）；
+- 省略与分页（elide_bubble_text / paginate_bubble_text，换行带避头尾禁则）；
+- 分页节奏与页码（page_dwell_ms / page_dots 与 PAGE_* 常量）；
 - 定位与尺寸（bubble_rect_for_anchor / breath_bubble_size_for_anchor /
   breath_bubble_size_for_scale）；
 - 自言自语图片清单（list_self_talk_images + SELF_TALK_IMAGE_SUFFIXES）。
@@ -193,6 +194,35 @@ def paginate_bubble_text(
         # 避免末页只有零星几个字、看起来像气泡被截断。
         pages[-2], pages[-1] = pages[-2][:-1], [pages[-2][-1]] + pages[-1]
     return ["\n".join(page) for page in pages]
+
+
+# —— 分页节奏与页码 ——
+# 每页停留时长按该页字数自适应：基础停留 + 每字阅读时长，钳制在
+# [PAGE_DWELL_MIN, PAGE_DWELL_MAX]。满页 3 行约 45-60 字 → 约 3.9-4.8s；
+# 稀疏短页（孤行重平衡后的两行短页）相应缩短，不再一刀切。
+PAGE_DWELL_BASE_MS = 1200
+PAGE_DWELL_PER_CHAR_MS = 60
+PAGE_DWELL_MIN_MS = 2500
+PAGE_DWELL_MAX_MS = 8000
+
+# 翻页过渡：淡出略快、淡入略慢，视觉更顺。
+PAGE_FADE_OUT_MS = 110
+PAGE_FADE_IN_MS = 150
+
+
+def page_dwell_ms(page_text: str) -> int:
+    """一页气泡文本的建议停留时长（按字数自适应）。"""
+    chars = len(str(page_text or "").replace("\n", ""))
+    dwell = PAGE_DWELL_BASE_MS + chars * PAGE_DWELL_PER_CHAR_MS
+    return max(PAGE_DWELL_MIN_MS, min(PAGE_DWELL_MAX_MS, dwell))
+
+
+def page_dots(index: int, total: int) -> str:
+    """页码圆点：当前页实心 ●、其余空心 ○；单页返回空串。"""
+    if total <= 1:
+        return ""
+    index = max(0, min(int(index), total - 1))
+    return " ".join("●" if i == index else "○" for i in range(total))
 
 
 def bubble_rect_for_anchor(

--- a/pet/throw_egg.py
+++ b/pet/throw_egg.py
@@ -19,6 +19,12 @@ from typing import Any
 # 更新角度且一碰就回正（用户实机要求，明确不要时间硬上限）。
 THROW_EGG_RECOVER_SPEED = 780.0  # px/s
 
+# 空中（未触碰边界/桌宠）继续跟随速度方向的最低速度。
+# 780 的贴地防抖阈值若也用于空中，会把"抛起后自然减速但未落地"的
+# 中段飞行角度提前冻结（用户实机反馈"慢下来鱼头就固定住了"）；空中没有
+# 贴地那种快速连续碰撞，跟随阈值可以低得多，只防近零速的 atan2 抖动。
+THROW_EGG_AIR_FOLLOW_SPEED = 150.0  # px/s
+
 
 class ThrowEggController:
     """管理“被击飞时头部跟随速度方向”的旋转会话。
@@ -51,13 +57,18 @@ class ThrowEggController:
     def update(self, vx: float, vy: float, touching_boundary: bool) -> None:
         """每 tick 由 _tick_throw_physics 调用；低速贴界则恢复正常姿态。
 
-        速度高于阈值时才更新角度（低于阈值保持当前角，防抖）；
-        速度低于阈值且触碰边界 → end()。不设飞行时间上限（用户明确要求）。
+        速度高于阈值时才更新角度（低于阈值保持当前角，防抖）；阈值分档：
+        触碰边界用 THROW_EGG_RECOVER_SPEED（贴地弹跳防抖），空中用
+        THROW_EGG_AIR_FOLLOW_SPEED（空中无连续碰撞，低速也继续跟随）。
+        速度低于贴地阈值且触碰边界 → end()。不设飞行时间上限（用户明确要求）。
         """
         if not self._active:
             return
         speed = math.hypot(vx, vy)
-        if speed >= THROW_EGG_RECOVER_SPEED:
+        follow_threshold = (
+            THROW_EGG_RECOVER_SPEED if touching_boundary else THROW_EGG_AIR_FOLLOW_SPEED
+        )
+        if speed >= follow_threshold:
             # 屏幕坐标 y 朝下：向右飞=90°、向下=180°、向上=0°、向左=270°。
             self._angle_deg = 90.0 + math.degrees(math.atan2(vy, vx))
         if speed < THROW_EGG_RECOVER_SPEED and touching_boundary:

--- a/pet/window.py
+++ b/pet/window.py
@@ -2312,7 +2312,20 @@ class PetWindow(QWidget, WindowFeatureGateMixin):
                         int(round(catalog.CANVAS_H * self.scale)),
                         self._squash_progress,
                     )
-                painter.drawPixmap(x, y, w, h, self._frame_pixmap)
+                # 彩蛋/探头旋转在 squash 期间必须保持：碰撞触发 220ms Q 弹时丢
+                # 旋转会让头槌飞行中的桌宠闪一瞬间回正姿态（实机观感反馈），
+                # 且 _sync_mask 的旋转路径一直在转——不转会导致画面与 mask
+                # 轮廓错位。路径与 mask 分支一致：平移到绘制矩形左上角后绕中心旋转。
+                effects_angle = getattr(self, '_effects_current_angle', None)
+                sq_angle = effects_angle() if callable(effects_angle) else 0.0
+                if abs(sq_angle) > 1e-6:
+                    painter.translate(x, y)
+                    sq_rect = QRect(0, 0, w, h)
+                    self._effects_paint(painter, sq_rect)
+                    painter.drawPixmap(0, 0, w, h, self._frame_pixmap)
+                    self._effects_paint_end(painter, sq_rect)
+                else:
+                    painter.drawPixmap(x, y, w, h, self._frame_pixmap)
             else:
                 # 落地对齐：整帧贴窗口底线；捕获头顶空间经 _content_frame_rect 上移
                 content_rect = _content_frame_rect(self)

--- a/tests/test_collision_window.py
+++ b/tests/test_collision_window.py
@@ -1028,6 +1028,70 @@ def test_real_collision_impulse_cancels_edge_probe_and_settle_arms_reentry(tmp_p
     win.close()
 
 
+def test_probe_active_soft_hit_displacement_is_discarded(tmp_path, app):
+    """探头会话期间软撞（非真实撞击）的分离位移不得移动窗口。
+
+    实机 bug：探头（PEEKING）稳态无 timer 归位，软撞位移把窗口顶偏后
+    桌宠"卡"在错误的露出量上（身体多露出/少露出一截）。探头会话期间
+    位置归探头控制器管；真实撞击仍进入 throw 并取消会话（上方测试覆盖）。
+    """
+    win, session = _make_pet_window(tmp_path, "pet_probe_soft")
+    avail = win.screen_available().availableGeometry()
+    local = win.character_local_region()
+    win.move(avail.left() - local.left(), 100)
+    win.cfg.set("edge_probe_enabled", True)
+    win.sync_optional_services()
+    probe = win._edge_probe
+    probe.on_release(was_dragging=True)
+    assert probe.active
+    x_before, y_before = win.x(), win.y()
+
+    # 软撞：dv 低于真实撞击阈值，但带分离位移 dx/dy。
+    soft_dv = win._collision_client._hit_min_dv / 2.0
+    msg = {"a": "pet_probe_soft", "b": "other", "pair": "other|pet_probe_soft",
+           "dvx_a": soft_dv, "dvy_a": 0.0, "dx_a": 5.0, "dy_a": 3.0}
+    win._on_collision_impulse(msg)
+
+    assert win.x() == x_before and win.y() == y_before  # 位置未被顶偏
+    assert probe.active is True                          # 探头会话不受影响
+    assert win._physics_mode is None                     # 软撞不进入 throw
+    win.close()
+
+
+def test_squash_paint_keeps_effects_rotation(tmp_path, app):
+    """碰撞 Q 弹（squash 220ms）期间彩蛋/探头旋转不丢：头槌被撞不闪回正。
+
+    实机 bug：头槌（throw-egg）飞行中被其他桌宠碰撞触发 squash，
+    paintEvent 的 squash 分支不经过旋转管线 → 闪一瞬间回正再恢复
+    （_sync_mask 的旋转路径一直在转，丢失还造成画面与轮廓错位）。
+    """
+    win, session = _make_pet_window(tmp_path, "pet_squash_rot")
+    if win._frame_pixmap is None:
+        win._rebuild_frame()
+
+    class _FakeEgg:
+        active = True
+
+        def current_angle_deg(self):
+            return 90.0
+
+    win._throw_egg = _FakeEgg()
+    win._squash_active = True
+    win._squash_progress = 0.5
+
+    calls = []
+    orig = win._effects_paint
+
+    def _spy(painter, rect):
+        calls.append(1)
+        return orig(painter, rect)
+
+    win._effects_paint = _spy
+    win.grab()  # 触发 paintEvent（offscreen 可渲染，不经过 _rebuild_frame）
+    assert calls, "squash 分支绘制未经过旋转管线（实机：头槌被撞闪回正）"
+    win.close()
+
+
 def test_probe_collision_throw_arms_egg_and_rotation_follows_velocity(tmp_path, app):
     """批 D 集成：探头激活→真实撞击 arm 彩蛋→飞行整帧旋转跟随速度→落地停稳兜底恢复。"""
     win, session = _make_pet_window(tmp_path, "pet_probe_egg")

--- a/tests/test_speech_bubble.py
+++ b/tests/test_speech_bubble.py
@@ -120,6 +120,39 @@ def test_paginate_bubble_text_multiple_pages_keeps_full_content():
     assert "\n".join(pages_long).replace("\n", "") == char * 37
 
 
+def test_paginate_bubble_text_no_orphan_punctuation_page():
+    # 避头尾（kinsoku）：闭标点不允许出现在行首。无禁则时，15 字 + "！"
+    # 会让 "！" 被挤到第 4 行行首 → 第 2 页只剩一个 "！"（孤字页）。
+    _get_app()
+    font = QFont("Arial", 12)
+    metrics = QFontMetrics(font)
+    char = "测"
+    line_w = metrics.horizontalAdvance(char * 5)
+
+    text = char * 15 + "！"
+    pages = paginate_bubble_text(metrics, text, line_w, max_lines=3)
+    assert len(pages) == 2
+    for page in pages:
+        for line in page.split("\n"):
+            assert not line.startswith("！")
+    # 全文无损
+    assert "\n".join(pages).replace("\n", "") == text
+
+
+def test_paginate_bubble_text_rebalances_single_line_last_page():
+    # 孤行控制：末页只剩 1 行时从前一页匀一行（3+1 → 2+2）
+    _get_app()
+    font = QFont("Arial", 12)
+    metrics = QFontMetrics(font)
+    char = "测"
+    line_w = metrics.horizontalAdvance(char * 5)
+
+    pages = paginate_bubble_text(metrics, char * 16, line_w, max_lines=3)
+    assert len(pages) == 2
+    assert [len(page.split("\n")) for page in pages] == [2, 2]
+    assert "\n".join(pages).replace("\n", "") == char * 16
+
+
 def test_breath_size_for_content_short_text_matches_legacy():
     _get_app()
     bubble = PetSpeechBubble(style_id="breath_bubble")

--- a/tests/test_speech_bubble.py
+++ b/tests/test_speech_bubble.py
@@ -5,17 +5,23 @@ from __future__ import annotations
 from math import ceil
 from PySide6.QtCore import QRect, QSize
 from PySide6.QtGui import QFont, QFontMetrics
+from PySide6.QtTest import QTest
 from PySide6.QtWidgets import QApplication
 
+import pet.speech_bubble as speech_bubble_module
 from pet.speech_bubble import (
     BUBBLE_TEXT_COLUMN,
     BUBBLE_TEXT_SLACK,
+    PAGE_DWELL_MAX_MS,
+    PAGE_DWELL_MIN_MS,
     FlowLayout,
     PetSpeechBubble,
     bubble_label_size,
     bubble_max_lines,
     elide_bubble_text,
     normalize_bubble_text,
+    page_dots,
+    page_dwell_ms,
     paginate_bubble_text,
 )
 
@@ -151,6 +157,86 @@ def test_paginate_bubble_text_rebalances_single_line_last_page():
     assert len(pages) == 2
     assert [len(page.split("\n")) for page in pages] == [2, 2]
     assert "\n".join(pages).replace("\n", "") == char * 16
+
+
+def test_page_dwell_ms_scales_with_length():
+    # 短页钳到下限、满页（约 50 字）落在中段、超长页钳到上限
+    assert page_dwell_ms("") == PAGE_DWELL_MIN_MS
+    assert page_dwell_ms("短") == PAGE_DWELL_MIN_MS
+    mid = page_dwell_ms("字" * 50)
+    assert mid == 1200 + 50 * 60
+    assert PAGE_DWELL_MIN_MS < mid < PAGE_DWELL_MAX_MS
+    assert page_dwell_ms("字" * 500) == PAGE_DWELL_MAX_MS
+    # 换行符不计入字数
+    assert page_dwell_ms("字\n字") == page_dwell_ms("字字")
+
+
+def test_page_dots_rendering():
+    assert page_dots(0, 1) == ""
+    assert page_dots(0, 3) == "● ○ ○"
+    assert page_dots(1, 3) == "○ ● ○"
+    assert page_dots(2, 3) == "○ ○ ●"
+    # 越界索引钳到最后一页
+    assert page_dots(9, 2) == "○ ●"
+
+
+def test_paged_bubble_uses_adaptive_dwells_and_dots():
+    """多页气泡：逐页停留表与页数一致，页码指示为圆点。"""
+    _get_app()
+    bubble = PetSpeechBubble(style_id="classic_top")
+    text = "主人～DSH开始干活啦，人家会帮您盯着它的～" * 20
+    bubble.show_text(text, QRect(0, 0, 120, 120), 40000)
+    try:
+        assert len(bubble._pages) > 1
+        assert len(bubble._page_dwells) == len(bubble._pages)
+        for page, dwell in zip(bubble._pages, bubble._page_dwells):
+            assert dwell == page_dwell_ms(page)
+        assert bubble._page_indicator.text() == page_dots(0, len(bubble._pages))
+    finally:
+        bubble.dismiss()
+
+
+def test_paged_bubble_flip_fades_and_updates_dots(monkeypatch):
+    """翻页：淡出→换字→淡入走完后，文本/圆点页码更新且透明度复位。"""
+    _get_app()
+    # 动画时长压到 1ms，避免测试依赖真实动画时长
+    monkeypatch.setattr(speech_bubble_module, "PAGE_FADE_OUT_MS", 1)
+    monkeypatch.setattr(speech_bubble_module, "PAGE_FADE_IN_MS", 1)
+    bubble = PetSpeechBubble(style_id="classic_top")
+    text = "主人～DSH开始干活啦，人家会帮您盯着它的～" * 20
+    bubble.show_text(text, QRect(0, 0, 120, 120), 40000)
+    try:
+        pages = list(bubble._pages)
+        assert len(pages) > 1
+        bubble._on_page_timeout()
+        QTest.qWait(150)  # 等淡出 → 换字 → 淡入走完
+        assert bubble.label.text() == pages[1]
+        assert bubble._page_indicator.text() == page_dots(1, len(pages))
+        assert bubble._page_fade is None
+        assert bubble._label_opacity is not None
+        assert bubble._label_opacity.opacity() == 1.0
+    finally:
+        bubble.dismiss()
+
+
+def test_paged_bubble_reset_stops_fade_and_restores_opacity(monkeypatch):
+    """翻页动画进行中换内容：动画被打断、透明度复位，不会留下隐形 label。"""
+    _get_app()
+    # 拉长动画，保证 _reset_paging 落在动画进行中
+    monkeypatch.setattr(speech_bubble_module, "PAGE_FADE_OUT_MS", 60000)
+    bubble = PetSpeechBubble(style_id="classic_top")
+    text = "主人～DSH开始干活啦，人家会帮您盯着它的～" * 20
+    bubble.show_text(text, QRect(0, 0, 120, 120), 40000)
+    try:
+        bubble._on_page_timeout()
+        assert bubble._page_fade is not None  # 淡出进行中
+        bubble._reset_paging()
+        assert bubble._page_fade is None
+        assert bubble._label_opacity.opacity() == 1.0
+        assert bubble._pages == []
+        assert not bubble._page_timer.isActive()
+    finally:
+        bubble.dismiss()
 
 
 def test_breath_size_for_content_short_text_matches_legacy():

--- a/tests/test_throw_egg.py
+++ b/tests/test_throw_egg.py
@@ -121,6 +121,41 @@ def test_angle_debounces_below_speed_threshold():
     assert egg.current_angle_deg() == before
 
 
+def test_airborne_low_speed_keeps_following():
+    """空中（未触界）低速仍跟随速度方向：780 是贴地防抖阈值，不适用于空中。
+
+    用户实机反馈：抛起后自然减速但还未落地时，鱼头固定在最后一次角度
+    （视觉上像"变回探头角度"）。空中没有贴地那种快速连续碰撞，跟随
+    阈值降到 AIR_FOLLOW（150），只防近零速 atan2 抖动。
+    """
+    win = _FakeWin()
+    egg = ThrowEggController(win)
+    egg.arm()
+    egg.update(900.0, 0.0, False)
+    assert egg.current_angle_deg() == pytest.approx(90.0)
+    # 300 px/s 空中减速向右下：旧实现冻结在 90°，新实现继续跟随。
+    egg.update(300.0, 300.0, False)
+    assert egg.active
+    assert egg.current_angle_deg() == pytest.approx(135.0)
+    # 近零速（<150）空中仍防抖，且不会因"未触界"误恢复。
+    before = egg.current_angle_deg()
+    egg.update(100.0, 0.0, False)
+    assert egg.active
+    assert egg.current_angle_deg() == before
+
+
+def test_touching_boundary_still_uses_high_threshold():
+    """贴地/触界维持 780 高阈值：低速弹跳段不更新角度且一碰即回正。"""
+    win = _FakeWin()
+    egg = ThrowEggController(win)
+    egg.arm()
+    egg.update(900.0, 0.0, False)
+    # 300 px/s 触界：角度不跟随（若按空中阈值会更新到 135°），且低速触界回正。
+    egg.update(300.0, 300.0, True)
+    assert not egg.active
+    assert egg.current_angle_deg() == 0.0
+
+
 def test_low_speed_touching_boundary_recovers():
     win = _FakeWin()
     egg = ThrowEggController(win)


### PR DESCRIPTION
## 问题

实机反馈的三处观感问题（均与边缘探头 / 头槌彩蛋相关）：

1. **头槌飞行中被碰撞会闪一瞬间回正**：碰撞触发 220ms squash Q 弹时，`paintEvent` 的 squash 分支不经过特效旋转管线（`_sync_mask` 的旋转路径一直在转，画面与轮廓还会错位），squash 结束后旋转恢复——视觉上就是"闪一下回正再回到头槌角度"。
2. **探头状态被撞不飞、卡出错误身位**：PEEKING 稳态无 timer 归位，软撞（dv 低于真实撞击阈值）的分离位移把窗口顶偏后不会自动归位，桌宠停在错误的露出量上。
3. **头槌减速后鱼头固定成探头角度**：`THROW_EGG_RECOVER_SPEED=780` 的防抖阈值本为贴地弹跳设计（低速贴地连续碰撞会反复翻转方向），但同样冻结了空中低速段——抛起自然减速后鱼头不再跟随速度方向。

## 修复

- `pet/window.py`：squash 分支补上与 `_sync_mask` 一致的旋转路径（平移到绘制矩形左上角后绕中心旋转），仅在特效角非零时启用，零开销路径不变。
- `pet/collision_client.py`：探头会话激活且非真实撞击时丢弃分离位移（位置归探头控制器管）；真实撞击仍进入 throw 并取消会话，行为不变。
- `pet/throw_egg.py`：跟随阈值分档——触界维持 780（贴地防抖），空中降为 150 继续跟随（空中无连续碰撞，只需防近零速 atan2 抖动）。

## 验证

- 新增用例：squash 旋转管线 spy 断言（无修复时必红）、软撞位移丢弃（位置不变/会话不受影响/不进 throw）、空中低速继续跟随、触界维持高阈值回正
- 相关区（collision/throw_egg/edge_probe/architecture）77 条全绿；合并树上全量 pytest 1912 passed
- 实机复测：头槌连续被撞不再闪回正；探头软撞不再卡身位；低速飞行鱼头持续跟随

## 追加：气泡分页修复与体验优化

实机反馈：长消息分页时末页只剩一个标点（气泡显示 2/2 页却只有「！」），且每页固定时长停留、翻页硬切。

- **换行避头尾（kinsoku）**：逐字换行没有行首禁则，长句末尾的闭标点会被挤到下一行行首，正文恰好撑满一页时末尾标点独占一整页。现在闭标点不站行首（把上一行末字符拉下来同行），`elide` 与 `paginate` 合并为同一换行助手，两处行为不再分叉。
- **末页孤行重平衡**：末页只剩 1 行时从前一页匀一行（3+1 → 2+2），避免末页零星几字看起来像被截断。
- **逐页字数自适应停留**：`page_dwell_ms`（1200ms 基础 + 60ms/字，钳 2500-8000ms）取代固定 2200-5000ms 一刀切，满页约 4-5s、短页相应缩短。
- **翻页淡入淡出 + 圆点页码**：110ms 淡出 → 换字 → 150ms 淡入取代硬切；页码从「1/3」数字改为圆点（● ○ ○）。`_reset_paging` / `hideEvent` / `show_image` 三条路径都会打断动画并复位透明度，不留透明 label；透明度效果懒创建，单页气泡零开销。

### 验证（气泡部分）

- 新增 7 个用例：标点孤字页、孤行重平衡、停留时长分级、圆点渲染、分页集成、翻页动画走完、动画打断兜底（动画时长 monkeypatch 到 1ms，不赌真实时序）
- 合并树上全量 pytest 1905 passed / 8 skipped，ruff 干净
