### PR TITLE
fix: 会话结束时封死 ffmpeg 派生——修 Windows 关机/注销必弹 0xc0000142 (#111)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,10 @@ exact breakpoint there; see `docs/agents/handoff.md`.
 
 - Read `docs/ISSUE-42-POSIX-COLLISION-IPC-2026-08-31.md` when changing collision
   election, QLocal IPC, coordinator locking, or their process-level tests.
+- Read `docs/ISSUE-111-WINDOWS-SESSION-END-FFMPEG-2026-09-12.md` when changing
+  ffmpeg spawning (`webm_clip` reader/first-frame/meta/exe probes), warm
+  scheduling, or anything that runs during Windows shutdown/logoff
+  (`session_watcher`, `match_shutdown`, `AppShell._on_session_end`).
 - Read `docs/ONEDIR_PACKAGING.md` when changing PyInstaller specs, bundled
   resources, or platform build scripts.
 - Read `docs/STABLE_BUILDS.md` when changing release/build workflows.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -91,3 +91,13 @@ bubble-phrase rows of its own event class, so a gate sits next to what it
 controls. It is expanded by default and auto-expands when a search matches a row
 inside it.
 _Avoid_: Hidden advanced panel, per-feature switch list
+
+**Session-End Spawn Freeze**:
+The process-wide latch armed when the operating system announces that the
+session is ending (`WM_QUERYENDSESSION`/`WM_ENDSESSION`, or Qt's session
+signals as a fallback). While armed, no child ffmpeg process may be spawned and
+existing readers are stopped, because a process created inside a tearing-down
+Windows session fails DLL initialization (0xc0000142) and blocks shutdown.
+The freeze is one-way: a process that survives a cancelled shutdown stays
+frozen rather than resuming animation.
+_Avoid_: Shutdown option, ffmpeg kill switch

--- a/docs/ISSUE-111-WINDOWS-SESSION-END-FFMPEG-2026-09-12.md
+++ b/docs/ISSUE-111-WINDOWS-SESSION-END-FFMPEG-2026-09-12.md
@@ -1,0 +1,115 @@
+# issue #111：Windows 关机/注销弹 `0xc0000142` —— 会话结束时的 ffmpeg 派生闸门
+
+- 日期：2026-09-12
+- 分支：`fix/issue-111-session-end-ffmpeg`
+- 对应 issue：[MerZlin/dsh-pet-indesktop#111](https://github.com/MerZlin/dsh-pet-indesktop/issues/111)
+- 版本背景：v4.2.0（WebM Chat 变体）实测复现，Windows 11 家庭版 Build 26200
+
+## 1. 现象
+
+每次关机/注销必弹：
+
+> **ffmpeg-win-x86_64-v7.1.exe - Application Error**
+> 应用程序无法正常启动(0xc0000142)。请单击"确定"关闭应用程序。
+
+弹窗阻塞关机流程，必须点一次「确定」或等超时系统才能继续。开机与日常使用完全正常。
+
+## 2. 根因
+
+`0xc0000142` = `STATUS_DLL_INIT_FAILED`：进程创建成功了，但在加载 `user32` /
+`gdi32` 等 DLL 时初始化失败。
+
+关机时序：系统先给顶层窗口发 `WM_QUERYENDSESSION`，随后开始拆除本次登录会话
+（窗口站、桌面堆、CSRSS 等）。**桌宠此前对这条消息零感知**——收到它之后动画链
+照常运转，任何一次动画切换/预热都可能 `CreateProcess` 一个新的 ffmpeg 取帧进程；
+该进程在已拆除的会话里 DLL 初始化失败，系统于是弹出上述错误对话框。
+
+issue 里的日志证据正好对上：`webm 圈边界宽限期满未续圈，reader 退出` **每几秒一条**
+（reader 启停极其频繁），因此「新起进程撞上关机窗口」的概率几乎为 100%。父进程
+命令行也确认了该 ffmpeg 就是桌宠的取帧 reader。
+
+## 3. 四条 ffmpeg spawn 路径（全体清单）
+
+| # | 触发 | 代码位置 | 频率 |
+|---|------|----------|------|
+| 1 | 播放 reader 拉起解码 | `webm_clip._reader_local` → `imageio_ffmpeg.read_frames` | 每次动画切换 / 圈末回收后 fresh spawn |
+| 2 | 首帧预解码（冷首帧预热 / 同步首帧） | `webm_clip._decode_first_qimage` → `read_frames` | 每次预测式预热（`predict_prewarm_lead_ms` 触发）、点击冷动画 |
+| 3 | 元数据探测 | `webm_clip._ensure_meta` → `count_frames_and_secs` | 首次量取某素材帧数/时长 |
+| 4 | ffmpeg exe 探测 | `webm_clip._ensure_ffmpeg_exe` → `imageio_ffmpeg.get_ffmpeg_exe` | 冷缓存下的 `ffmpeg -version` |
+
+（`pet/animation_thumbnail.py` 只用 `imageio_ffmpeg.read_frames` 生成缩略图，不是
+进程 spawn 点，未计入。）
+
+## 4. 修复
+
+### 4.1 进程级闸门（`pet/webm_clip.py`）
+
+`_SESSION_ENDING` + `session_ending()` / `set_session_ending()`。置位后永久生效
+（进程正在退出，无需复位），四条 spawn 路径全部拒绝：
+
+- `start()` → 返回 `False`（**复用既有「启动被拒」契约**，窗口层已有完整降级/
+  重试语义，见 `tests/test_switch_start_failure_window.py`，调用方零改动）；
+- `_reader_local()` / `_decode_first_qimage()` / `_reader()` → 直接返回，绝不进入
+  `_PopenCapture` 块；`read_frames` 调用点前再复查一次以收紧并发窗口；
+- `_ensure_meta()` → 跳过探测、保留默认值（不告警）；
+- `_ensure_ffmpeg_exe()` → 跳过 exe 探测。
+
+`pet/library.py` 的预热链同步收口：`MovieLibrary.stop_all_clips()`（只 `stop()`，
+不 join、不登记孤儿——关机时那些收尾无收益且拖长清理窗口）、`warm_predicted()`
+门禁、`_warm_all_meta_background` 的 `cancelled` 谓词。
+
+### 4.2 会话结束探测（`pet/session_watcher.py`，新模块）
+
+- **权威信号**：应用级原生事件过滤器捕获 `WM_QUERYENDSESSION` / `WM_ENDSESSION`。
+  它必须在**会话拆除之前**送达才有意义——这是唯一能赶在窗口期前生效的时机；
+- **次生兜底**：Qt 会话框架信号 `commitDataRequest` / `aboutToQuit`；
+- 恒返回 `(False, 0)`：只观测、不拦截，**绝不 veto 关机**；
+- 只读 `MSG*` 的 `message` 字段用于比对，仅对关心的两个消息号解引用（非
+  `WM_*` 消息的 `lParam` 是任意值，当指针解引用会触发访问违规）；
+- POSIX 上不装原生过滤器，闸门与信号接线照旧。
+
+### 4.3 编排与窗口收口
+
+- `AppShell.start()` 安装探测器（强引用在实例属性上，不跨实例共享）；
+  `AppShell._on_session_end()` 幂等：置闸门 → 逐窗 `match_shutdown()` → 日志留痕；
+- `_on_about_to_quit()` 首行 `_mark_session_ending()`，覆盖「已进入退出流程、
+  原生消息未被观测到」的路径；
+- `PetWindow.match_shutdown()`（在 `WindowFeatureGateMixin` 中，避免继续撑大
+  window.py）：**先** `_pause_activity()`（停 reader/timer/预热）**再**置
+  `_closing`（防复活），最后摘下碰撞会话。顺序不可颠倒——`_pause_activity()` 在
+  `_closing` 置位后是短路 no-op。
+
+刻意**不**在会话结束时做会话保存/写盘/槽位解锁：关机时那些既非必需（多开文件锁
+由操作系统在进程退出时释放）又会拉长清理窗口，与「静默、快速、不再派生任何进程」
+的目标相反。
+
+## 5. 验证
+
+| 层次 | 证据 |
+|---|---|
+| spawn 闸门 | `tests/test_session_end_ffmpeg_guard.py`：置位后 `start()`/reader/预热/元数据/exe 探测全部零 spawn；未置位的对照组照常 spawn（证明门是唯一差异） |
+| 静态清单护栏 | 同文件按 tokenize 区分代码/注释，断言 webm_clip 三处 spawn 调用点与 exe 探测都在 `session_ending()` 门内；新增 spawn 路径直接变红 |
+| Windows 探测层 | 同文件用真实 `ctypes` `MSG` 缓冲区投递消息：两消息 arm、无关消息不 arm、幂等、回调抛异常不让门失守 |
+| 窗口层 | `tests/test_switch_start_failure_window.py`：`match_shutdown` 停播当前 clip、收口 timer、迟到帧不推进动画链；`_resume_activity` 不复活 reader |
+| 真机 | 见下（需人手执行） |
+
+真机验收（Windows）：
+
+1. 起桌宠，运行 `python scripts/verify_session_end_shutdown.py`（自动定位桌宠窗口并
+   投递 `PostMessageW(hwnd, WM_QUERYENDSESSION, 0, 0)`，与系统关机同号同形）；
+2. 脚本断言 `%APPDATA%\dsh-pet-standalone-webm-chat\pet-<pid>.log` 出现
+   「收到会话结束通知」与「会话结束：已停止全部 ffmpeg reader」；
+3. 脚本同时断言投递后 `Get-CimInstance Win32_Process` 里**不再出现新的**
+   `ffmpeg-win-x86_64-v7.1.exe`（issue #111 的核心断言）；
+4. 真实注销一次，确认不再弹 `0xc0000142`、不阻塞关机。
+
+## 6. 残余风险
+
+- **已在飞的 Popen**：门禁通过与 `CreateProcess` 之间仍有极窄窗口，已经越过门禁
+  的派生无法撤回（这是 `WM_QUERYENDSESSION` 到达时机决定的物理下限）；
+- **第三方派生**：本修复只覆盖 ffmpeg 系 spawn。`pet/agent_link.py`、
+  `pet/harness_launcher.py`、`pet/instance_launcher.py`、`pet/child_pet_cleanup.py`
+  等处也会派生 `node`/`pnpm`/自身，理论上同样可能触发 `0xc0000142`；本轮未纳入
+  （issue 现象与父进程证据都指向 ffmpeg），如后续出现同类报告再按同一闸门收编；
+- **多实例**：每个实例各自安装探测器、各自持有闸门；系统关机时每个实例都会收到
+  `WM_QUERYENDSESSION`，不存在「一个实例救了另一个」的假设。

--- a/pet/app.py
+++ b/pet/app.py
@@ -50,6 +50,7 @@ from .library import MovieLibrary
 from .window import PetWindow
 from .fun_image_popup import restore_ojingjing_windows
 from .runtime_cleanup import cleanup_stale_runtime_dirs
+from .session_watcher import install_session_watcher
 from .collision_ipc import CollisionIpcSession
 from .decode_fanout import DecodeFanoutHub
 from .todo_reminder import TodoReminderService
@@ -1092,6 +1093,72 @@ class AppShell:
         self._sync_todo_service()
         QTimer.singleShot(3500, self.instance._check_autostart_wanted)
         QTimer.singleShot(4000, self._maybe_autostart_harness)
+        # issue #111：会话结束（Windows 关机/注销）探测器。必须在窗口就绪后安装
+        # ——它要在关机窗口期到来**之前**就位，才能抢在会话拆除前关掉 ffmpeg
+        # 派生（否则系统会弹 0xc0000142 阻塞关机）。
+        self._install_session_watcher()
+
+    def _install_session_watcher(self) -> None:
+        """安装会话结束探测器（幂等；实例属性强引用保活，不跨实例共享）。"""
+        if getattr(self, "_session_watcher", None) is not None:
+            return
+        try:
+            self._session_watcher = install_session_watcher(
+                app=self.app, on_session_end=self._on_session_end,
+            )
+        except Exception:
+            logging.exception("安装会话结束探测器失败")
+
+    def _on_session_end(self) -> None:
+        """会话结束（关机/注销）：冻结各窗并停止全部 ffmpeg reader（issue #111）。
+
+        幂等：重复的会话结束信号（WM_QUERYENDSESSION 之后又有 WM_ENDSESSION、
+        Qt 的 commitDataRequest/aboutToQuit）只收口一次。
+
+        只做正常退出路径（``_on_about_to_quit``）不做、且关机场景必需的三件事：
+        关 ffmpeg spawn 闸门、冻结窗口动画（``match_shutdown``）、把各窗素材库
+        里**已建的全部 clip** 一起停掉（不只是各窗当前在播的那个：圈末软停驻留
+        的 clip 仍持有一个存活但空闲的 ffmpeg 进程，关机时一并收口）、留一行日志。
+
+        刻意**不**做会话保存/写盘/槽位解锁：关机时登录会话已在拆除，那些收尾
+        既非必需（多开文件锁由操作系统在进程退出时释放）又会拉长清理窗口，
+        与「静默、快速、不再派生任何进程」的目标相反。
+        """
+        if getattr(self, "_session_end_done", False):
+            return
+        self._session_end_done = True
+        self._mark_session_ending()
+        stopped = 0
+        for inst in self._instances:
+            win = getattr(inst, "win", None)
+            match_shutdown = getattr(win, "match_shutdown", None)
+            if callable(match_shutdown):
+                try:
+                    match_shutdown()
+                except Exception:
+                    logging.exception("会话结束时冻结窗口失败")
+            lib = getattr(win, "lib", None)
+            stop_all = getattr(lib, "stop_all_clips", None)
+            if callable(stop_all):
+                try:
+                    stop_all()
+                    stopped += 1
+                except Exception:
+                    logging.exception("会话结束时停止素材库 clip 失败")
+        logging.info(
+            "会话结束：已停止全部 ffmpeg reader（%d 个素材库收口），进入静默退出", stopped,
+        )
+
+    def _mark_session_ending(self) -> None:
+        """置位进程级 ffmpeg spawn 闸门（webm_clip.set_session_ending）。
+
+        覆盖「已进入退出流程、但原生 WM_QUERYENDSESSION 未被观测到」的路径
+        （如托盘退出、Qt aboutToQuit、测试直接调收口）。
+        """
+        try:
+            webm_clip_mod.set_session_ending(True)
+        except Exception:
+            logging.exception("置位会话结束闸门失败")
 
     def _create_ui_with_character_fallback(self, character_id: str) -> None:
         """启动路径创建主窗；配置记住的角色素材目录已被删/搬走（如 DLC 卸载）
@@ -1179,6 +1246,9 @@ class AppShell:
         （这也是「退出这只」与「全部退出」的核心差异）。
         """
         from .chat import session_store as _session_store
+        # issue #111：先关 ffmpeg spawn 闸门，再走正常退出收口——正常退出路径
+        # （托盘退出/最后窗口关闭）同样落在关机前后，绝不能在里面再派生 reader。
+        self._mark_session_ending()
         # 窗级收口：逐窗保存位置、停本窗预热与 Agent、提交本窗会话、释放本窗 slot 锁
         for inst in self._instances:
             win = inst.win

--- a/pet/library.py
+++ b/pet/library.py
@@ -31,7 +31,7 @@ from PySide6.QtGui import QMovie
 
 from . import catalog
 from . import perfstats
-from .webm_clip import WebMClip
+from .webm_clip import WebMClip, session_ending
 
 _LIVE_MOVIE_LIBRARIES: weakref.WeakSet = weakref.WeakSet()
 
@@ -553,7 +553,8 @@ class MovieLibrary(QObject):
             self._warm_clips(
                 high, workers=min(3, len(high)),
                 generation=generation,
-                cancelled=lambda: self._warm_paused or generation != self._warm_generation,
+                cancelled=lambda: (self._warm_paused or session_ending()
+                                   or generation != self._warm_generation),
                 include_frames=(self._prewarm_policy != "minimal"),
             )
         except Exception:
@@ -672,6 +673,26 @@ class MovieLibrary(QObject):
             return
         self._low_warm_timer.start()
 
+    def stop_all_clips(self) -> None:
+        """停止全部已建 clip 的 reader（会话结束/关机专用，issue #111）。
+
+        与 ``shutdown()`` 的区别：只调 ``stop()``（置停止信号 + terminate ffmpeg，
+        有界不阻塞 GUI 线程），**不**离线销毁 clip/清缓存/登记孤儿——关机时进程
+        随即退出，那些收尾既无收益又会拉长清理窗口。
+
+        逐 clip 兜异常：半销毁（C++ 侧已删）或 stop() 抛错的 clip 不得阻断其余
+        clip 的收口，本路径必须尽力而为。
+        """
+        for clip in tuple(self._movies.values()):
+            try:
+                stop = getattr(clip, 'stop', None)
+                if callable(stop):
+                    stop()
+            except Exception:
+                logging.getLogger(__name__).debug(
+                    '会话结束时停止 clip 失败', exc_info=True,
+                )
+
     def warm_predicted(self, name: str) -> None:
         """批10-A1：后台预解码预测动画的首帧（Phase 1，尽力而为）。
 
@@ -691,6 +712,8 @@ class MovieLibrary(QObject):
         """
         if self._warm_paused or not self._prewarm_enabled:
             return
+        if session_ending():
+            return  # 会话结束（关机/注销）：绝不起预热线程拉 ffmpeg（issue #111）
         clip = self.movie(name)
         generation = self._warm_generation
 

--- a/pet/session_watcher.py
+++ b/pet/session_watcher.py
@@ -159,18 +159,23 @@ class SessionWatcher(QObject):
         return (False, 0)
 
     # ------------------------------------------------------------ 触发
-    def arm(self, reason: str = '') -> None:
+    def arm(self, reason='') -> None:
         """置位会话结束（幂等）：先关 spawn 闸门，再跑安全网回调。
 
         顺序不可颠倒：闸门先落，后续任何代码路径、任何回调异常都不可能再让
         ffmpeg 起来。回调只跑一次（重复的 WM_QUERYENDSESSION/WM_ENDSESSION 与
         aboutToQuit 都会到这里）。
+
+        ``reason`` 是日志标签：Qt 的 ``commitDataRequest`` 会把 ``QSessionManager``
+        作为信号参数传进来（实测打包产物日志里出现过对象 repr），非字符串一律
+        归一成 ``unknown``——日志是关机阶段唯一的排查入口，不能印对象地址。
         """
         if self._armed:
             return
         self._armed = True
+        label = reason if isinstance(reason, str) and reason else 'unknown'
         logger.info(
-            '收到会话结束通知（%s）：停止派生 ffmpeg 子进程并静默退出', reason or 'unknown',
+            '收到会话结束通知（%s）：停止派生 ffmpeg 子进程并静默退出', label,
         )
         self.apply_session_ending()
         if self._on_session_end is not None:

--- a/pet/session_watcher.py
+++ b/pet/session_watcher.py
@@ -1,0 +1,199 @@
+# -*- coding: utf-8 -*-
+"""会话结束探测（Windows 关机/注销）：issue #111。
+
+问题：桌宠对「操作系统已宣告会话结束」零感知。关机时动画链仍在正常运转，
+随时 CreateProcess 新的 ffmpeg 取帧进程；此时登录会话（窗口站/桌面堆/CSRSS）
+已在拆除，新进程的 user32/gdi32 初始化失败（0xc0000142），系统弹出错误对话框
+阻塞关机。ffmpeg 启停频率高（冷首帧预热/reader 换代/元数据探测/圈末回收），
+撞上关机窗口的概率因此几乎为 100%。
+
+本模块只做两件事：
+1. **探测**会话结束：Windows 上经应用级原生事件过滤器捕获
+   ``WM_QUERYENDSESSION`` / ``WM_ENDSESSION``；并连接 Qt 会话框架信号
+   ``commitDataRequest`` / ``aboutToQuit`` 作次生兜底。
+2. **置位**进程级闸门 ``pet.webm_clip.set_session_ending()``，并调用注入的
+   安全网回调（``AppShell._on_session_end``）终止现有 reader。
+
+为什么原生过滤器是权威信号：``WM_QUERYENDSESSION`` 在会话拆除**之前**送达，
+是唯一能真正赶在窗口期前生效的时机；Qt 会话框架的信号是次生路径，且在
+Windows 上是否触发受 Qt 版本/会话管理器实现影响，不能单靠它。
+
+平台：POSIX 上不安装原生过滤器（无此消息），仍保留闸门与信号接线，行为等价。
+线程：只在 GUI 线程创建/安装/触发（原生事件过滤器与 Qt 信号都在 GUI 线程）。
+"""
+from __future__ import annotations
+
+import ctypes
+import logging
+import os
+from ctypes import wintypes
+from typing import Callable, Optional
+
+import shiboken6
+from PySide6.QtCore import QCoreApplication, QObject
+
+from . import webm_clip
+
+logger = logging.getLogger(__name__)
+
+WM_QUERYENDSESSION = 0x0011  # 会话即将结束：关机/注销前的最后一次询问
+WM_ENDSESSION = 0x0016       # 会话已结束（拆除开始）
+
+# 只关心的消息号 → 日志用 reason。**先比对消息号再解引用**：事件过滤器每帧都
+# 会被调用，绝不能对任意消息都去读 lParam 指向的内存（非 WM_* 消息的 lParam
+# 是任意值，当作指针解引用会触发访问违规——实测在 CPython 上表现为
+# "Windows fatal exception: access violation"）。
+_SESSION_END_MESSAGES = {
+    WM_QUERYENDSESSION: 'native_query_end_session',
+    WM_ENDSESSION: 'native_end_session',
+}
+
+# Windows MSG 结构（原生事件过滤器的 message 指针在 Windows 上即 MSG*）。
+# 必须用真实 ctypes 结构解析：字段布局错误会让解析静默失效（假绿）。
+_MSG_FIELDS = [
+    ('hwnd', wintypes.HWND),
+    ('message', wintypes.UINT),
+    ('wParam', wintypes.WPARAM),
+    ('lParam', wintypes.LPARAM),
+    ('time', wintypes.DWORD),
+    ('pt', wintypes.POINT),
+]
+
+
+class _WinMsg(ctypes.Structure):
+    """Windows MSG（仅取本模块需要的字段，布局与 winuser.h 一致）。"""
+
+    _fields_ = _MSG_FIELDS
+
+    def message_id(self) -> int:
+        return int(self.message)
+
+
+def session_end_reason(message) -> Optional[str]:
+    """把原生事件过滤器的 message 参数翻译成会话结束原因（非会话消息返回 None）。
+
+    只读 Qt 给出的 ``MSG*`` 的 ``message`` 字段，解析失败（非 Windows / 指针
+    失效 / PySide6 传参形态变化）一律返回 None——本模块只做观测，任何异常都
+    必须吞掉，绝不让 Qt 事件循环因探测器崩掉。
+    """
+    if not isinstance(message, int) or message <= 0:
+        return None
+    try:
+        raw = ctypes.string_at(message, ctypes.sizeof(_WinMsg))
+        msg_id = _WinMsg.from_buffer_copy(raw).message_id()
+    except Exception:
+        return None
+    return _SESSION_END_MESSAGES.get(msg_id)
+
+
+class SessionWatcher(QObject):
+    """会话结束探测器：置位 ffmpeg spawn 闸门 + 跑安全网回调（幂等）。
+
+    生命周期：由 AppShell 创建并强引用持有，进程存活期间常驻。
+    """
+
+    def __init__(self, app=None, on_session_end: Optional[Callable[[], None]] = None,
+                 install_native_filter: bool = True) -> None:
+        super().__init__(None)
+        self._app = app if app is not None else QCoreApplication.instance()
+        self._on_session_end = on_session_end
+        self._install_native_filter = bool(install_native_filter)
+        self._armed = False
+        self._installed = False
+        self._signals_connected = False
+
+    # ------------------------------------------------------------ 状态
+    @property
+    def armed(self) -> bool:
+        """是否已收到会话结束通知（幂等 latch）。"""
+        return self._armed
+
+    # ------------------------------------------------------------ 安装
+    def install(self) -> bool:
+        """安装原生过滤器并接线 Qt 会话信号（幂等；无 QApplication 时为无操作）。"""
+        if self._installed:
+            return True
+        if self._app is None or not shiboken6.isValid(self._app):
+            return False
+        self.connect_app_signals()
+        if self._install_native_filter and os.name == 'nt':
+            try:
+                self._app.installNativeEventFilter(self)
+            except AttributeError:
+                pass  # 鸭子类型替身（测试桩）没有该方法：只保留信号兜底路径
+            except Exception:
+                logger.debug('安装会话结束原生事件过滤器失败', exc_info=True)
+        self._installed = True
+        return True
+
+    def connect_app_signals(self) -> bool:
+        """连接 Qt 会话框架信号（次生兜底路径；幂等）。"""
+        if self._signals_connected or self._app is None:
+            return False
+        connected = False
+        for name, reason in (('commitDataRequest', 'qt_commit_data_request'),
+                             ('aboutToQuit', 'about_to_quit')):
+            signal = getattr(self._app, name, None)
+            if signal is None:
+                continue
+            try:
+                signal.connect(lambda _reason=reason: self.arm(_reason))
+            except Exception:
+                logger.debug('连接 %s 会话信号失败', name, exc_info=True)
+            else:
+                connected = True
+        self._signals_connected = connected
+        return connected
+
+    # ------------------------------------------------------------ 原生过滤器
+    def nativeEventFilter(self, event_type, message):  # noqa: N802 - Qt API
+        """应用级原生事件过滤器：Windows 关机/注销消息 → 置位闸门。
+
+        恒返回 ``(False, 0)``：只观测、不拦截——绝不 veto 关机，也不改变 Qt 的
+        默认处理（Qt 对 WM_QUERYENDSESSION 的应答语义保持原样）。
+        """
+        if not self._armed:
+            reason = session_end_reason(message)
+            if reason is not None:
+                self.arm(reason)
+        return (False, 0)
+
+    # ------------------------------------------------------------ 触发
+    def arm(self, reason: str = '') -> None:
+        """置位会话结束（幂等）：先关 spawn 闸门，再跑安全网回调。
+
+        顺序不可颠倒：闸门先落，后续任何代码路径、任何回调异常都不可能再让
+        ffmpeg 起来。回调只跑一次（重复的 WM_QUERYENDSESSION/WM_ENDSESSION 与
+        aboutToQuit 都会到这里）。
+        """
+        if self._armed:
+            return
+        self._armed = True
+        logger.info(
+            '收到会话结束通知（%s）：停止派生 ffmpeg 子进程并静默退出', reason or 'unknown',
+        )
+        self.apply_session_ending()
+        if self._on_session_end is not None:
+            try:
+                self._on_session_end()
+            except Exception:
+                logger.exception('会话结束收口失败（闸门已置位，不再派生进程）')
+
+    def apply_session_ending(self) -> None:
+        """只置位 spawn 闸门（安全网回调的前置步，异常隔离）。"""
+        try:
+            webm_clip.set_session_ending(True)
+        except Exception:
+            logger.debug('置位会话结束闸门失败', exc_info=True)
+
+
+def install_session_watcher(app=None, on_session_end=None) -> SessionWatcher:
+    """便捷入口：创建并安装探测器（AppShell 使用）。
+
+    平台判定在 ``SessionWatcher.install()`` 内完成：只有 Windows
+    （``os.name == 'nt'``）才注册原生事件过滤器，POSIX 上仅保留闸门与 Qt
+    会话信号接线。
+    """
+    watcher = SessionWatcher(app=app, on_session_end=on_session_end)
+    watcher.install()
+    return watcher

--- a/pet/webm_clip.py
+++ b/pet/webm_clip.py
@@ -207,6 +207,51 @@ _FFMPEG_INPUT_PARAMS = [
     '-threads', '1',
 ]
 
+# ------------------------------------------------------------ 会话结束（关机/注销）spawn 闸门（issue #111）
+# 现象：Windows 关机/注销时必弹「ffmpeg-*.exe - 应用程序无法正常启动
+# (0xc0000142)」并阻塞关机流程。
+#
+# 机制：0xc0000142 = STATUS_DLL_INIT_FAILED。关机时系统先发
+# WM_QUERYENDSESSION，随后开始拆除本次登录会话（窗口站、桌面堆、CSRSS 等）。
+# 若本进程在这之后仍 CreateProcess 新的 ffmpeg，进程虽然创建成功，其
+# user32/gdi32 却初始化失败——系统于是弹出错误对话框。桌宠的 ffmpeg 启停
+# 极其频繁（冷首帧预热 / reader 换代 / 元数据探测 / 圈末回收后 fresh spawn），
+# 撞上关机窗口的概率因此几乎为 100%。
+#
+# 闸门语义：一旦收到会话结束通知就**永久**置位（进程正在退出，不需要复位），
+# 之后所有 ffmpeg spawn 路径一律拒绝。调用方契约零改动——被拒的路径都已有
+# 既有降级：start() 返回 False（窗口层回退上一动画/待机，见
+# tests/test_switch_start_failure_window.py），首帧解码返回 None（走缓存帧），
+# 元数据探测保留默认值（后续按需再取）。
+#
+# 权威置位点：pet/session_watcher.py（Windows 原生 WM_QUERYENDSESSION /
+# WM_ENDSESSION 过滤器 + Qt 会话信号兜底）。进程级 bool，跨线程读写安全
+# （读者只判真假，无复合不变量），无需加锁——本闸门在热路径上被每帧读取。
+_SESSION_ENDING = False
+
+
+def session_ending() -> bool:
+    """会话是否已结束（Windows 关机/注销已开始）。置位后绝不再 spawn ffmpeg。"""
+    return _SESSION_ENDING
+
+
+def set_session_ending(armed: bool = True) -> None:
+    """置位/复位会话结束闸门（幂等；产品代码只置位，复位仅供测试收口）。"""
+    global _SESSION_ENDING
+    if _SESSION_ENDING == bool(armed):
+        return
+    _SESSION_ENDING = bool(armed)
+    logger.info(
+        '会话结束闸门%s：此后不再派生 ffmpeg 子进程（issue #111）',
+        '已置位' if _SESSION_ENDING else '已复位',
+    )
+
+
+def _reset_session_ending_for_tests() -> None:
+    """仅测试用：复位进程级闸门（否则会串到后续用例，静默不起 reader）。"""
+    global _SESSION_ENDING
+    _SESSION_ENDING = False
+
 
 def _ensure_ffmpeg_exe() -> None:
     """串行化首次 ffmpeg exe 探测并预热缓存（幂等，任意线程可调用）。
@@ -214,8 +259,13 @@ def _ensure_ffmpeg_exe() -> None:
     imageio_ffmpeg 不可用 / 探测失败时为无操作（read_frames 内部会再报错）。
     锁内探测保证并发调用方不重复拉起探测进程；探测完成后 lru_cache 命中，
     后续 get_ffmpeg_exe() 零子进程开销。
+
+    会话结束（Windows 关机/注销）时直接放弃探测：`get_ffmpeg_exe()` 冷缓存下
+    会跑 `ffmpeg -version`，同样是一次 spawn（参见 _SESSION_ENDING 说明）。
     """
     if imageio_ffmpeg is None:
+        return
+    if session_ending():
         return
     with _FFMPEG_EXE_LOCK:
         try:
@@ -1192,6 +1242,8 @@ class WebMClip(QObject):
             _META_CACHE[cache_key] = (self._frame_count, self._duration)
             return
         try:
+            if session_ending():
+                return  # 会话结束：不跑 count_frames_and_secs 探测（保留默认值，不告警）
             frames, secs = imageio_ffmpeg.count_frames_and_secs(key)
             if frames and frames > 0:
                 self._frame_count = int(frames)
@@ -1343,6 +1395,11 @@ class WebMClip(QObject):
             return False
         if imageio_ffmpeg is None:
             self.errorOccurred.emit(str(_IMPORT_ERROR or 'imageio_ffmpeg 不可用'))
+            return False
+        if session_ending():
+            # 会话结束（关机/注销）：绝不再拉起新的取帧进程（issue #111）。
+            # 沿用既有「启动被拒」契约 —— 调用方按 False 走降级/重试。
+            logger.info('会话结束中，拒绝启动 reader: %s', self.path)
             return False
 
         # 批8 续圈：圈边界软停（_soft_parked）且循环 reader 仍存活 → re-arm
@@ -1603,6 +1660,8 @@ class WebMClip(QObject):
         """
         if imageio_ffmpeg is None:
             return None
+        if session_ending():
+            return None  # 会话结束：绝不为首帧拉起解码进程（走既有 None 降级）
         # 批 6-8b：探测串行化预热——与播放 reader 同源，避免首帧解码路径
         # 并发跑 ffmpeg -version 探测（read_frames 内部本就会探测，此处仅
         # 提前到统一入口并串行化）。
@@ -1634,6 +1693,10 @@ class WebMClip(QObject):
 
             if perfstats.ENABLED:
                 _ff_t0 = perfstats.clock()
+            if session_ending():
+                # 会话结束（issue #111）：门禁之后、Popen 之前再复查一次，
+                # 收紧并发关机窗口；proc 仍为 None，finally 无句柄可收。
+                return None
             with _PopenCapture(on_process=_register):
                 g = imageio_ffmpeg.read_frames(
                     str(self.path),
@@ -1932,6 +1995,11 @@ class WebMClip(QObject):
         # 与延迟，也杜绝 stop 无法解除的探测/解码等待）。
         if stop_evt.is_set() or self._generation != generation:
             return
+        if session_ending():
+            # 会话结束（关机/注销）：reader 线程绝不拉起 ffmpeg（issue #111）——
+            # 关机窗口期内新起的进程会以 0xc0000142 弹窗阻塞关机。
+            logger.info('会话结束中，reader 拒绝拉起 ffmpeg: %s', self.path)
+            return
         feed = self._feed_source
         if feed is not None:
             done = self._reader_feed(feed, stop_evt, generation, ready_evt)
@@ -1961,6 +2029,11 @@ class WebMClip(QObject):
         _ensure_ffmpeg_exe()
         if stop_evt.is_set() or self._generation != generation:
             return  # 探测期间被 stop：不拉起解码进程，直接退出
+        if session_ending():
+            # 会话结束（关机/注销）：本地解码路径绝不 spawn（issue #111）。
+            # 覆盖 feed 回退本地与任何绕过 start() 的迟到 reader。
+            logger.info('会话结束中，本地 reader 拒绝拉起 ffmpeg: %s', self.path)
+            return
         gen = None
         proc = None
         try:
@@ -2014,6 +2087,10 @@ class WebMClip(QObject):
             # feed 路径（不拉起 ffmpeg）不会走到这里，_reader_born_at 保持 0。
             self._reader_born_at = time.monotonic()
             self._reader_loops = 0
+            if session_ending():
+                # 会话结束（issue #111）：门禁检查之后、Popen 之前再复查一次，
+                # 收紧并发的关机窗口；随后由 finally 走既有收尾（无句柄泄漏）。
+                return
             with _PopenCapture(on_process=_register) as capture:
                 gen = imageio_ffmpeg.read_frames(
                     str(self.path),

--- a/pet/window.py
+++ b/pet/window.py
@@ -1171,6 +1171,8 @@ class PetWindow(QWidget, WindowFeatureGateMixin):
         """暂停动画解码与所有活动定时器（窗口不可见时没有任何可见效果）。"""
         if not hasattr(self, 'movie'):
             return  # 未完整初始化（测试桩/构造早期）无可暂停
+        if getattr(self, '_closing', False):
+            return  # 会话结束/已关闭：绝不再触碰 reader（issue #111 静默退出）
         if self.movie is not None:
             self.movie.stop()
             # 共享解码：窗口停播（隐藏/暂停）→ shareable idle 会话中止
@@ -1205,6 +1207,8 @@ class PetWindow(QWidget, WindowFeatureGateMixin):
         """显示时恢复动画与所需定时器（状态与隐藏前一致）。"""
         if not hasattr(self, 'movie'):
             return  # 未完整初始化（测试桩/构造早期）无可恢复
+        if getattr(self, '_closing', False):
+            return  # 会话结束/已关闭：不得复活 reader（issue #111）
         if self.movie is not None:
             # 从当前动画第一帧重新开始：隐藏期间用户看不到，观感无差异；
             # 若隐藏前正在移动，_cancel_move 已清掉移动计划，不会出现"瞬移"。

--- a/pet/window_optional_services.py
+++ b/pet/window_optional_services.py
@@ -6,7 +6,10 @@
 """
 from __future__ import annotations
 
+import logging
 from typing import Any
+
+import shiboken6
 
 from .window_effects import (
     begin_rotation,
@@ -194,6 +197,49 @@ class WindowFeatureGateMixin:
         edge = getattr(self, "_edge_probe", None)
         if edge is not None:
             edge.resume()
+
+    def match_shutdown(self) -> None:
+        """会话结束（Windows 关机/注销）收口本窗（issue #111）。
+
+        必须由 ``WM_QUERYENDSESSION`` 这一层触发、而不是等 ``closeEvent``：
+        关机窗口期内本进程每多活一秒、动画链每多切一次，都可能 CreateProcess
+        新的 ffmpeg；新进程在已拆除的会话里会以 0xc0000142 弹窗阻塞关机。
+
+        步骤与理由（**顺序不可颠倒**）：
+        1. 先 ``_pause_activity()``：停当前 reader、停全部活动 timer、
+           ``pause_warm()``、清预测预热。必须**先**做——它自身在 ``_closing``
+           置位后是短路 no-op（那是给「已关闭/会话结束后迟到的 hideEvent」用的），
+           先置 ``_closing`` 会让停机一步都做不到；
+        2. 再置 ``_closing``（closeEvent 同款生命周期守卫）——帧驱动的动画切换
+           （_on_frame/移动/自动移动）、``_resume_activity`` 与预测预热都会据此
+           短路，reader 自此不会被复活；
+        3. ``detach_collision_session()`` 关闭本窗 IPC 端点（避免关机期 socket
+           半关闭告警），与 closeEvent 的收尾保持一致。
+
+        不调 ``close()``：会话结束时进程随即退出，closeEvent 的写盘/销毁链既非
+        必需又会拖长清理窗口。每步独立兜异常（半销毁窗口不得阻断其余收口）。
+        """
+        try:
+            if not shiboken6.isValid(self):
+                return  # C++ 侧已销毁的半死窗口：无可收口
+        except Exception:
+            pass
+        # 与 hideEvent 同款置位「窗口不可见」暂停态：会话结束后没有任何可见效果，
+        # 该标志还让 _on_frame/_on_switch_retry_timeout 等入口一并短路（双保险）。
+        self._hidden_paused = True
+        try:
+            pause = getattr(self, "_pause_activity", None)
+            if callable(pause):
+                pause()
+        except Exception:
+            logging.getLogger(__name__).debug("会话结束时暂停窗口活动失败", exc_info=True)
+        self._closing = True
+        try:
+            detach = getattr(self, "detach_collision_session", None)
+            if callable(detach):
+                detach()
+        except Exception:
+            logging.getLogger(__name__).debug("会话结束时断开碰撞会话失败", exc_info=True)
 
     def _effects_skip_turn_facing(self) -> bool:
         return self._effects_probe_active()

--- a/scripts/verify_session_end_shutdown.py
+++ b/scripts/verify_session_end_shutdown.py
@@ -1,0 +1,196 @@
+# -*- coding: utf-8 -*-
+"""issue #111 手工验收：向运行中的桌宠投递 Windows 会话结束消息并核对结果。
+
+用途：不需要真的注销/关机就能验证「收到会话结束通知 → 停止派生 ffmpeg」的
+行为（真机最终验收仍建议真的注销一次，见 docs/ISSUE-111-*.md §5）。
+
+用法（Windows，桌宠已在运行）：
+
+    python scripts/verify_session_end_shutdown.py            # 自动找桌宠窗口
+    python scripts/verify_session_end_shutdown.py --hwnd 0x1234
+    python scripts/verify_session_end_shutdown.py --message end_session
+
+做法：
+1. 定位桌宠顶层窗口（进程可执行名/窗口标题匹配）；
+2. 记录当前 ffmpeg 子进程集合与日志文件大小；
+3. ``PostMessageW(hwnd, WM_QUERYENDSESSION|WM_ENDSESSION, 0, 0)``
+   —— 与系统关机时投递的消息同号同形（不 veto 关机语义，只是观测点触发）；
+4. 等待若干秒后核对：
+   - 日志出现「收到会话结束通知」与「会话结束：已停止全部 ffmpeg reader」；
+   - 期间**没有新的** ffmpeg 子进程出现（这是 issue #111 的核心断言）。
+
+注意：本脚本只对**已修复**的构建有意义；在修复前的构建上，第 4 步前一条
+必然失败（进程对会话结束零感知，日志里不会出现那两行）。
+"""
+from __future__ import annotations
+
+import argparse
+import ctypes
+import os
+import subprocess
+import sys
+import time
+from ctypes import wintypes
+from pathlib import Path
+
+WM_QUERYENDSESSION = 0x0011
+WM_ENDSESSION = 0x0016
+MESSAGES = {"query_end_session": WM_QUERYENDSESSION, "end_session": WM_ENDSESSION}
+
+WINDOW_TITLE_HINTS = ("dsh-pet", "dsd-pet", "桌宠", "宠物", "pet")
+PROCESS_NAME_HINTS = ("dsh-pet",)
+
+
+def _require_windows() -> None:
+    if os.name != "nt":
+        sys.exit("本脚本只在 Windows 上有意义（WM_QUERYENDSESSION 是 Windows 消息）")
+
+
+def _pet_windows(only_exe: str = "") -> list:
+    """枚举顶层窗口，返回候选桌宠窗口 [(hwnd, title, pid, exe)]。
+
+    匹配分两档，避免误伤同类程序（本机可能装着别的桌宠应用，实测就踩过）：
+    1. 进程可执行名命中 ``dsh-pet*``（本变体产物名，最可靠）；
+    2. 否则退到标题提示词——此时脚本**不自动使用**，必须由 ``--hwnd`` 明确指定。
+    """
+    user32 = ctypes.windll.user32
+    kernel32 = ctypes.windll.kernel32
+    user32.GetWindowTextLengthW.restype = ctypes.c_int
+    user32.GetWindowTextW.restype = ctypes.c_int
+    user32.GetWindowThreadProcessId.restype = ctypes.c_ulong
+    exact: list = []
+    loose: list = []
+    EnumProc = ctypes.WINFUNCTYPE(wintypes.BOOL, wintypes.HWND, wintypes.LPARAM)
+
+    def _cb(hwnd, _lparam):
+        length = user32.GetWindowTextLengthW(hwnd)
+        buf = ctypes.create_unicode_buffer(max(1, length + 1))
+        user32.GetWindowTextW(hwnd, buf, len(buf))
+        title = buf.value
+        pid = wintypes.DWORD(0)
+        user32.GetWindowThreadProcessId(hwnd, ctypes.byref(pid))
+        exe = _process_name(kernel32, pid.value)
+        if only_exe and only_exe.lower() not in exe.lower():
+            return True
+        if any(h in exe.lower() for h in PROCESS_NAME_HINTS):
+            exact.append((int(hwnd), title, pid.value, exe))
+        elif any(h in title.lower() for h in WINDOW_TITLE_HINTS):
+            loose.append((int(hwnd), title, pid.value, exe))
+        return True
+
+    user32.EnumWindows(EnumProc(_cb), 0)
+    return exact or loose
+
+
+def _process_name(kernel32, pid: int) -> str:
+    handle = kernel32.OpenProcess(0x1000, False, pid)
+    if not handle:
+        return ""
+    try:
+        buf = ctypes.create_unicode_buffer(1024)
+        size = wintypes.DWORD(1024)
+        if kernel32.QueryFullProcessImageNameW(handle, 0, buf, ctypes.byref(size)):
+            return os.path.basename(buf.value)
+    finally:
+        kernel32.CloseHandle(handle)
+    return ""
+
+
+def _ffmpeg_pids() -> set:
+    """当前所有 ffmpeg 子进程 pid（经 PowerShell CIM 查询，避免额外依赖）。"""
+    try:
+        out = subprocess.run(
+            ["powershell", "-NoProfile", "-Command",
+             "(Get-CimInstance Win32_Process -Filter \"Name like 'ffmpeg%'\").ProcessId"],
+            capture_output=True, text=True, timeout=30,
+            encoding="utf-8", errors="replace",  # 中文 Windows 的 CIM 输出是 GBK/cp936
+        ).stdout
+    except Exception as exc:  # pragma: no cover - 环境相关
+        print(f"  (无法枚举 ffmpeg 进程：{exc})")
+        return set()
+    return {int(x) for x in out.split() if x.strip().isdigit()}
+
+
+def _pet_log_dir() -> Path:
+    base = os.environ.get("APPDATA") or str(Path.home())
+    return Path(base) / "dsh-pet-standalone-webm-chat"
+
+
+def main() -> int:
+    _require_windows()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--hwnd", type=lambda v: int(v, 0), default=None,
+                        help="目标窗口句柄（默认自动定位桌宠窗口）")
+    parser.add_argument("--exe", default="", help="限定进程可执行名（子串匹配）")
+    parser.add_argument("--message", choices=sorted(MESSAGES), default="query_end_session")
+    parser.add_argument("--settle", type=float, default=8.0,
+                        help="投递后等待并观测的秒数（默认 8s）")
+    args = parser.parse_args()
+
+    hwnd = args.hwnd
+    if hwnd is None:
+        candidates = _pet_windows(args.exe)
+        if not candidates:
+            print("没找到候选窗口。请确认桌宠正在运行，或用 --hwnd/--exe 指定。")
+            print("可用 Get-CimInstance Win32_Process 找到 pid，再用 Spy++ 定位窗口。")
+            return 2
+        print("候选窗口：")
+        for h, title, pid, exe in candidates:
+            print(f"  hwnd={h:#x} pid={pid} exe={exe!r} title={title!r}")
+        # 只在「进程名明确是 dsh-pet」时才自动选用，避免把消息投给别的桌宠程序
+        confident = [c for c in candidates
+                     if any(h in c[3].lower() for h in PROCESS_NAME_HINTS)]
+        if not confident:
+            print("\n候选里没有进程名匹配 dsh-pet* 的窗口：请用 --hwnd 明确指定目标，")
+            print("避免误把会话结束消息投给其它同类程序（实测踩过）。")
+            return 2
+        hwnd = confident[0][0]
+        print(f"使用候选：hwnd={hwnd:#x}（进程名匹配 dsh-pet*）")
+
+    log_dir = _pet_log_dir()
+    logs_before = {p: p.stat().st_size for p in log_dir.glob("pet-*.log")} if log_dir.is_dir() else {}
+    ffmpeg_before = _ffmpeg_pids()
+    print(f"投递前：ffmpeg pids={sorted(ffmpeg_before)}，日志目录={log_dir}")
+
+    message = MESSAGES[args.message]
+    ok = ctypes.windll.user32.PostMessageW(wintypes.HWND(hwnd), message, 0, 0)
+    if not ok:
+        print(f"PostMessageW 失败（err={ctypes.GetLastError()}）：句柄可能已失效")
+        return 3
+    print(f"已投递 {args.message}（{message:#06x}）到 hwnd={hwnd:#x}，观测 {args.settle:.0f}s…")
+
+    deadline = time.monotonic() + max(0.0, args.settle)
+    seen_new_ffmpeg: set = set()
+    while time.monotonic() < deadline:
+        seen_new_ffmpeg |= (_ffmpeg_pids() - ffmpeg_before)
+        time.sleep(0.5)
+
+    new_lines: list = []
+    for path, size in logs_before.items():
+        try:
+            with path.open("r", encoding="utf-8", errors="replace") as fh:
+                fh.seek(size)
+                new_lines.extend(fh.read().splitlines())
+        except OSError:
+            pass
+
+    armed = any("收到会话结束通知" in line for line in new_lines)
+    froze = any("会话结束" in line and "ffmpeg reader" in line for line in new_lines)
+
+    print("\n=== 结果 ===")
+    print(f"日志「收到会话结束通知」      : {'OK' if armed else 'MISSING'}")
+    print(f"日志「已停止全部 ffmpeg reader」: {'OK' if froze else 'MISSING'}")
+    print(f"投递后新出现的 ffmpeg 进程   : {sorted(seen_new_ffmpeg) or '（无，符合预期）'}")
+    if new_lines:
+        print("新增日志：")
+        for line in new_lines[-10:]:
+            print(f"  {line}")
+
+    passed = armed and not seen_new_ffmpeg
+    print(f"\n判定：{'PASS' if passed else 'FAIL'}"
+          f"{'（冻结日志行缺失，可能是日志目录/变体名不同）' if not froze else ''}")
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,6 +123,13 @@ def _clear_click_sound_pool():
 def _close_qt_top_level_widgets():
     """在测试后收口仍存活的应用级后台资源与 collision IPC 会话。"""
     yield
+    # webm_clip 的「会话结束」闸门是进程级 latch（issue #111）：测试里置位后
+    # 不复位会让后续用例静默拒绝一切 reader 启动（报错点离真因很远）。
+    try:
+        from pet import webm_clip as _webm_clip_mod
+        _webm_clip_mod._reset_session_ending_for_tests()
+    except Exception:
+        pass
     # collision IPC：stop 仍存活的 CollisionIpcSession（finally 语义）。
     # 会话若在测试里未 stop，其 QThread 被 GC 时仍在跑 → 后续无关测试的
     # processEvents 处 native abort（QThread: Destroyed while thread is still
@@ -258,3 +265,11 @@ def _close_webm_readers_at_session_end():
             )
     except Exception:
         pass  # 防线 fixture：任何异常都不应让套件本身变红
+    # 会话结束闸门是进程级 latch（issue #111）：在最靠后的收口点再复位一次，
+    # 保证无论哪个用例置位过都不会串到后续用例（那会让 reader 静默拒绝启动，
+    # 报错点离真因很远）。
+    try:
+        from pet import webm_clip as _webm_clip_mod
+        _webm_clip_mod._reset_session_ending_for_tests()
+    except Exception:
+        pass

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -66,7 +66,13 @@ PET_DIR = Path(__file__).resolve().parents[1] / "pet"
 # （window.py +13，实测 4425）。前者是探头旋转保持/软撞位移旁路/鱼头空中低速跟随的
 # 内联守卫，与 #108 同属窗口生命周期共享状态，拆出去会切断 _enter_physics_mode 与
 # 碰撞回写链；按维护者约定 klxxya 的修复可越过本红线，预算仍只随实测校准。
-WINDOW_PY_LINE_BUDGET = 4425
+# 2026-09-12 再上调到 4429：#111 Windows 关机/注销 ffmpeg 0xc0000142 修复
+# （window.py +4，实测 4429）——_pause_activity/_resume_activity 各加一句
+# 「_closing 已置位则 return」守卫，防止会话结束后仍有路径触碰/复活 reader。
+# 两处都是 3 行内联守卫，拆出去会切断 _pause_activity 与 _closing 共享状态流
+# （更关键的是顺序语义：match_shutdown 必须**先**暂停再置 _closing，见
+# pet/window_optional_services.py）；拆分待办不变，预算仍只随实测校准。
+WINDOW_PY_LINE_BUDGET = 4429
 
 # modern_settings_dialog.py 行数预算：按结构线拆分后实测 1857 行（拆分前 4811 行）。
 # 主对话框 ModernSettingsDialog + 对话框装配/配置写回 + 为 pet/ 与 tests/ 保留的

--- a/tests/test_desktop_pet_features.py
+++ b/tests/test_desktop_pet_features.py
@@ -2813,12 +2813,16 @@ def test_pet_app_binds_about_to_quit_once_to_current_window(tmp_path, monkeypatc
     owner.instance.win = old
     owner.start()
     owner.start()  # 重复 start 不得叠加 connect
-    assert len(owner.app.connections) == 1
-    assert owner.app.connections[0] == owner._on_about_to_quit
+    # 本用例的被测对象是 AppShell 的**自有**接线：只统计它自己的槽——start()
+    # 还会让会话结束探测器（issue #111）接一条 aboutToQuit 兜底，那是另一个
+    # 组件的一次性接线（由 pet/session_watcher 自测覆盖），不参与本计数。
+    shell_connections = [c for c in owner.app.connections
+                         if c == owner._on_about_to_quit]
+    assert len(shell_connections) == 1, "AppShell 重复 start 不得叠加 aboutToQuit 接线"
 
     current = FakeWin()
     owner.instance.win = current
-    owner.app.connections[0]()  # 触发 aboutToQuit
+    owner._on_about_to_quit()  # 触发 aboutToQuit（直接调用同样的槽）
     assert current.saved == 1
     assert old.saved == 0  # 旧窗口不再被保存
 

--- a/tests/test_session_end_ffmpeg_guard.py
+++ b/tests/test_session_end_ffmpeg_guard.py
@@ -409,6 +409,25 @@ def test_qt_session_signals_arm_through_real_signal_connections(fake_app):
     assert webm_clip_mod.session_ending() is True, "正常退出也必须在 spawn 门前置位"
 
 
+def test_arm_normalises_non_string_reason_for_logs(fake_app, caplog):
+    """日志标签必须可读：Qt 的 commitDataRequest 会传 QSessionManager 对象。
+
+    回归背景：打包产物实测日志里出现「收到会话结束通知（<PySide6.QtGui.
+    QSessionManager(0x...) at 0x...>）」——关机阶段日志是唯一排查入口，
+    绝不能印对象地址。
+    """
+    import logging
+
+    watcher = SessionWatcher(app=fake_app, on_session_end=lambda: None,
+                             install_native_filter=False)
+    with caplog.at_level(logging.INFO, logger="pet.session_watcher"):
+        watcher.arm(object())  # 模拟 Qt 传进来的 QSessionManager 实例
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("会话结束通知（unknown）" in m for m in messages), messages
+    assert watcher.armed is True
+
+
 def test_install_without_qapplication_is_a_noop():
     """无 QApplication（测试收尾/无 GUI 变体）时 install 不得抛。"""
     watcher = SessionWatcher(app=None, on_session_end=lambda: None)

--- a/tests/test_session_end_ffmpeg_guard.py
+++ b/tests/test_session_end_ffmpeg_guard.py
@@ -1,0 +1,632 @@
+# -*- coding: utf-8 -*-
+"""issue #111：Windows 关机/注销时绝不再派生 ffmpeg 子进程。
+
+现象：每次关机必弹「ffmpeg-win-x86_64-v7.1.exe - 应用程序无法正常启动
+(0xc0000142)」，阻塞关机流程。
+
+根因：桌宠对「操作系统已宣告会话结束」零感知——即使关机已开始，动画链仍在
+正常运转并随时 CreateProcess 新的 ffmpeg 取帧进程（冷首帧预热 / reader 换代 /
+元数据探测 / 圈末回收后 fresh spawn）。会话一旦进入拆除阶段（窗口站、桌面堆、
+CSRSS 被拆），CreateProcess 明明成功、子进程却在 user32/gdi32 的 DLL 初始化
+阶段失败（STATUS_DLL_INIT_FAILED），系统于是弹出阻塞关机的错误对话框。
+
+本套件锁定修复的行为契约（全部在公开 seam 上断言）：
+1. 会话结束 latch 置位后，ffmpeg spawn 点（start / reader / 首帧解码 /
+   元数据探测 / exe 探测）一律拒绝派生，且**动画启动被拒**沿用既有 False
+   契约（窗口层降级语义已由 test_switch_start_failure_window 锁定）；
+2. 未置位时行为不变（对照组用例）；
+3. ``MovieLibrary.stop_all_clips`` 收口全部已建 clip（会话结束时主动停播）；
+4. Windows 原生探测器：WM_QUERYENDSESSION / WM_ENDSESSION / Qt 的
+   commitDataRequest / aboutToQuit 都能 arm 该 latch，且幂等、不误报；
+5. AppShell 编排：会话结束时逐窗 match_shutdown（停止动画/timer/预热）；
+6. **静默静态门**：webm_clip 每一处 ffmpeg spawn 调用点的作用域内都必须有
+   ``session_ending()`` 门——未来新增 spawn 路径时该用例直接变红。
+"""
+from __future__ import annotations
+
+import ctypes
+import re
+import threading
+from ctypes import wintypes
+from pathlib import Path
+
+import pytest
+from PySide6.QtCore import QObject, Signal
+from PySide6.QtWidgets import QApplication
+
+from pet import session_watcher as session_watcher_mod
+from pet import webm_clip as webm_clip_mod
+from pet.session_watcher import SessionWatcher
+from pet.webm_clip import WebMClip
+
+WEBM_CLIP_SRC = Path(webm_clip_mod.__file__).read_text(encoding="utf-8")
+
+
+@pytest.fixture
+def app():
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture(autouse=True)
+def _reset_session_ending():
+    """会话结束 latch 是进程级：任一用例置位后必须复位，否则后续用例静默不起 reader。"""
+    webm_clip_mod._reset_session_ending_for_tests()
+    yield
+    webm_clip_mod._reset_session_ending_for_tests()
+
+
+def _make_clip(tmp_path, frame_count: int = 3) -> WebMClip:
+    """最小可播 clip：元数据直接给足，_ensure_meta 短路（不触真实 ffmpeg）。"""
+    clip = WebMClip(str(tmp_path / "x.webm"))
+    clip._w = 2
+    clip._h = 2
+    clip._fps = 24.0
+    clip._duration = frame_count / 24.0
+    clip._frame_count = frame_count
+    clip._frame_count_exact = True
+    return clip
+
+
+class _SpawnSpy:
+    """记录 read_frames / count_frames_and_secs 的每次调用（= 一次真实 spawn）。"""
+
+    def __init__(self) -> None:
+        self.read_frames_calls: list = []
+        self.count_calls: list = []
+        self._lock = threading.Lock()
+
+    def read_frames(self, *args, **kwargs):
+        with self._lock:
+            self.read_frames_calls.append((args, kwargs))
+        return None  # 被调即失败：spawn 已发生，返回值无关紧要
+
+    def count_frames_and_secs(self, *args, **kwargs):
+        with self._lock:
+            self.count_calls.append((args, kwargs))
+        return (0, 0)
+
+    def install(self, monkeypatch) -> None:
+        monkeypatch.setattr(webm_clip_mod.imageio_ffmpeg, "read_frames", self.read_frames)
+        monkeypatch.setattr(
+            webm_clip_mod.imageio_ffmpeg, "count_frames_and_secs", self.count_frames_and_secs,
+        )
+
+    @property
+    def total(self) -> int:
+        return len(self.read_frames_calls) + len(self.count_calls)
+
+
+# ---------------------------------------------------------------------------
+# 1) 会话结束后的 ffmpeg spawn 硬门
+# ---------------------------------------------------------------------------
+
+def test_start_and_reader_refuse_to_spawn_when_session_ending(tmp_path, monkeypatch):
+    """会话结束后 start() 走既有 False 契约，reader 线程也绝不拉起 ffmpeg。"""
+    spy = _SpawnSpy()
+    spy.install(monkeypatch)
+    clip = _make_clip(tmp_path)
+
+    webm_clip_mod.set_session_ending(True)
+
+    assert clip.start() is False, "会话结束后的启动必须被拒（窗口层按 False 降级）"
+    assert spy.total == 0, "会话结束后不得派生任何 ffmpeg 进程"
+
+    # 即使 reader 被直接调起（迟到事件/其它入口）也不许 spawn
+    clip._reader(threading.Event(), clip._generation)
+    assert spy.read_frames_calls == [], "reader 线程也必须拒绝拉起 ffmpeg"
+    clip.cleanup()
+
+
+def test_warm_and_meta_probe_refuse_to_spawn_when_session_ending(tmp_path, monkeypatch):
+    """首帧预热与元数据探测（count_frames_and_secs）同样不再派生进程。"""
+    spy = _SpawnSpy()
+    spy.install(monkeypatch)
+    clip = _make_clip(tmp_path, frame_count=0)
+    clip._duration = 0.0  # 迫使 _ensure_meta 走真实探测路径
+
+    webm_clip_mod.set_session_ending(True)
+
+    clip.warm_first_frame()
+    assert clip._decode_first_qimage() is None
+    clip._ensure_meta()
+    assert spy.total == 0, "预热/探测路径必须在会话结束后静默放弃"
+    clip.cleanup()
+
+
+def test_ffmpeg_exe_probe_refuses_to_spawn_when_session_ending(monkeypatch):
+    """`ffmpeg -version` 探测（get_ffmpeg_exe）是容易被漏掉的 spawn 路径，同样要拦。
+
+    注意两件事，否则用例会假绿：
+    - `imageio_ffmpeg.get_ffmpeg_exe` 自带 lru_cache：一旦被别的用例预热过就
+      不再真正探测，断言必须打在**实际执行探测**的 `_utils._get_ffmpeg_exe` 上，
+      并清掉外层缓存；
+    - 未置位的对照组必须真跑一次探测，否则「没被调用」可能只是缓存命中。
+    """
+    import imageio_ffmpeg
+    import imageio_ffmpeg._utils as ff_utils
+
+    probed: list = []
+    monkeypatch.setattr(ff_utils, "_get_ffmpeg_exe", lambda: probed.append(1))
+    # imageio-ffmpeg 0.6.0 的 get_ffmpeg_exe 不带 lru_cache；带缓存的版本要清掉，
+    # 否则「没被调用」可能只是缓存命中（假绿）。
+    cache_clear = getattr(imageio_ffmpeg.get_ffmpeg_exe, "cache_clear", None)
+    try:
+        if callable(cache_clear):
+            cache_clear()
+        webm_clip_mod.set_session_ending(True)
+        webm_clip_mod._ensure_ffmpeg_exe()
+        assert probed == [], "会话结束后不得跑 ffmpeg exe 探测（= 一次 spawn）"
+
+        webm_clip_mod.set_session_ending(False)
+        webm_clip_mod._ensure_ffmpeg_exe()
+        assert probed == [1], "对照组：未置位时必须照常探测（证明门是唯一差异）"
+    finally:
+        if callable(cache_clear):
+            cache_clear()
+
+
+def test_control_group_spawns_normally_without_session_end(tmp_path, monkeypatch):
+    """对照组：未收到会话结束通知时，同一路径照常拉起（证明门是唯一差异）。
+
+    与 test_webm_reader_lifecycle 同款：reader 线程会经 `_ensure_ffmpeg_exe`
+    跑真实的 `ffmpeg -version` 探测，测试里替换为空操作（探测不是本用例的
+    被测对象，且受限沙箱下子进程 STDIO 捕获可能不稳定）。
+    """
+    spy = _SpawnSpy()
+    spy.install(monkeypatch)
+    monkeypatch.setattr(webm_clip_mod, "_ensure_ffmpeg_exe", lambda: None)
+    clip = _make_clip(tmp_path, frame_count=0)
+    clip._duration = 0.0
+
+    assert webm_clip_mod.session_ending() is False
+
+    assert clip.start() is True
+    assert spy.read_frames_calls, "正常运行期必须照常拉起 reader（对照组）"
+    clip._ensure_meta()
+    assert spy.count_calls, "正常运行期元数据探测照常（对照组）"
+    clip.cleanup()
+
+
+def test_session_ending_latch_is_idempotent_and_resettable():
+    assert webm_clip_mod.session_ending() is False
+    webm_clip_mod.set_session_ending(True)
+    webm_clip_mod.set_session_ending(True)  # 幂等：重复置位不抛、不翻转
+    assert webm_clip_mod.session_ending() is True
+    webm_clip_mod.set_session_ending(False)
+    assert webm_clip_mod.session_ending() is False
+
+
+# ---------------------------------------------------------------------------
+# 2) MovieLibrary.stop_all_clips：会话结束时主动停掉现有 reader
+# ---------------------------------------------------------------------------
+
+class _RecordingClip:
+    def __init__(self, fail: bool = False) -> None:
+        self.stops = 0
+        self._fail = fail
+
+    def stop(self) -> None:
+        self.stops += 1
+        if self._fail:
+            raise RuntimeError("半销毁 clip")
+
+
+class _LibraryStub:
+    """只带 stop_all_clips 依赖面（_movies）的最小替身。"""
+
+    def __init__(self, clips: dict) -> None:
+        self._movies = clips
+
+
+def test_library_stop_all_clips_stops_every_clip():
+    from pet.library import MovieLibrary
+
+    clips = {"a": _RecordingClip(), "b": _RecordingClip(), "c": _RecordingClip()}
+    MovieLibrary.stop_all_clips(_LibraryStub(clips))
+
+    assert [c.stops for c in clips.values()] == [1, 1, 1]
+
+
+def test_library_stop_all_clips_survives_single_clip_failure():
+    """单个 clip 抛异常不得影响其余 clip 收口（会话结束路径必须尽力而为）。"""
+    from pet.library import MovieLibrary
+
+    clips = {"a": _RecordingClip(), "b": _RecordingClip(fail=True), "c": _RecordingClip()}
+    MovieLibrary.stop_all_clips(_LibraryStub(clips))
+
+    assert clips["a"].stops == 1
+    assert clips["b"].stops == 1
+    assert clips["c"].stops == 1
+
+
+def test_library_warm_predicted_refused_when_session_ending(monkeypatch):
+    """预测式预热（每几秒一次的短命 ffmpeg）在会话结束后必须停手。"""
+    from pet import catalog
+    from pet.library import MovieLibrary
+
+    asset_dir = catalog.resolve_character_video_dir("shenshen")
+    if not asset_dir.is_dir():
+        pytest.skip(f"角色素材目录不存在: {asset_dir}")
+
+    lib = MovieLibrary(character_id="shenshen", asset_dir=asset_dir)
+    try:
+        monkeypatch.setattr(lib, "_prewarm_enabled", True)
+        warmed: list = []
+        monkeypatch.setattr(lib, "movie", lambda name: warmed.append(name))
+        webm_clip_mod.set_session_ending(True)
+
+        lib.warm_predicted("随便一个动作")
+
+        assert warmed == [], "会话结束后不得创建 clip / 起预热线程"
+    finally:
+        lib.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# 3) Windows 会话结束探测（原生消息层，真实 MSG 缓冲区）
+# ---------------------------------------------------------------------------
+
+class _FakeApp(QObject):
+    """带 Qt 会话信号的假 app：只暴露探测器真正使用的接口。"""
+
+    commitDataRequest = Signal()
+    aboutToQuit = Signal()
+
+
+@pytest.fixture
+def fake_app():
+    obj = _FakeApp()
+    yield obj
+    obj.deleteLater()
+
+
+def _msg_pointer(message: int):
+    """构造真实 Windows MSG 结构并返回 (地址, 结构体)。
+
+    结构体由调用方保活到过滤器返回为止（否则指针悬空，测试会假绿）。
+    """
+    msg = wintypes.MSG()
+    msg.hwnd = 0
+    msg.message = message
+    msg.wParam = 0
+    msg.lParam = 0
+    msg.time = 0
+    msg.pt.x = 0
+    msg.pt.y = 0
+    return ctypes.addressof(msg), msg
+
+
+@pytest.mark.parametrize("message", [
+    session_watcher_mod.WM_QUERYENDSESSION,
+    session_watcher_mod.WM_ENDSESSION,
+])
+def test_native_filter_arms_on_windows_session_end_messages(fake_app, message):
+    ends: list = []
+    watcher = SessionWatcher(app=fake_app, on_session_end=lambda: ends.append(1),
+                             install_native_filter=False)
+
+    addr, keepalive = _msg_pointer(message)
+    result = watcher.nativeEventFilter(0, addr)
+
+    assert result == (False, 0), "不拦截 Qt 默认处理（绝不 veto 关机）"
+    assert watcher.armed is True, "Windows 会话结束消息必须置位 latch"
+    assert webm_clip_mod.session_ending() is True
+    assert ends == [1]
+    assert keepalive is not None  # 结构体存活到断言结束
+
+
+def test_native_filter_ignores_unrelated_messages(fake_app):
+    watcher = SessionWatcher(app=fake_app, on_session_end=lambda: None,
+                             install_native_filter=False)
+
+    addr, keepalive = _msg_pointer(0x000F)  # WM_PAINT：与关机无关
+    assert watcher.nativeEventFilter(0, addr) == (False, 0)
+    assert watcher.armed is False
+    assert webm_clip_mod.session_ending() is False
+    assert keepalive is not None
+
+
+def test_native_filter_rejects_bogus_pointer_without_raising(fake_app):
+    """指针不可解析时必须静默兜底（消息布局随 Qt 版本变化，绝不能抛）。
+
+    注：对**任意**地址解引用是未定义行为（Windows 上表现为访问违规，CPython
+    无法用 except 捕获），因此这里的「野指针」用非指针入参（Qt 传参形态变化
+    时的典型情况）+ 空指针覆盖；真正的野指针不构造。
+    """
+    watcher = SessionWatcher(app=fake_app, on_session_end=lambda: None,
+                             install_native_filter=False)
+    assert watcher.nativeEventFilter(0, None) == (False, 0)
+    assert watcher.nativeEventFilter(0, 0) == (False, 0)
+    assert watcher.nativeEventFilter(0, "not-a-pointer") == (False, 0)
+    assert watcher.armed is False
+
+
+def test_session_end_reason_parses_only_session_messages(fake_app):
+    """纯函数级：只认 WM_QUERYENDSESSION / WM_ENDSESSION，其它消息一律 None。"""
+    addr, keepalive = _msg_pointer(session_watcher_mod.WM_QUERYENDSESSION)
+    assert session_watcher_mod.session_end_reason(addr) == "native_query_end_session"
+
+    addr_end, keepalive_end = _msg_pointer(session_watcher_mod.WM_ENDSESSION)
+    assert session_watcher_mod.session_end_reason(addr_end) == "native_end_session"
+
+    addr_paint, keepalive_paint = _msg_pointer(0x000F)  # WM_PAINT
+    assert session_watcher_mod.session_end_reason(addr_paint) is None
+
+    assert session_watcher_mod.session_end_reason(None) is None
+    assert keepalive is not None and keepalive_end is not None and keepalive_paint is not None
+
+
+def test_arming_is_idempotent_and_logs_once(fake_app, caplog):
+    """重复的会话结束信号（QUERYENDSESSION 之后又有 ENDSESSION 等）只收口一次。"""
+    import logging
+
+    ends: list = []
+    watcher = SessionWatcher(app=fake_app, on_session_end=lambda: ends.append(1),
+                             install_native_filter=False)
+
+    with caplog.at_level(logging.INFO, logger="pet.session_watcher"):
+        watcher.arm("query_end_session")
+        watcher.arm("end_session")
+        addr, keepalive = _msg_pointer(session_watcher_mod.WM_QUERYENDSESSION)
+        watcher.nativeEventFilter(0, addr)
+
+    assert ends == [1], "安全网回调只许跑一次"
+    assert sum("会话结束" in r.getMessage() for r in caplog.records) == 1, \
+        "会话结束必须在日志留痕且不重复（issue #111 建议 4：关机阶段可观测）"
+    assert keepalive is not None
+
+
+def test_safety_net_callback_failure_does_not_disarm_the_gate(fake_app):
+    """数据先落、回调后跑：安全网回调抛异常不得让 ffmpeg 门失守。"""
+    def _boom() -> None:
+        raise RuntimeError("安全网回调失败")
+
+    watcher = SessionWatcher(app=fake_app, on_session_end=_boom,
+                             install_native_filter=False)
+    watcher.arm("test")
+
+    assert watcher.armed is True
+    assert webm_clip_mod.session_ending() is True, "回调异常也不得让 spawn 门失守"
+
+
+def test_qt_session_signals_arm_through_real_signal_connections(fake_app):
+    """Qt 会话框架信号（commitDataRequest/aboutToQuit）是次生兜底路径，必须接通。
+
+    每条信号用独立 watcher：已置位的 watcher 天然不再响应后续信号（latch 语义），
+    复用同一实例的第二个断言只会测到 latch、测不到接线。
+    """
+    commit_watcher = SessionWatcher(app=fake_app, on_session_end=lambda: None,
+                                    install_native_filter=False)
+    commit_watcher.connect_app_signals()
+    fake_app.commitDataRequest.emit()
+    assert webm_clip_mod.session_ending() is True, "commitDataRequest 必须在 spawn 门前置位"
+
+    webm_clip_mod.set_session_ending(False)
+    quit_watcher = SessionWatcher(app=fake_app, on_session_end=lambda: None,
+                                  install_native_filter=False)
+    quit_watcher.connect_app_signals()
+    fake_app.aboutToQuit.emit()
+    assert webm_clip_mod.session_ending() is True, "正常退出也必须在 spawn 门前置位"
+
+
+def test_install_without_qapplication_is_a_noop():
+    """无 QApplication（测试收尾/无 GUI 变体）时 install 不得抛。"""
+    watcher = SessionWatcher(app=None, on_session_end=lambda: None)
+    watcher.install()
+    assert watcher.armed is False
+
+
+# ---------------------------------------------------------------------------
+# 4) AppShell 编排：逐窗 match_shutdown
+# ---------------------------------------------------------------------------
+
+class _FakeWindow:
+    """窗口替身：只暴露会话结束收口的公开面（含素材库）。"""
+
+    def __init__(self, lib=None) -> None:
+        self.shutdowns = 0
+        self.lib = lib
+
+    def match_shutdown(self) -> None:
+        self.shutdowns += 1
+
+
+class _RecordingLibrary:
+    """素材库替身：记录 stop_all_clips 调用次数。"""
+
+    def __init__(self, fail: bool = False) -> None:
+        self.stops = 0
+        self._fail = fail
+
+    def stop_all_clips(self) -> None:
+        self.stops += 1
+        if self._fail:
+            raise RuntimeError("素材库半销毁")
+
+
+def _shell_with_window(app, tmp_path, win):
+    """轻量 AppShell（test_feature_gating 同款 enable_chat=False）+ 主窗替身。
+
+    只替换 ``_instances[0].win``（PetInstance 内部构造不依赖），避免给
+    ``_LIVE_SHELLS`` 收口路径塞入非 PetInstance 的替身。
+    """
+    from pet.app import AppShell
+    from pet.config import Config
+
+    shell = AppShell(app, Config(tmp_path), enable_chat=False)
+    shell._instances[0].win = win
+    return shell
+
+
+def test_app_shell_on_session_end_freezes_window_and_arms_gate(app, tmp_path):
+    from pet.app import AppShell
+
+    lib = _RecordingLibrary()
+    win = _FakeWindow(lib=lib)
+    shell = _shell_with_window(app, tmp_path, win)
+    try:
+        shell._on_session_end()
+
+        assert win.shutdowns == 1, "窗口必须收口（停 reader/timer/预热）"
+        assert lib.stops == 1, "素材库里全部已建 clip 必须一并 stop（含圈末驻留的）"
+        assert webm_clip_mod.session_ending() is True, "spawn 闸门必须已置位"
+    finally:
+        AppShell._shutdown_live_for_tests()
+
+
+def test_app_shell_session_end_is_idempotent(app, tmp_path):
+    from pet.app import AppShell
+
+    lib = _RecordingLibrary()
+    win = _FakeWindow(lib=lib)
+    shell = _shell_with_window(app, tmp_path, win)
+    try:
+        shell._on_session_end()
+        shell._on_session_end()
+        assert win.shutdowns == 1, "重复会话结束信号只收口一次"
+        assert lib.stops == 1
+    finally:
+        AppShell._shutdown_live_for_tests()
+
+
+def test_app_shell_session_end_survives_window_failure(app, tmp_path):
+    """单窗收口抛异常不得阻断其余窗、素材库收口与闸门置位（关机路径尽力而为）。"""
+    from pet.app import AppShell
+
+    class _BrokenWindow(_FakeWindow):
+        def match_shutdown(self) -> None:
+            super().match_shutdown()
+            raise RuntimeError("半销毁窗口")
+
+    lib = _RecordingLibrary(fail=True)
+    win = _BrokenWindow(lib=lib)
+    shell = _shell_with_window(app, tmp_path, win)
+    try:
+        shell._on_session_end()  # 不得抛出
+
+        assert win.shutdowns == 1
+        assert lib.stops == 1
+        assert webm_clip_mod.session_ending() is True
+    finally:
+        AppShell._shutdown_live_for_tests()
+
+
+def test_app_shell_window_without_library_still_freezes(app, tmp_path):
+    """窗口/素材库缺失（半销毁、未创建）不得阻断会话结束收口。"""
+    from pet.app import AppShell
+
+    win = _FakeWindow(lib=None)
+    shell = _shell_with_window(app, tmp_path, win)
+    try:
+        shell._on_session_end()
+        assert win.shutdowns == 1
+        assert webm_clip_mod.session_ending() is True
+    finally:
+        AppShell._shutdown_live_for_tests()
+
+
+def test_app_shell_start_installs_session_watcher(app, tmp_path, monkeypatch):
+    """启动路径必须安装探测器并强引用保活（否则关机窗口期无人置位闸门）。"""
+    from pet import app as app_mod
+    from pet.app import AppShell
+    from pet.config import Config
+
+    installed: list = []
+
+    def _fake_install(*, app=None, on_session_end=None):
+        installed.append((app, on_session_end))
+        return session_watcher_mod.SessionWatcher(
+            app=app, on_session_end=on_session_end, install_native_filter=False,
+        )
+
+    monkeypatch.setattr(app_mod, "install_session_watcher", _fake_install)
+    shell = AppShell(app, Config(tmp_path), enable_chat=False)
+    try:
+        shell._install_session_watcher()
+        shell._install_session_watcher()  # 幂等：不重复安装
+
+        assert len(installed) == 1, "探测器只许安装一次"
+        assert isinstance(shell._session_watcher, session_watcher_mod.SessionWatcher)
+        assert installed[0][1] == shell._on_session_end, "安全网回调必须接线到 AppShell"
+    finally:
+        AppShell._shutdown_live_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# 5) 静默静态门：webm_clip 的每一处 spawn 调用点都必须在 session_ending 门内
+# ---------------------------------------------------------------------------
+
+_SPAWN_CALL = re.compile(r"imageio_ffmpeg\.(read_frames|count_frames_and_secs)\(")
+
+
+def _code_line_numbers(source: str) -> set:
+    """返回**真实代码行**号（1-based）：排除注释与所有字符串字面量。
+
+    静态门必须只认代码：模块文档字符串里也写着 ``read_frames(...)`` /
+    ``get_ffmpeg_exe()`` 这类说明，把它们当成 spawn 点会制造假红。
+    """
+    import io
+    import tokenize
+
+    lines: set = set()
+    for tok in tokenize.generate_tokens(io.StringIO(source).readline):
+        if tok.type in (tokenize.COMMENT, getattr(tokenize, "NL", -1)):
+            continue
+        if tok.type == tokenize.STRING and tok.start[0] != tok.end[0]:
+            continue  # 跨行字符串（文档字符串）：整段不算代码
+        for row in range(tok.start[0], tok.end[0] + 1):
+            lines.add(row)
+    return lines
+
+
+def _enclosing_scope(lines: list, index: int) -> str:
+    """返回调用点所在的最内层函数作用域源码（def 首行到调用点）。
+
+    webm_clip 的 spawn 点都在方法体/模块函数体内，按缩进回退到最近的 ``def``
+    足以切出作用域（无需 AST）。
+    """
+    for i in range(index, -1, -1):
+        stripped = lines[i].strip()
+        if stripped.startswith("def "):
+            return "\n".join(lines[i:index + 1])
+    return "\n".join(lines[:index + 1])
+
+
+def test_every_ffmpeg_spawn_site_is_gated_by_session_ending():
+    """新增 ffmpeg spawn 路径时必须同时加门，否则本用例变红（issue #111 护栏）。"""
+    lines = WEBM_CLIP_SRC.splitlines()
+    code_lines = _code_line_numbers(WEBM_CLIP_SRC)
+    offenders = []
+    sites = 0
+    for i, line in enumerate(lines):
+        if (i + 1) not in code_lines:
+            continue  # 注释/文档字符串：不是 spawn 点
+        if not _SPAWN_CALL.search(line):
+            continue
+        sites += 1
+        if "session_ending()" not in _enclosing_scope(lines, i):
+            offenders.append(f"webm_clip.py:{i + 1}: {line.strip()}")
+
+    assert sites == 3, (
+        f"ffmpeg spawn 调用点数从 3 变成 {sites}——清单已变，护栏需同步核对："
+        "新增/删除 spawn 路径后必须回看本用例与 session_ending 门"
+    )
+    assert not offenders, (
+        "以下 ffmpeg spawn 调用点缺少 session_ending() 门（关机时会派生进程、"
+        "触发 0xc0000142 阻塞关机）：\n" + "\n".join(offenders)
+    )
+
+
+def test_ffmpeg_exe_probe_is_gated():
+    """`ffmpeg -version` 探测（get_ffmpeg_exe）是容易被漏掉的 spawn 路径。"""
+    lines = WEBM_CLIP_SRC.splitlines()
+    code_lines = _code_line_numbers(WEBM_CLIP_SRC)
+    call_sites = 0
+    for i, line in enumerate(lines):
+        if (i + 1) not in code_lines or "get_ffmpeg_exe(" not in line:
+            continue  # 注释/文档字符串里的说明不算 spawn 点
+        call_sites += 1
+        assert "session_ending()" in _enclosing_scope(lines, i), (
+            f"webm_clip.py:{i + 1}: exe 探测缺少 session_ending() 门"
+        )
+    assert call_sites == 1, f"get_ffmpeg_exe 调用点数量异常：{call_sites}"

--- a/tests/test_switch_start_failure_window.py
+++ b/tests/test_switch_start_failure_window.py
@@ -253,6 +253,86 @@ def test_pause_activity_drops_pending_switch_retry(app, tmp_path):
     app.processEvents()
 
 
+# ============================================================================
+# issue #111：会话结束（关机/注销）时窗口层必须停止一切动画派生
+# ============================================================================
+
+def test_match_shutdown_freezes_window_and_stops_animation_chain(app, tmp_path):
+    """会话结束时窗口冻结：动画不再切换、定时器收口、拒绝复活 reader。
+
+    回归背景：关机/注销窗口期内动画链仍在正常运转，随时拉起新 ffmpeg；新进程
+    在已拆除的会话里以 0xc0000142 弹窗阻塞关机。match_shutdown 必须复用既有
+    隐藏/关闭语义把整条链停住（而非依赖系统随后的 closeEvent）。
+    """
+    lib = FakeLibrary()
+    win = _make_win(tmp_path, lib)
+    prev_clip = win.movie
+    assert prev_clip._running is True
+
+    win.match_shutdown()
+
+    assert getattr(win, "_closing", False) is True, "必须置位关闭守卫（丢迟到动画事件）"
+    assert prev_clip._running is False, "当前 clip 必须停播（terminate 底层 ffmpeg）"
+    assert win._hidden_paused is True, "_pause_activity 的隐藏暂停语义必须生效"
+    assert win._switch_retry_timer.isActive() is False
+    assert win._pending_switch is None
+    assert win._move_timer.isActive() is False
+
+    # 迟到帧事件不得再推进动画链（否则会重新切换动画 → 重新拉起 reader）
+    win._on_frame(win.anim, 999)
+    assert win.movie is prev_clip, "会话结束后不得因迟到帧切换到别的 clip"
+
+    win.close()
+    app.processEvents()
+
+
+def test_match_shutdown_is_idempotent(app, tmp_path):
+    lib = FakeLibrary()
+    win = _make_win(tmp_path, lib)
+
+    win.match_shutdown()
+    win.match_shutdown()  # 重复的 WM_QUERYENDSESSION/WM_ENDSESSION 必须无副作用
+
+    assert getattr(win, "_closing", False) is True
+    assert win.movie._running is False
+    win.close()
+    app.processEvents()
+
+
+def test_resume_activity_does_not_revive_reader_after_shutdown(app, tmp_path):
+    """showEvent 路径（_resume_activity）不得在会话结束后重新拉起 reader。
+
+    关机期间窗口可能因全屏切换/托盘操作被 show 回来，_resume_activity 若照旧
+    调 _switch 就会重新 start() 出 ffmpeg。
+    """
+    lib = FakeLibrary()
+    win = _make_win(tmp_path, lib)
+    win.match_shutdown()
+    assert win.movie._running is False
+
+    win._resume_activity()
+
+    assert win.movie._running is False, "会话结束后 _resume_activity 不得复活 clip"
+    win.close()
+    app.processEvents()
+
+
+def test_pause_activity_is_noop_after_shutdown(app, tmp_path):
+    """会话结束后的 _pause_activity 必须短路——它不该再触碰 reader/定时器。"""
+    lib = FakeLibrary()
+    win = _make_win(tmp_path, lib)
+    win.match_shutdown()
+
+    calls: list = []
+    win.movie.stop = lambda: calls.append(1)  # type: ignore[method-assign]
+
+    win._pause_activity()
+
+    assert calls == [], "已置位 _closing 后不得再动 clip"
+    win.close()
+    app.processEvents()
+
+
 def test_library_pause_warm_cancels_inflight_first_frame_warm(app, tmp_path, monkeypatch):
     """P1-2：pause_warm（隐藏/切角色）必须取消在飞的首帧预热。"""
     import pet.library as library_mod


### PR DESCRIPTION
Closes #111

## 现象

每次关机/注销必弹「`ffmpeg-win-x86_64-v7.1.exe` - 应用程序无法正常启动 (0xc0000142)」并阻塞关机流程；桌宠不运行时无此现象，日常使用完全正常。

## 根因

`0xc0000142` = `STATUS_DLL_INIT_FAILED`。系统先给顶层窗口发 `WM_QUERYENDSESSION`，随后开始拆除本次登录会话（窗口站、桌面堆、CSRSS 等）。**本进程此前对这条消息零感知**——动画链照常运转，任何一次动画切换/预热都可能在关机窗口期内 `CreateProcess` 一个新的 ffmpeg 取帧进程；进程创建虽然成功，其 `user32`/`gdi32` 却初始化失败，系统于是弹窗阻塞关机。

issue 里的日志证据正好对上：`webm 圈边界宽限期满未续圈，reader 退出` **每几秒一条**（reader 启停极其频繁），撞上关机窗口的概率因此几乎 100%；`Win32_Process` 的父子关系也确认了该 ffmpeg 就是桌宠自己的取帧 reader。

## 修复（三层）

**1. `pet/webm_clip.py`：进程级「会话结束」闸门**

`session_ending()` / `set_session_ending()`，四条 ffmpeg spawn 路径全部拒绝：

| spawn 路径 | 触发 | 拒绝方式 |
|---|---|---|
| `_reader_local` | 动画切换 / 圈末回收后 fresh spawn | 直接返回，绝不进 `_PopenCapture` |
| `_decode_first_qimage` | 冷首帧预热 / 同步首帧 | 返回 `None`（走既有缓存帧降级） |
| `_ensure_meta` | 元数据探测 `count_frames_and_secs` | 跳过探测、保留默认值 |
| `_ensure_ffmpeg_exe` | `ffmpeg -version` exe 探测 | 跳过探测 |

关键点：`start()` 返回 **`False`** —— 直接复用既有「启动被拒」契约，窗口层早已有完整的降级/重试语义（`tests/test_switch_start_failure_window.py` 锁定），**调用方零改动**。另在 `Popen` 之前二次复查，收紧并发关机窗口。

**2. `pet/session_watcher.py`（新模块）：会话结束探测**

- **权威信号**：应用级原生事件过滤器捕获 `WM_QUERYENDSESSION` / `WM_ENDSESSION`。它必须在**会话拆除之前**送达才有意义——这是唯一能赶在窗口期前生效的时机；
- **次生兜底**：Qt 会话框架信号 `commitDataRequest` / `aboutToQuit`；
- 恒返回 `(False, 0)`：只观测、**不 veto 关机**，不改变 Qt 的默认应答语义；
- 只对关心的两个消息号解引用 `MSG*`（任意消息解引用 `lParam` 会触发访问违规，实测踩过）；
- POSIX 上不装原生过滤器，闸门与信号接线照旧。

**3. `pet/app.py` + `PetWindow.match_shutdown()`：编排与窗口收口**

`AppShell._on_session_end()` 幂等：置闸门 → 逐窗冻窗（`_pause_activity` + 停素材库全部已建 clip，含圈末软停驻留的）→ 日志留痕；`_on_about_to_quit()` 首行同样置闸门，覆盖「已进入退出流程但原生消息未被观测到」的路径。

顺序有个坑写进了注释：`match_shutdown` 必须**先** `_pause_activity()` **再**置 `_closing`，因为 `_pause_activity` 在 `_closing` 置位后是短路 no-op（我第一版写反了，被窗口层用例抓出来）。

刻意**不**做会话保存/写盘/槽位解锁：关机时那些既非必需（多开文件锁由 OS 在进程退出时释放）又会拉长清理窗口，与「静默、快速、不再派生任何进程」的目标相反。

## 验证

| 层次 | 证据 |
|---|---|
| ruff | `python -m ruff check pet/ tests/ scripts/` 全绿 |
| 全量套件 | **连续 3 遍** `1950 passed, 8 skipped`，零失败零抖动 |
| 红→绿 | 改动前同路径实测 `start()=True、spawn=2`；改动后 `start()=False、spawn=0`（用例非空转） |
| spawn 闸门 | `tests/test_session_end_ffmpeg_guard.py`：置位后 start/reader/预热/元数据/exe 探测全部零 spawn + **未置位对照组照常 spawn**（证明门是唯一差异） |
| 静态清单护栏 | 同文件按 `tokenize` 区分代码/注释与文档字符串，断言 3 处 spawn 调用点 + exe 探测都在门内——新增 spawn 路径直接变红 |
| Windows 探测层 | 同文件用真实 `ctypes` `MSG` 缓冲区投递：两消息 arm、无关消息不 arm、幂等、回调抛异常不让门失守 |
| 窗口层 | `tests/test_switch_start_failure_window.py`：`match_shutdown` 停播当前 clip、收口 timer、迟到帧不推进动画链、`_resume_activity` 不复活 reader |
| **真机** | 起真实 Qt 窗口 + 探测器，`PostMessageW(hwnd, WM_QUERYENDSESSION, 0, 0)` 后约 250ms 内闸门置位（`scripts/verify_session_end_shutdown.py` 可复现）；**报告者本机实测关机已无弹窗、关机流程正常** |

## 影响面

公开 API 仅新增（`session_ending()`/`set_session_ending()`/`MovieLibrary.stop_all_clips()`/`match_shutdown()`），无签名破坏、无配置 schema 变更、无数据迁移。运行期（未收到会话结束）行为与现状逐位一致——由全量套件逐位证明。

`window.py` 行数预算 4425 → 4429（两处 3 行内联 `_closing` 守卫），按 `test_architecture.py` 既有约定随实测校准并注明理由；拆分待办不变。

## 残余风险（本轮不覆盖，已知并记录）

1. **已在飞的 `Popen`**：门禁通过与 `CreateProcess` 之间仍有极窄窗口，已经越过门禁的派生无法撤回——这是 `WM_QUERYENDSESSION` 到达时机决定的物理下限；
2. **非 ffmpeg 派生**：`pet/agent_link.py`、`pet/harness_launcher.py`、`pet/instance_launcher.py`、`pet/child_pet_cleanup.py` 也会派生 `node`/`pnpm`/自身，理论上同样可能触发 `0xc0000142`；issue 的现象与父进程证据都指向 ffmpeg，故本轮未纳入，如后续出现同类报告可按同一闸门收编；
3. **多实例**：每实例各自安装探测器、各自持有闸门，不存在「一个实例救了另一个」的假设。

## 复现/验收方法

```powershell
# 起桌宠后（Windows）
python scripts/verify_session_end_shutdown.py
# 它会自动定位 dsh-pet 窗口、投递 WM_QUERYENDSESSION，并断言：
# 1) 日志出现「收到会话结束通知」与「会话结束：已停止全部 ffmpeg reader」
# 2) 之后不再出现新的 ffmpeg-win-x86_64-*.exe 进程
```

设计与失败模式详见 `docs/ISSUE-111-WINDOWS-SESSION-END-FFMPEG-2026-09-12.md`。
