### PR TITLE
feat: 灵动岛重做——事件动效/四边停靠/快捷卡片 + 果冻墙本进程直连碰撞

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -12,6 +12,16 @@ This project includes third-party software and assets subject to their respectiv
 - **Origin / Source Repository**: [MeteorNOX/DeepSeek-Balance-Whale-Widget](https://github.com/MeteorNOX/DeepSeek-Balance-Whale-Widget)
 - **License**: MIT License
 
+---
+
+## 2. Character Animation Assets（深深 / 小鲸鱼 webm 素材）
+
+- **Files**: `assets/characters/**`（640×360 / 24fps / VP9-alpha 透明 webm）
+- **Origin / Source Repository**: [PC2005-cloud/dsh-pet](https://github.com/PC2005-cloud/dsh-pet)（动作素材做法与素材来源；本项目经整理搬运）
+- **Notes**: 角色 OC「溟月」出自画师上善无形，素材由社区成员整理制作。
+  此类同人素材按 CC BY-NC-SA 类条款发布，**仅限个人非商业使用**，
+  使用须保留署名与来源，不得用于任何商业/盈利场景。
+
 ### MIT License Text
 
 ```text

--- a/pet/app.py
+++ b/pet/app.py
@@ -93,6 +93,25 @@ class _BalanceBridge(_BackgroundResult):
             self.owner._update_island_balance(payload)
 
 
+class _QuietBalanceBridge(_BackgroundResult):
+    """灵动岛卡片展开时的静默余额查询：只更新岛卡片，不冒泡、不播余额动画。"""
+
+    def __init__(self, owner):
+        super().__init__()
+        self.owner = owner
+        self.done.connect(self._apply)
+
+    def _apply(self, ok: bool, payload) -> None:
+        owner = self.owner
+        island = getattr(owner, "island", None) if owner is not None else None
+        if island is None or not shiboken6.isValid(island):
+            return
+        if ok:
+            owner._update_island_balance(payload, animate=False)
+        else:
+            island.set_balance_info(owner._island_tier_hint(), "余额查询失败")
+
+
 def _persona_picker(win):
     """Return an application-owned picker without extending PetWindow state."""
     try:
@@ -934,8 +953,13 @@ class AppShell:
         self._notification_click_callback = None
         self._toast_windows: list[DesktopNotification] = []
         self.island = None
+        self.island_collision = None  # 果冻墙：岛的静态碰撞体（island_collision.py）
         self._spawned_pet_count = 0
         self._balance_busy = False
+        # 静默余额查询（岛卡片展开）独立忙标志与节流时间戳；
+        # None = 从未查询过（不用 monotonic 绝对值做回拨算术）
+        self._quiet_balance_busy = False
+        self._quiet_balance_last: float | None = None
         self._balance_cache = None
         self._balance_bridge = None
         self._on_about_to_quit_connected = False
@@ -1160,6 +1184,7 @@ class AppShell:
         except Exception:
             logging.exception("置位会话结束闸门失败")
 
+
     def _create_ui_with_character_fallback(self, character_id: str) -> None:
         """启动路径创建主窗；配置记住的角色素材目录已被删/搬走（如 DLC 卸载）
         时回退默认角色重试一次，而不是直接弹错退出。默认角色也缺素材则照常
@@ -1211,6 +1236,9 @@ class AppShell:
           thinking 由 dsh_state 收敛后经联动管线补思考气泡/动画——对话开始的
           稳定触发点之一（与真人消息双保险，呈现管线自带同态去重）。
         """
+        island = getattr(self, "island", None)
+        if island is not None and shiboken6.isValid(island):
+            island.set_agent_active(to_state in ("working", "thinking"))
         if to_state == "offline":
             alm = self._dsh_link_manager()
             if alm is not None and hasattr(alm, "dismiss_all_interactions"):
@@ -1291,6 +1319,24 @@ class AppShell:
                 inst.collision_ipc.stop()
             except Exception:
                 logging.exception("退出时停止碰撞会话失败")
+        # 果冻墙：岛的静态碰撞体随「全部退出」收口（主动 leave 即时移出碰撞世界）
+        body = getattr(self, "island_collision", None)
+        if body is not None:
+            try:
+                body.stop()
+            except Exception:
+                logging.exception("退出时停止灵动岛碰撞体失败")
+        # 进程级全局订阅注销：类级 list 长期持有本 shell 强引用，不注销会
+        # 阻碍 GC（no-chat 变体无 ChatService，导入守卫与注册处同口径）
+        try:
+            from .chat.service import ChatService as _ChatService
+        except ImportError:
+            _ChatService = None
+        if _ChatService is not None:
+            try:
+                _ChatService.unregister_global_finished(self._on_global_chat_finished)
+            except Exception:
+                logging.exception("退出时注销全局聊天订阅失败")
         # 会话异步写盘（B8）：全部会话已保存，再永久关闭写盘 worker
         #（关掉后迟到的 queued 回调提交会被明确拒绝）。
         if self.todo_service is not None:
@@ -1326,7 +1372,8 @@ class AppShell:
         - 停待办提醒服务定时器（其 ``_app`` 反向强引用 shell，且无主 QTimer 的
           timeout 连接从 Qt C++ 侧强引用住整个对象图，Python gc 回收不掉）；
         - 共享子系统经 ``SharedSubsystems._shutdown_live_for_tests`` 收口；
-        - 断开 shell → app 的 aboutToQuit 连接并释放反向引用。
+        - 断开 shell → app 的 aboutToQuit 连接并释放反向引用；
+        - 停灵动岛碰撞体定时器并注销全局聊天订阅（同生产收口口径）。
 
         不做 ``_on_about_to_quit`` 的退出语义（保存位置/永久关闭写盘 worker）：
         那是「全部退出」，测试收口不得触发。
@@ -1353,6 +1400,19 @@ class AppShell:
                     except (RuntimeError, TypeError):
                         pass
                     shell._on_about_to_quit_connected = False
+                # 灵动岛碰撞体 30Hz 定时器与全局聊天订阅（同生产收口口径，
+                # 不停会在后续测试里打异常循环/阻碍 GC）
+                body = getattr(shell, "island_collision", None)
+                if body is not None:
+                    try:
+                        body.stop()
+                    except Exception:
+                        logging.debug("测试收口灵动岛碰撞体失败", exc_info=True)
+                try:
+                    from .chat.service import ChatService as _ChatService
+                    _ChatService.unregister_global_finished(shell._on_global_chat_finished)
+                except Exception:
+                    pass
                 shell._instances = []
             except Exception:
                 logging.debug("测试收口 AppShell 失败", exc_info=True)
@@ -1410,20 +1470,99 @@ class AppShell:
     def _sync_dynamic_island(self) -> None:
         """按配置创建/隐藏灵动岛；桌宠隐藏后灵动岛仍可常驻。"""
         island_cfg = self.config.get("dynamic_island", {})
-        enabled = bool(island_cfg.get("enabled", False)) if isinstance(island_cfg, dict) else False
+        enabled = bool(island_cfg.get("enabled", True)) if isinstance(island_cfg, dict) else False
         if not enabled:
             if getattr(self, "island", None) is not None:
                 self.island.hide()
+            body = getattr(self, "island_collision", None)
+            if body is not None:
+                body.stop()
             return
         if getattr(self, "island", None) is None:
             from .dynamic_island import DynamicIsland
 
             self.island = DynamicIsland(self.config)
             self.island.clicked.connect(self._toggle_pet_from_island)
+            self.island.toggle_pet_requested.connect(self._toggle_pet_from_island)
+            self.island.open_chat_requested.connect(self._open_chat_from_island)
+            self.island.open_settings_requested.connect(self._open_settings_from_island)
+            # 卡片展开 → 静默刷新余额（不冒泡、不播动画，只更新岛卡片）
+            self.island.card_expanded.connect(self._quiet_balance_refresh)
+            # 进程级聊天完成订阅：AI 回复到达 → 岛播事件动效并记录最近消息。
+            # 无聊天功能的打包变体会排除 pet.chat（参照 config.py 的同款守卫），
+            # 那里跳过订阅即可，灵动岛本体照常可用。
+            try:
+                from .chat.service import ChatService
+            except ImportError as exc:
+                if str(getattr(exc, "name", "") or "").startswith("pet.chat"):
+                    ChatService = None  # 无聊天打包变体：跳过订阅，岛本体照常
+                else:
+                    raise
+            if ChatService is not None:
+                ChatService.register_global_finished(self._on_global_chat_finished)
         self.island.refresh_from_config()
         # 批5.2a：灵动岛按**聚合**可见态同步（任一窗可见 = 可见），替代只看主窗。
         self.island.set_pet_visible(self._aggregate_pet_visible())
         self.island.show()
+        self._sync_island_collision(island_cfg)
+
+    def _sync_island_collision(self, island_cfg) -> None:
+        """果冻墙：按配置创建/启停岛的本进程碰撞体（island_collision.py）。
+
+        本进程直连检测（30Hz 圆链扫掠 + 本地结算），不走碰撞 IPC——
+        IPC 版的保活/快照时序在 GUI 卡顿时会让岛掉出碰撞世界（实机教训）。
+        岛的位置永远由用户拖拽决定；拖拽中岛速参与结算（岛=移动的拍子）。
+        """
+        enabled = bool(island_cfg.get("collision_enabled", True)) \
+            if isinstance(island_cfg, dict) else True
+        body = getattr(self, "island_collision", None)
+        if not enabled:
+            if body is not None:
+                body.stop()
+            return
+        if self.island is None:
+            return
+        if body is None:
+            from .island_collision import IslandCollisionBody
+
+            body = IslandCollisionBody(
+                self.island, self.config,
+                pets_provider=lambda: [
+                    inst.win for inst in self._instances if inst.win is not None
+                ])
+            self.island_collision = body
+            self.island.on_geometry_changed = body.submit
+            self.island.on_pet_visibility_changed = body.set_own_pet_visible
+        try:
+            body.start()
+        except Exception:
+            # 岛对象异常（如测试桩无 geometry）时碰撞体降级为不启用，
+            # 不影响灵动岛本体功能。
+            logging.exception("启动灵动岛碰撞体失败")
+
+    def _open_chat_from_island(self) -> None:
+        if not getattr(self, "enable_chat", True):
+            # no-chat 打包变体：给可见反馈（岛弹跳），不静默 no-op
+            island = getattr(self, "island", None)
+            if island is not None and shiboken6.isValid(island):
+                island.bump(1.5, 0.0, -1.0)
+            return
+        inst = self.instance
+        if inst is not None and callable(getattr(inst, "open_quick_chat", None)):
+            inst.open_quick_chat()
+
+    def _open_settings_from_island(self) -> None:
+        inst = self.instance
+        if inst is not None and callable(getattr(inst, "open_modern_settings", None)):
+            inst.open_modern_settings()
+
+    def _on_global_chat_finished(self, text: str) -> None:
+        """ChatService 全局完成回调（GUI 线程）：驱动灵动岛事件动效。"""
+        island = getattr(self, "island", None)
+        if island is None or not shiboken6.isValid(island):
+            return
+        island.set_last_message(text)
+        island.notify_event("reply")
 
     def _aggregate_pet_visible(self) -> bool:
         """是否有任一窗可见（聚合可见态——灵动岛按它同步 set_pet_visible）。"""
@@ -1454,24 +1593,88 @@ class AppShell:
         if minutes:
             self._balance_timer.start(minutes * 60000)
 
-    def _update_island_balance(self, payload) -> None:
-        """把余额文本/峰谷提示同步给灵动岛（若有）。"""
-        if getattr(self, "island", None) is None:
-            return
-        text = "余额 --"
-        info = {}
-        if isinstance(payload, dict):
-            text = str(payload.get("text") or "余额 --")
-            info = payload.get("info") or {}
+    def _island_tier_hint(self) -> str:
+        """灵动岛余额峰谷提示文案（与 _update_island_balance / 静默查询共用）。"""
         peak_label, idle_label = balance_mod.resolve_tier_labels(
             str(self.config.get("balance_tier_labels_mode", "default") or "default"),
             str(self.config.get("balance_tier_label_peak", "") or ""),
             str(self.config.get("balance_tier_label_idle", "") or ""),
         )
-        hint = balance_mod.deepseek_pricing_hint(
+        return balance_mod.deepseek_pricing_hint(
             peak_label=peak_label, idle_label=idle_label,
         )
-        self.island.set_balance_info(hint, text)
+
+    def _update_island_balance(self, payload, *, animate: bool = True) -> None:
+        """把余额文本/峰谷提示同步给灵动岛（若有）。
+
+        animate=False 用于静默刷新路径（卡片展开后的缓存命中/后台查询）：
+        只更新文本不播余额弹跳动画——弹跳会把展开卡片顶出窗口截边。
+        """
+        if getattr(self, "island", None) is None:
+            return
+        text = "余额 --"
+        if isinstance(payload, dict):
+            text = str(payload.get("text") or "余额 --")
+        self.island.set_balance_info(self._island_tier_hint(), text)
+        if animate:
+            self.island.notify_event("balance")
+
+    def _quiet_balance_refresh(self, *, force: bool = False) -> None:
+        """灵动岛卡片展开时的静默余额刷新：不冒泡、不播动画，只更新岛卡片。
+
+        30s 内存/文件缓存命中直接用；否则后台查询（60s 节流，查询忙时跳过）。
+        未配置 API Key 时明确提示，不再停留 "余额 --"。
+        """
+        island = getattr(self, "island", None)
+        if island is None or getattr(self, "_quiet_balance_busy", False):
+            return
+        if not getattr(self, "enable_chat", True):
+            island.set_balance_info(self._island_tier_hint(), "此版本无余额查询")
+            return
+        now = time.monotonic()
+        import hashlib
+        settings = self.config.chat_settings()
+        provider = settings.active_config
+        provider.api_key = self.config.resolve_api_key(provider)
+        if not provider.api_key:
+            island.set_balance_info(
+                self._island_tier_hint(), "未配置 API Key（设置 → 聊天）")
+            return
+        key_digest = hashlib.sha256(str(provider.api_key or '').encode()).hexdigest()[:12]
+        provider_key = '|'.join([
+            str(getattr(provider, 'id', '') or ''),
+            str(provider.base_url or ''),
+            key_digest,
+        ])
+        if self._balance_cache is not None and now - self._balance_cache[0] < 30.0 \
+                and self._balance_cache[2] == provider_key:
+            self._update_island_balance(self._balance_cache[1], animate=False)
+            return
+        file_payload = self._read_balance_file_cache(provider_key)
+        if file_payload is not None:
+            self._balance_cache = (now, file_payload, provider_key)
+            self._update_island_balance(file_payload, animate=False)
+            return
+        last = getattr(self, "_quiet_balance_last", None)
+        if not force and last is not None and now - last < 60.0:
+            # 节流命中且缓存已过期：明示状态，不停留在旧值上装死
+            island.set_balance_info(self._island_tier_hint(), "刚刚查询过，稍后自动更新")
+            return
+        self._quiet_balance_last = now
+        island.set_balance_info(self._island_tier_hint(), "查询中…")
+        bridge = _QuietBalanceBridge(owner=self)
+        self._quiet_balance_bridge = bridge
+        self._quiet_balance_busy = True  # 独立忙标志：不占显式查询的闸门
+        try:
+            threading.Thread(
+                target=self._balance_worker,
+                args=(bridge, provider.base_url, provider.api_key, provider.verify_ssl, provider_key),
+                kwargs={"quiet": True},
+                daemon=True, name='pet-balance-quiet',
+            ).start()
+        except Exception as exc:  # noqa: BLE001 - 启动失败也必须释放忙状态
+            self._quiet_balance_busy = False
+            QTimer.singleShot(0, lambda message=str(exc): bridge.done.emit(False, message))
 
     # ------------------------------------------------------------ 余额
     def show_balance(self, parent=None) -> None:
@@ -1520,7 +1723,7 @@ class AppShell:
             error_message = f'余额查询失败：{exc}'
             QTimer.singleShot(0, lambda message=error_message: bridge.done.emit(False, message))
 
-    def _balance_worker(self, bridge, base_url: str, api_key: str, verify_ssl: bool, provider_key: str = '') -> None:
+    def _balance_worker(self, bridge, base_url: str, api_key: str, verify_ssl: bool, provider_key: str = '', *, quiet: bool = False) -> None:
         try:
             info = balance_mod.fetch_balance(base_url, api_key, verify_ssl=verify_ssl)
             text = balance_mod.format_balance(info)
@@ -1531,7 +1734,10 @@ class AppShell:
         except Exception as exc:  # noqa: BLE001 - 任何失败走气泡提示
             bridge.done.emit(False, f'余额查询失败：{exc}')
         finally:
-            self._balance_busy = False
+            if quiet:
+                self._quiet_balance_busy = False
+            else:
+                self._balance_busy = False
 
     def _read_balance_file_cache(self, provider_key: str = '') -> dict | None:
         """读取跨实例共享的余额缓存（30s 内有效，且必须是同一 provider 的缓存）。

--- a/pet/chat/service.py
+++ b/pet/chat/service.py
@@ -37,6 +37,20 @@ class _Worker(QThread):
             self.stopped_by_user.emit() if self.cancel.is_set() else self.failed.emit(str(exc))
 class ChatService(QObject):
     started=Signal(str); delta=Signal(str,str); finished=Signal(str,str); error=Signal(str,str); stopped=Signal(str)
+    # 进程级「回复完成」订阅（灵动岛事件动效等）：AppShell 注册一次，
+    # 回调总在 GUI 线程执行（worker→本对象的链路全是 QueuedConnection）。
+    _global_finished_listeners: list = []
+
+    @classmethod
+    def register_global_finished(cls, callback):
+        if callback not in cls._global_finished_listeners:
+            cls._global_finished_listeners.append(callback)
+
+    @classmethod
+    def unregister_global_finished(cls, callback):
+        if callback in cls._global_finished_listeners:
+            cls._global_finished_listeners.remove(callback)
+
     def __init__(self,provider=None,parent=None):
         super().__init__(parent); self.provider=provider or OpenAICompatibleProvider(); self._request_id=None; self._cancel=None; self._worker=None; self._workers=set()
         # 退出时先取消并短等在飞 worker，避免 QThread 运行中被销毁导致崩溃
@@ -87,7 +101,11 @@ class ChatService(QObject):
     def _delta(self,rid,text):
         if self._current(rid): self.delta.emit(rid,text)
     def _finished(self,rid,text):
-        if self._current(rid): self.finished.emit(rid,text)
+        if self._current(rid):
+            self.finished.emit(rid,text)
+            for cb in list(type(self)._global_finished_listeners):
+                try: cb(text)
+                except Exception: pass
     def _error(self,rid,text):
         if self._current(rid): self.error.emit(rid,text)
     def _stopped(self,rid):

--- a/pet/collision.py
+++ b/pet/collision.py
@@ -40,6 +40,17 @@ FLAG_AUTO_CURSOR_HIDDEN: int = 1 << 7   # 128: 自动光标穿透/隐藏
 FLAG_PAUSED: int = 1 << 8               # 256: 暂停活动
 FLAG_COLLISION_ENABLED: int = 1 << 9    # 512: 开启碰撞
 FLAG_PREDICTED_BOUNCE: int = 1 << 10    # 1024: 客户端已预测的反弹事件
+FLAG_STATIC: int = 1 << 11              # 2048: 静态布景（无限质量但保留弹性）。
+# 注意：FLAG_STATIC 的 IPC 链路（碰撞世界静态成员注册/结算）当前**生产代码
+# 不可达**——灵动岛碰撞走本进程直连（island_collision.py），不注册进 IPC
+# 碰撞世界。该链路为「多进程实例的桌宠撞岛」预留，启用前需在岛场景实测
+# 保活/快照时序（此前的穿透问题正出自那条链路）。STATIC_RESTITUTION 由
+# 直连路径使用，不受此影响。
+
+# 静态布景（灵动岛果冻墙）专用恢复系数：>1 表示撞岛被"加速弹开"——
+# 撞到岛像撞到弹床，比撞墙更活泼；只作用于 FLAG_STATIC 参与的碰撞，
+# 鱼撞鱼/撞拖拽鱼仍走 collision_restitution 配置。
+STATIC_RESTITUTION: float = 1.3
 
 
 @dataclass
@@ -379,7 +390,17 @@ def solve_collision_impulse(
 
     e = max(0.0, min(1.0, float(restitution)))
     if state_a.is_infinite_mass or state_b.is_infinite_mass:
-        e = 0.0
+        # 无限质量体（拖拽/锁定中的肥鱼）吸能 e=0：被握着的一方不动，
+        # 撞来的也贴停不弹飞。但 FLAG_STATIC 静态布景（灵动岛果冻墙）
+        # 用 STATIC_RESTITUTION 加速弹开——撞岛像撞弹床，吸停会显得岛"不存在"。
+        static_involved = (
+            (state_a.is_infinite_mass and state_a.flags & FLAG_STATIC)
+            or (state_b.is_infinite_mass and state_b.flags & FLAG_STATIC)
+        )
+        if static_involved:
+            e = STATIC_RESTITUTION
+        else:
+            e = 0.0
     if vn >= -IMPULSE_MIN_APPROACH_SPEED:
         e = 0.0
     sum_inv_m = inv_m_a + inv_m_b

--- a/pet/collision_client.py
+++ b/pet/collision_client.py
@@ -339,7 +339,15 @@ class CollisionClient(QObject):
         radius_x = max(1.0, rect.width() / 2.0)
         radius_y = max(1.0, rect.height() / 2.0)
         hit_dv = math.hypot(dvx, dvy)
-        is_real_hit = hit_dv >= self._hit_min_dv
+        # 撞静态布景（灵动岛果冻墙）放宽命中阈值：岛的语义就是"撞上去会弹"，
+        # 漫游/走路蹭到（dv 常在 60~300 之间）也该有看得见的反弹，
+        # 而不是被 300 的通用阈值吃掉只剩缓慢推出。
+        other_id = str(message.get('b') if message.get('a') == runtime_id
+                       else message.get('a') or '')
+        other = self.peer_snapshots.get(other_id) or {}
+        hit_floor = 60.0 if int(other.get('flags', 0)) & collision.FLAG_STATIC \
+            else self._hit_min_dv
+        is_real_hit = hit_dv >= hit_floor
         has_velocity_impulse = abs(dvx) > 1e-9 or abs(dvy) > 1e-9
         # 偏差豁免的本意是"协调者眼中的我已经过期就别瞬移我"——直接比较
         # 协调者 tick 时认定的我方中心（ax/ay 或 bx/by）与当前实际中心，
@@ -504,7 +512,7 @@ class CollisionClient(QObject):
                     radius_x, radius_y,
                     scale=float(raw_peer.get('scale', collision.DEFAULT_BASE_SCALE) or collision.DEFAULT_BASE_SCALE),
                     collision_mass_scale=float(win.cfg.get('collision_mass_scale', 1.0))),
-                is_infinite_mass=bool(flags & (collision.FLAG_DRAGGING | collision.FLAG_LOCK_POSITION)),
+                is_infinite_mass=bool(flags & (collision.FLAG_DRAGGING | collision.FLAG_LOCK_POSITION | collision.FLAG_STATIC)),
                 flags=flags,
                 circles=peer_circles,
             )

--- a/pet/collision_ipc.py
+++ b/pet/collision_ipc.py
@@ -31,7 +31,10 @@ RUNTIME_ID_MAX_LENGTH = 128
 CHARACTER_MAX_LENGTH = 512
 MAX_COLLISION_CIRCLES = 3
 ACTIVE_MEMBER_MAX_AGE = 1.2
-_KNOWN_FLAGS_MASK = (1 << 11) - 1
+# 静态布景（灵动岛）的新鲜度宽限：位置不变、保活在 GUI 线程，宽限内
+# 最多成为 3s 的"残影墙"（进程崩溃场景），远小于甩丢一只鱼的体感代价。
+STATIC_MEMBER_MAX_AGE = 3.0
+_KNOWN_FLAGS_MASK = (1 << 12) - 1  # 含 FLAG_STATIC(2048)：静态布景果冻墙
 
 
 def _bounded_text(value: Any, max_bytes: int) -> str:
@@ -428,6 +431,9 @@ class _CollisionWorker(QObject):
         is_new = self.runtime_id not in self.members
         if not is_new:
             self.previous_members[self.runtime_id] = dict(self.members[self.runtime_id])
+        elif int(member.get("flags", 0)) & collision.FLAG_STATIC:
+            # 同另两条路径：静态布景（岛）首帧用当前帧垫底，保住 swept 覆盖
+            self.previous_members[self.runtime_id] = dict(member)
         self.members[self.runtime_id] = member
         self._membership_dirty = self._membership_dirty or is_new
 
@@ -451,11 +457,21 @@ class _CollisionWorker(QObject):
         return {k: v for k, v in member.items() if k != "last_seen"}
 
     def _fresh_member_values(self, now: float) -> list[dict[str, Any]]:
-        """Return members inside the shared solver/publication freshness window."""
-        return [
-            value for value in self.members.values()
-            if now - float(value.get("last_seen", now)) <= ACTIVE_MEMBER_MAX_AGE
-        ]
+        """Return members inside the shared solver/publication freshness window.
+
+        FLAG_STATIC 成员（灵动岛）放宽到 STATIC_MEMBER_MAX_AGE：它的位置只随
+        用户拖拽变化，保活定时器又跑在繁忙的 GUI 线程——一次事件循环卡顿
+        不该让岛瞬间从碰撞世界消失（"甩上去直接穿过"的根因）。
+        """
+        fresh = []
+        for value in self.members.values():
+            age = now - float(value.get("last_seen", now))
+            max_age = STATIC_MEMBER_MAX_AGE \
+                if int(value.get("flags", 0)) & collision.FLAG_STATIC \
+                else ACTIVE_MEMBER_MAX_AGE
+            if age <= max_age:
+                fresh.append(value)
+        return fresh
 
     def _send(self, socket, message: collision_codec.WireMessage) -> None:
         try:
@@ -552,6 +568,11 @@ class _CollisionWorker(QObject):
                 is_new = runtime_id not in self.members
                 if not is_new:
                     self.previous_members[runtime_id] = dict(self.members[runtime_id])
+                elif int(member.get("flags", 0)) & collision.FLAG_STATIC:
+                    # 静态布景（岛）首帧没有"上一帧"：用当前帧垫底，swept
+                    # 退化为静态检测——否则岛（重）加入的头两帧内高速甩来的
+                    # 桌宠会隧道穿透（预留链路，见 collision.FLAG_STATIC 注释）
+                    self.previous_members[runtime_id] = dict(member)
                 self.members[runtime_id] = member
                 self._membership_dirty = self._membership_dirty or is_new
             elif kind == "leave":
@@ -686,6 +707,9 @@ class _CollisionWorker(QObject):
             is_new = self.runtime_id not in self.members
             if not is_new:
                 self.previous_members[self.runtime_id] = dict(self.members[self.runtime_id])
+            elif int(member.get("flags", 0)) & collision.FLAG_STATIC:
+                # 同 peer 侧：静态布景（岛）首帧用当前帧垫底，保住 swept 覆盖
+                self.previous_members[self.runtime_id] = dict(member)
             self.members[self.runtime_id] = member
             self._membership_dirty = self._membership_dirty or is_new
             if collision_debug.ENABLED:
@@ -812,8 +836,11 @@ class _CollisionWorker(QObject):
                 keys = ("runtime_id", "x", "y", "radius_x", "radius_y", "vx", "vy", "mass",
                          "is_infinite_mass", "flags", "instance_id", "character", "scale", "w", "h", "circles")
                 values = {key: state.get(key, defaults.get(key, 0.0)) for key in keys}
-                # 无限质量只认"被拖拽中"（用户手里握着）；lock_position 只是防拖拽，仍可被撞飞（碰碰车/台球需要）
-                values["is_infinite_mass"] = bool(int(values["flags"]) & collision.FLAG_DRAGGING)
+                # 无限质量认"被拖拽中"（用户手里握着）与 FLAG_STATIC 静态布景
+                # （灵动岛果冻墙）；lock_position 只是防拖拽，仍可被撞飞（碰碰车/台球需要）。
+                # 两者的弹性差异由 solve_collision_impulse 按 FLAG_STATIC 区分。
+                values["is_infinite_mass"] = bool(
+                    int(values["flags"]) & (collision.FLAG_DRAGGING | collision.FLAG_STATIC))
                 values["mass"] = collision.calculate_mass(
                     values["radius_x"], values["radius_y"],
                     scale=float(values.get("scale", 0.72) or 0.72),
@@ -845,7 +872,7 @@ class _CollisionWorker(QObject):
             if bounce_vx is None or bounce_vy is None:
                 continue
             pred_flags = int(snap.get("flags", 0))
-            pred_is_inf = bool(pred_flags & collision.FLAG_DRAGGING)
+            pred_is_inf = bool(pred_flags & (collision.FLAG_DRAGGING | collision.FLAG_STATIC))
             pred_rx = float(snap.get("radius_x", 0.0))
             pred_ry = float(snap.get("radius_y", 0.0))
             pred_x = float(snap.get("bounce_x", snap.get("x", 0.0)))

--- a/pet/config.py
+++ b/pet/config.py
@@ -486,7 +486,14 @@ def _default_dynamic_island_data() -> dict:
         "custom_text": "",
         "show_status": True,
         "style": "dark",           # dark / light / glass
+        "opacity": 1.0,            # 背景不透明度 0.4~1.0
+        "accent": "blue",          # 主题色：blue / green / purple / pink / orange
         "icon": "🐳",
+        "click_action": "expand",  # expand（展开卡片）/ toggle_pet（切换显隐，旧行为）
+        "event_effects": True,     # 事件动效：AI 回复/余额刷新/峰谷切换弹跳
+        "edge_dock": True,         # 拖到屏幕边缘收成细条，鼠标靠近滑出
+        "dock_edge": "none",       # none / top / bottom / left / right（拖拽落点写入）
+        "collision_enabled": True,  # 果冻墙：岛注册为静态碰撞体，肥鱼撞到会弹开
         "x": None,
         "y": None,
     }
@@ -508,7 +515,24 @@ def _clean_dynamic_island_data(value) -> dict:
     result["custom_text"] = str(result.get("custom_text") or "")[:80]
     style = str(result.get("style") or "dark").strip()
     result["style"] = style if style in {"dark", "light", "glass"} else "dark"
+    try:
+        result["opacity"] = max(0.4, min(1.0, float(result.get("opacity", 1.0))))
+    except (TypeError, ValueError):
+        result["opacity"] = 1.0
+    accent = str(result.get("accent") or "blue").strip()
+    result["accent"] = accent if accent in {"blue", "green", "purple", "pink", "orange"} else "blue"
     result["icon"] = str(result.get("icon") or "🐳").strip()[:8] or "🐳"
+    click_action = str(result.get("click_action") or "expand").strip()
+    result["click_action"] = click_action if click_action in {"expand", "toggle_pet"} else "expand"
+    # 布尔键必须用 _bool_or_default：bool("false") is True，字符串/None
+    # 会被误翻（同文件既有规则）；int 0/1 是旧配置的合法布尔编码，先归一
+    for _key in ("event_effects", "edge_dock", "collision_enabled"):
+        _v = result[_key]
+        if isinstance(_v, int) and not isinstance(_v, bool):
+            _v = bool(_v)
+        result[_key] = _bool_or_default(_v, defaults[_key])
+    edge = str(result.get("dock_edge") or "none").strip()
+    result["dock_edge"] = edge if edge in {"none", "top", "bottom", "left", "right"} else "none"
     # 至少保留一个组件：全部关闭时强制显示信息槽，避免空胶囊。
     if not (result["show_icon"] or result["show_name"] or result["show_info"] or result["show_status"]):
         result["show_info"] = True

--- a/pet/dynamic_island.py
+++ b/pet/dynamic_island.py
@@ -2,20 +2,126 @@
 """独立灵动岛胶囊窗口。
 
 - 常驻顶层小窗，可显示图标、名称、信息槽、状态灯；
-- 支持拖拽、屏幕顶部吸附、位置持久化；
-- 单击胶囊切换桌宠显示/隐藏（由应用层连接 clicked 信号）。
+- 支持拖拽、四边停靠半隐藏（收成细条、鼠标靠近滑出）、位置持久化；
+- 单击胶囊按 ``click_action`` 展开卡片（余额/最近消息/快捷按钮）或切换桌宠显隐；
+- 事件动效（``event_effects``）：AI 回复/余额刷新/峰谷切换时位移弹跳 +
+  表面轻压 + 短暂呼吸，静止时完全无定时器开销；dsh 工作时状态灯变蓝；
+- ``bump()`` 供碰撞系统调用：被撞时表面压扁回弹（史莱姆果冻形变只作用于
+  胶囊外形，文字图标保持锐利）+ 按撞击方向轻微踢动；
+- 外观：黑/白/玻璃质感自绘 + 背景不透明度 + 主题色（五级）。
 """
 from __future__ import annotations
 
-from PySide6.QtCore import QPoint, QRectF, Qt, QTimer, Signal
-from PySide6.QtGui import QColor, QGuiApplication, QLinearGradient, QPainter, QPen
-from PySide6.QtWidgets import QApplication, QWidget
+import logging
+import math
+import time
+
+from PySide6.QtCore import (
+    QPoint, QRect, QRectF, QSize, Qt, QTimer, Signal,
+)
+from PySide6.QtGui import (
+    QColor, QGuiApplication, QLinearGradient, QPainter, QPen,
+)
+from PySide6.QtWidgets import (
+    QApplication, QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget,
+)
 
 from . import catalog
 
+logger = logging.getLogger(__name__)
+
 _CAPSULE_HEIGHT = 44
+_CAPSULE_INSET = 6  # 胶囊绘制内缩：给果冻形变/悬停放大/踢动留出窗口内余量
 _EDGE_MARGIN = 16
-_SNAP_TOP_THRESHOLD = 24
+_DOCK_THRESHOLD = 40
+_STRIP_THICKNESS = 16
+_STRIP_SIDE = 64  # 左右停靠时竖条的长度
+_CARD_WIDTH = 340
+_CARD_HEIGHT = 148
+_CARD_AUTO_COLLAPSE_MS = 15_000
+_DOCK_BACK_MS = 800
+_BREATHE_AFTER_EVENT_S = 5.0
+
+# 弹簧参数：位移踢动（kick）、受击倾斜（tilt）、果冻形变（squish）
+_KICK_STIFFNESS = 210.0
+_KICK_DAMPING = 17.0
+_SCALE_STIFFNESS = 170.0
+_SCALE_DAMPING = 15.0
+_TILT_STIFFNESS = 120.0
+_TILT_DAMPING = 10.0
+_TILT_MAX_DEG = 3.5
+_SCALE_MIN = 0.97
+_SCALE_MAX = 1.03
+# 史莱姆形变：只作用于胶囊外形（背景/描边/阴影），文字图标绝不参与变换——
+# 形变的是"表面"，内容保持锐利（1.0=休息态，<1 压扁，弹簧回摆产生果冻抖动）
+_SQUISH_STIFFNESS = 150.0
+_SQUISH_DAMPING = 8.5
+_SQUISH_MIN = 0.85
+_SQUISH_MAX = 1.12
+_ANIM_TICK_MS = 16  # ~60fps，仅动画活跃时运行，静止零开销
+
+_DOCK_EDGES = ("none", "top", "bottom", "left", "right")
+
+# 主题色预设（设置页可换）：图标底圈 / 事件闪光 / 停靠描边共用
+_ACCENT_PRESETS = {
+    "blue": "#40b8ff",
+    "green": "#30a46c",
+    "purple": "#9b7bff",
+    "pink": "#ff7ab8",
+    "orange": "#ffa94d",
+}
+_DEFAULT_ACCENT = "blue"
+
+
+def spring_step(
+    value: float, velocity: float, target: float, dt: float,
+    stiffness: float = _KICK_STIFFNESS, damping: float = _KICK_DAMPING,
+) -> tuple[float, float]:
+    """阻尼弹簧积分一步（半隐式欧拉），返回新的 (value, velocity)。
+
+    dt 由调用方按真实帧间隔传入（钳到 50ms 防切后台后爆炸）。
+    """
+    dt = max(0.0, min(float(dt), 0.05))
+    accel = (target - value) * stiffness - velocity * damping
+    velocity += accel * dt
+    value += velocity * dt
+    return value, velocity
+
+
+def ease_out_cubic(t: float) -> float:
+    t = max(0.0, min(1.0, float(t)))
+    return 1.0 - (1.0 - t) ** 3
+
+
+def dock_edge_for(
+    rect: QRect, available: QRect, threshold: int = _DOCK_THRESHOLD,
+) -> str:
+    """按窗口矩形到屏幕可用区四边的距离判定停靠边，都不近则 "none"。
+
+    四边等权、取最近者——顶部被系统栏/MyDockFinder 占用时用户可靠左右下。
+    """
+    distances = {
+        "top": abs(rect.top() - available.top()),
+        "bottom": abs(available.bottom() - rect.bottom()),
+        "left": abs(rect.left() - available.left()),
+        "right": abs(available.right() - rect.right()),
+    }
+    edge, distance = min(distances.items(), key=lambda item: item[1])
+    return edge if distance <= threshold else "none"
+
+
+def strip_rect_for(rect: QRect, edge: str, available: QRect) -> QRect:
+    """停靠后的细条矩形：上下停靠压扁高度，左右停靠收成短竖条。"""
+    if edge in ("top", "bottom"):
+        y = available.top() if edge == "top" else available.bottom() - _STRIP_THICKNESS + 1
+        return QRect(rect.left(), y, rect.width(), _STRIP_THICKNESS)
+    if edge in ("left", "right"):
+        x = available.left() if edge == "left" else available.right() - _STRIP_THICKNESS + 1
+        length = min(_STRIP_SIDE, available.height())
+        y = max(available.top(), min(rect.center().y() - length // 2,
+                                     available.bottom() - length + 1))
+        return QRect(x, y, _STRIP_THICKNESS, length)
+    return QRect(rect)
 
 
 def _cfg_dict(config) -> dict:
@@ -26,7 +132,11 @@ def _cfg_dict(config) -> dict:
 class DynamicIsland(QWidget):
     """胶囊形态的独立灵动岛窗口。"""
 
-    clicked = Signal()
+    clicked = Signal()  # click_action == "toggle_pet" 时的单击（旧行为）
+    toggle_pet_requested = Signal()
+    open_chat_requested = Signal()
+    open_settings_requested = Signal()
+    card_expanded = Signal()  # 卡片展开（AppShell 借此静默刷新余额）
 
     def __init__(self, config, parent=None):
         super().__init__(parent)
@@ -51,6 +161,50 @@ class DynamicIsland(QWidget):
         self._balance_tier_text = "余额峰谷 --"
         self._balance_text = "余额 --"
         self._pet_visible = True
+        self._agent_active = False
+        self._last_message = ""
+        # 几何变化回调（果冻墙碰撞体挂这里跟踪拖拽/停靠滑动）：AppShell 注入。
+        self.on_geometry_changed = None
+        # 桌宠聚合可见性回调（碰撞体据此挂起/恢复）：AppShell 注入。
+        self.on_pet_visibility_changed = None
+
+        # ---- 模式与动效状态（静止时全部为稳态，_anim_timer 不运行）----
+        self._mode = "normal"  # normal / docked / expanded
+        self._hover_peek = False  # 停靠状态下鼠标靠近的临时滑出
+        # 位移弹跳（px）：事件下压回弹 / 受击定向踢动，绘制时整数化保持文字锐利
+        self._kick_x = 0.0
+        self._kick_y = 0.0
+        self._kick_vx = 0.0
+        self._kick_vy = 0.0
+        self._tilt = 0.0
+        self._tilt_v = 0.0
+        # 果冻形变（史莱姆表面浮动）：只调制胶囊外形，不碰文字
+        self._squish = 1.0
+        self._squish_v = 0.0
+        self._scale = 1.0  # 只做 ±3% 微缩放辅助（大缩放会糊文字，已弃用）
+        self._scale_v = 0.0
+        self._breathe_until = 0.0
+        self._hover_scale_target = 1.0
+        self._geo_from: QRect | None = None
+        self._geo_to: QRect | None = None
+        self._geo_t = 0.0
+
+        self._anim_timer = QTimer(self)
+        self._anim_timer.setInterval(_ANIM_TICK_MS)
+        self._anim_timer.timeout.connect(self._on_anim_tick)
+        self._anim_last = 0.0
+
+        self._dock_back_timer = QTimer(self)
+        self._dock_back_timer.setSingleShot(True)
+        self._dock_back_timer.setInterval(_DOCK_BACK_MS)
+        self._dock_back_timer.timeout.connect(self._dock_back)
+
+        self._card_collapse_timer = QTimer(self)
+        self._card_collapse_timer.setSingleShot(True)
+        self._card_collapse_timer.setInterval(_CARD_AUTO_COLLAPSE_MS)
+        self._card_collapse_timer.timeout.connect(self.collapse_card)
+
+        self._build_card()
 
         self._info_timer = QTimer(self)
         self._info_timer.setInterval(30_000)
@@ -65,19 +219,114 @@ class DynamicIsland(QWidget):
 
         self._apply_position()
 
+    # ------------------------------------------------------------ 模式/配置
+    @property
+    def mode(self) -> str:
+        return self._mode
+
+    @property
+    def dock_edge(self) -> str:
+        # 「靠边半隐藏」总开关关着时，存储的停靠边视为无——停靠判定/细条
+        # 绘制/碰撞跳过等所有读取处统一走"不停靠"，不留死状态（开关再开
+        # 时存储的边恢复生效）
+        if not self._edge_dock_enabled():
+            return "none"
+        return str(self._cfg.get("dock_edge") or "none")
+
+    def _click_action(self) -> str:
+        return str(self._cfg.get("click_action") or "expand")
+
+    def _event_effects_enabled(self) -> bool:
+        return bool(self._cfg.get("event_effects", True))
+
+    def _edge_dock_enabled(self) -> bool:
+        return bool(self._cfg.get("edge_dock", True))
+
+    def _opacity(self) -> float:
+        """背景不透明度倍率（0.4~1.0），设置页可调；非法值回退 1.0。"""
+        try:
+            value = float(self._cfg.get("opacity", 1.0))
+        except (TypeError, ValueError):
+            return 1.0
+        return max(0.4, min(1.0, value))
+
+    def _accent_color(self) -> QColor:
+        key = str(self._cfg.get("accent") or _DEFAULT_ACCENT)
+        return QColor(_ACCENT_PRESETS.get(key, _ACCENT_PRESETS[_DEFAULT_ACCENT]))
+
     # ------------------------------------------------------------ 对外
     def set_balance_info(self, tier_text: str, balance_text: str) -> None:
         self._balance_tier_text = str(tier_text or "余额峰谷 --")
         self._balance_text = str(balance_text or "余额 --")
+        self._sync_card_labels()
         self._refresh()
 
     def set_pet_visible(self, visible: bool) -> None:
         self._pet_visible = bool(visible)
+        callback = self.on_pet_visibility_changed
+        if callable(callback):
+            try:
+                callback(bool(visible))
+            except Exception:
+                pass
+        self._sync_card_labels()
         self.update()
 
+    def set_agent_active(self, active: bool) -> None:
+        """dsh/agent 工作状态：点亮蓝色状态灯；上升沿弹一下提示开工。"""
+        active = bool(active)
+        rising = active and not self._agent_active
+        self._agent_active = active
+        if rising:
+            self._bounce(impulse=3.0)
+        self.update()
+
+    def set_last_message(self, text: str) -> None:
+        """记录最近一条 AI 消息（展开卡片里显示摘要）。"""
+        self._last_message = str(text or "").strip()
+        self._sync_card_labels()
+
+    def notify_event(self, kind: str = "generic") -> None:
+        """事件动效入口：reply / balance / tier / generic。尊重 event_effects 开关。"""
+        if not self._event_effects_enabled():
+            return
+        impulse = {"reply": 5.0, "balance": 3.5, "tier": 4.0}.get(kind, 3.0)
+        self._bounce(impulse=impulse)
+        if kind == "reply":
+            self._breathe_until = time.monotonic() + _BREATHE_AFTER_EVENT_S
+            self._ensure_anim_timer()
+
+    def bump(self, strength: float = 1.0, dir_x: float = 0.0, dir_y: float = 0.0) -> None:
+        """被桌宠撞到（果冻墙→水波感）：撞击点荡开涟漪 + 轻微定向踢动。
+
+        dir_x/dir_y 为岛被顶着的方向（单位向量，由碰撞侧从对方 dv 取反得到）；
+        位移与形变只作用于绘制层，窗口几何不动（岛的位置永远由用户拖拽决定）。
+        """
+        if not self._event_effects_enabled():
+            return
+        strength = max(0.2, min(float(strength), 3.0))
+        # 史莱姆受击：表面压扁（弹簧回摆出果冻抖动）+ 轻微定向踢动/倾斜。
+        # 踢动速度钳制：窗口只有 44px 高，多鱼同撞叠加时位移超窗会被裁掉
+        self._squish_v -= 1.15 * strength
+        self._kick_vx = max(-150.0, min(150.0, self._kick_vx + float(dir_x) * 110.0 * strength))
+        self._kick_vy = max(-150.0, min(150.0, self._kick_vy + float(dir_y) * 110.0 * strength))
+        self._tilt_v += 13.0 * strength * (1 if dir_x >= 0 else -1)
+        self._ensure_anim_timer()
+
     def refresh_from_config(self) -> None:
+        old_edge = self.dock_edge
         self._cfg = _cfg_dict(self.config)
         self._schedule_next_balance_tier_refresh()
+        self._sync_card_labels()
+        if self.dock_edge != old_edge:
+            self._apply_position()
+        # 「靠边半隐藏」被关闭时已停靠的岛要复位回正常形态——否则一直是
+        # 16px 细条贴边（碰撞结算也随停靠跳过而长期失效）
+        if not self._edge_dock_enabled() and self._mode == "docked":
+            self._mode = "normal"
+            self._hover_peek = False
+            self._apply_fixed_size()
+            self._apply_position()
         self._refresh()
 
     # ------------------------------------------------------------ 余额峰谷
@@ -105,8 +354,9 @@ class DynamicIsland(QWidget):
             return label
 
     def _on_balance_tier_tick(self) -> None:
-        """到达预设档位切换点：刷新显示，并排下一次准点刷新。"""
+        """到达预设档位切换点：刷新显示、播事件动效，并排下一次准点刷新。"""
         self._refresh()
+        self.notify_event("tier")
         self._schedule_next_balance_tier_refresh()
 
     def _schedule_next_balance_tier_refresh(self) -> None:
@@ -126,9 +376,254 @@ class DynamicIsland(QWidget):
 
     def _refresh(self) -> None:
         """内容变化后立即重算尺寸、夹回屏幕并重绘。"""
+        if self._mode == "docked" and not self._hover_peek:
+            self.update()
+            return
         self._update_size()
         self._clamp_to_screen()
         self.update()
+
+    # ------------------------------------------------------------ 卡片
+    def _build_card(self) -> None:
+        """展开卡片：余额/峰谷两行 + 最近消息 + 三个快捷按钮。默认隐藏。"""
+        self._card_box = QWidget(self)
+        self._card_box.setObjectName("dynamic-island-card")
+        # 卡片底板由窗口 paintEvent 统一绘制（圆角连续），控件容器自身透明
+        self._card_box.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+        self._card_box.setStyleSheet("background: transparent;")
+        layout = QVBoxLayout(self._card_box)
+        layout.setContentsMargins(16, 6, 16, 12)
+        layout.setSpacing(4)
+        self._card_balance_label = QLabel(self._card_box)
+        self._card_tier_label = QLabel(self._card_box)
+        self._card_message_label = QLabel(self._card_box)
+        self._card_message_label.setWordWrap(True)
+        self._card_message_label.setMaximumHeight(34)
+        for label in (self._card_balance_label, self._card_tier_label,
+                      self._card_message_label):
+            layout.addWidget(label)
+        layout.addSpacing(2)
+        button_row = QHBoxLayout()
+        button_row.setSpacing(8)
+        self._card_toggle_btn = QPushButton("显隐桌宠", self._card_box)
+        self._card_chat_btn = QPushButton("聊天", self._card_box)
+        self._card_settings_btn = QPushButton("设置", self._card_box)
+        self._card_toggle_btn.clicked.connect(self._on_card_toggle)
+        self._card_chat_btn.clicked.connect(self._on_card_chat)
+        self._card_settings_btn.clicked.connect(self._on_card_settings)
+        for btn in (self._card_toggle_btn, self._card_chat_btn,
+                    self._card_settings_btn):
+            button_row.addWidget(btn)
+        layout.addLayout(button_row)
+        self._card_box.hide()
+        self._sync_card_labels()
+
+    def _sync_card_labels(self) -> None:
+        if not hasattr(self, "_card_box"):
+            return
+        _bg, primary, secondary = self._style_palette()
+        primary_hex = primary.name() if isinstance(primary, QColor) else "#e5eaf5"
+        secondary_hex = secondary.name() if isinstance(secondary, QColor) else "#a0aabe"
+        accent_hex = self._accent_color().name()
+        self._card_balance_label.setStyleSheet(
+            f"color: {primary_hex}; font-weight: bold; font-size: 14px;")
+        self._card_tier_label.setStyleSheet(f"color: {secondary_hex}; font-size: 11px;")
+        self._card_message_label.setStyleSheet(f"color: {secondary_hex}; font-size: 11px;")
+        # 按钮：圆角 8px、描边跟随主题色、悬停加亮；不用系统默认灰按钮
+        button_style = (
+            f"QPushButton {{ color: {primary_hex}; background: transparent;"
+            f" border: 1px solid {accent_hex}; border-radius: 8px;"
+            f" padding: 4px 10px; font-size: 12px; }}"
+            f"QPushButton:hover {{ background: {accent_hex}; color: #ffffff; }}"
+            f"QPushButton:pressed {{ background: {secondary_hex}; }}"
+        )
+        for btn in (self._card_toggle_btn, self._card_chat_btn,
+                    self._card_settings_btn):
+            btn.setStyleSheet(button_style)
+        self._card_balance_label.setText(self._balance_text)
+        self._card_tier_label.setText(self._balance_tier_text)
+        message = self._last_message or "（暂无最近消息）"
+        # 摘要最多两行，超出省略（标签限高 34px 配合 wordWrap）
+        metrics = self._card_message_label.fontMetrics()
+        elided = metrics.elidedText(
+            message, Qt.TextElideMode.ElideRight, max(40, (_CARD_WIDTH - 32) * 2))
+        self._card_message_label.setText(elided)
+        self._card_toggle_btn.setText("隐藏桌宠" if self._pet_visible else "显示桌宠")
+
+    def resizeEvent(self, event) -> None:  # noqa: N802
+        super().resizeEvent(event)
+        if hasattr(self, "_card_box"):
+            self._card_box.setGeometry(
+                0, _CAPSULE_HEIGHT, self.width(),
+                max(0, self.height() - _CAPSULE_HEIGHT))
+
+    def _on_card_toggle(self) -> None:
+        self.toggle_pet_requested.emit()
+        self.collapse_card()
+
+    def _on_card_chat(self) -> None:
+        self.open_chat_requested.emit()
+        self.collapse_card()
+
+    def _on_card_settings(self) -> None:
+        self.open_settings_requested.emit()
+        self.collapse_card()
+
+    def expand_card(self) -> None:
+        """展开卡片（单击胶囊的默认行为）。停靠状态先滑出再展开。"""
+        if self._mode == "expanded":
+            self.collapse_card()
+            return
+        self._dock_back_timer.stop()
+        self._mode = "expanded"
+        self._hover_peek = False
+        # 单击展开时鼠标多半已在岛内（enterEvent 已把悬停放大目标置 1.02），
+        # 展开态禁用整窗缩放，目标拉回 1.0（见 paintEvent 截边说明）
+        self._hover_scale_target = 1.0
+        self._card_box.show()
+        self._sync_card_labels()
+        self._animate_to(self._target_rect())
+        self._card_collapse_timer.start()
+        self.card_expanded.emit()
+
+    def collapse_card(self, *, animate: bool = True) -> None:
+        """收起卡片；配置为停靠边时收回细条。拖拽起手时 animate=False
+        （动画会与拖拽抢几何，直接把窗拽回停靠位）。"""
+        if self._mode != "expanded":
+            return
+        self._card_collapse_timer.stop()
+        self._card_box.hide()
+        self._mode = "docked" if self.dock_edge != "none" else "normal"
+        self._hover_peek = False
+        if animate:
+            self._animate_to(self._target_rect())
+        else:
+            self._geo_from = None
+            self._geo_to = None
+            self._set_free_geometry(self._target_rect())
+            self._apply_fixed_size()
+
+    # ------------------------------------------------------------ 动效核心
+    def _bounce(self, impulse: float = 4.0) -> None:
+        """事件弹跳：下压几像素再弹簧回位（整数位移，文字不糊）+ 表面轻压。"""
+        self._kick_y = 1.5 + min(float(impulse), 5.0)
+        self._kick_vy = 0.0
+        self._squish_v -= impulse * 0.14
+        self._scale_v += impulse * 0.06
+        self._ensure_anim_timer()
+
+    def _ensure_anim_timer(self) -> None:
+        # 隐藏即休眠：隐藏态不被后台事件（AI 回复/余额刷新）拉起 60fps
+        # 动画定时器空转；showEvent 恢复时会重刷新并重启动效
+        if not self.isVisible():
+            return
+        if not self._anim_timer.isActive():
+            self._anim_last = time.monotonic()
+            self._anim_timer.start()
+
+    def _animating(self) -> bool:
+        return (
+            self._geo_to is not None
+            or abs(self._kick_x) > 0.3 or abs(self._kick_y) > 0.3
+            or abs(self._kick_vx) > 5.0 or abs(self._kick_vy) > 5.0
+            or abs(self._squish - 1.0) > 0.004 or abs(self._squish_v) > 0.02
+            or abs(self._scale - self._hover_scale_target) > 0.001
+            or abs(self._scale_v) > 0.005
+            or abs(self._tilt) > 0.05
+            or abs(self._tilt_v) > 1.0
+            or time.monotonic() < self._breathe_until
+        )
+
+    def _on_anim_tick(self) -> None:
+        now = time.monotonic()
+        dt = now - (self._anim_last or now)
+        self._anim_last = now
+
+        # 几何滑移（停靠/展开）：定时插值，ease-out
+        if self._geo_to is not None and self._geo_from is not None:
+            self._geo_t = min(1.0, self._geo_t + dt / 0.18)
+            k = ease_out_cubic(self._geo_t)
+            rect = QRect(
+                round(self._geo_from.x() + (self._geo_to.x() - self._geo_from.x()) * k),
+                round(self._geo_from.y() + (self._geo_to.y() - self._geo_from.y()) * k),
+                round(self._geo_from.width() + (self._geo_to.width() - self._geo_from.width()) * k),
+                round(self._geo_from.height() + (self._geo_to.height() - self._geo_from.height()) * k),
+            )
+            self._set_free_geometry(rect)
+            if self._geo_t >= 1.0:
+                self._geo_from = None
+                self._geo_to = None
+                self._set_free_geometry(self._target_rect())
+
+        # 位移踢动回位 / 微缩放 / 受击倾斜 / 果冻形变回弹
+        self._kick_x, self._kick_vx = spring_step(
+            self._kick_x, self._kick_vx, 0.0, dt)
+        self._kick_y, self._kick_vy = spring_step(
+            self._kick_y, self._kick_vy, 0.0, dt)
+        self._scale, self._scale_v = spring_step(
+            self._scale, self._scale_v, self._hover_scale_target, dt,
+            stiffness=_SCALE_STIFFNESS, damping=_SCALE_DAMPING)
+        self._scale = max(_SCALE_MIN, min(_SCALE_MAX, self._scale))
+        self._tilt, self._tilt_v = spring_step(
+            self._tilt, self._tilt_v, 0.0, dt,
+            stiffness=_TILT_STIFFNESS, damping=_TILT_DAMPING)
+        self._squish, self._squish_v = spring_step(
+            self._squish, self._squish_v, 1.0, dt,
+            stiffness=_SQUISH_STIFFNESS, damping=_SQUISH_DAMPING)
+        self._squish = max(_SQUISH_MIN, min(_SQUISH_MAX, self._squish))
+        # 踢动位移钳制在窗口内（±5px）：弹簧过冲也不画出界被裁
+        self._kick_x = max(-5.0, min(5.0, self._kick_x))
+        self._kick_y = max(-5.0, min(5.0, self._kick_y))
+        if not self._animating():
+            self._kick_x = self._kick_y = 0.0
+            self._kick_vx = self._kick_vy = 0.0
+            self._squish = 1.0
+            self._scale = 1.0 if self._hover_scale_target == 1.0 else self._hover_scale_target
+            self._tilt = 0.0
+            self._anim_timer.stop()
+        self.update()
+
+    def _finish_animations(self) -> None:
+        """立即跳到所有动画终点（测试与即需布局用）。"""
+        self._anim_timer.stop()
+        self._geo_from = None
+        self._geo_to = None
+        self._kick_x = self._kick_y = 0.0
+        self._kick_vx = self._kick_vy = 0.0
+        self._squish = 1.0
+        self._squish_v = 0.0
+        self._scale = 1.0
+        self._scale_v = 0.0
+        self._tilt = 0.0
+        self._tilt_v = 0.0
+        self._breathe_until = 0.0
+        self._hover_scale_target = 1.0
+        self._set_free_geometry(self._target_rect())
+        self.update()
+
+    def _animate_to(self, target: QRect) -> None:
+        if target == self.geometry() and not self._anim_timer.isActive():
+            self._set_free_geometry(target)
+            return
+        self._geo_from = self.geometry()
+        self._geo_to = target
+        self._geo_t = 0.0
+        self._ensure_anim_timer()
+
+    def _emit_geometry_changed(self) -> None:
+        callback = self.on_geometry_changed
+        if callable(callback):
+            try:
+                callback()
+            except Exception:
+                pass
+
+    def _set_free_geometry(self, rect: QRect) -> None:
+        """动画期间解除固定尺寸直接摆几何；到位后由 _apply_fixed_size 锁定。"""
+        self.setMinimumSize(0, 0)
+        self.setMaximumSize(16777215, 16777215)
+        self.setGeometry(rect)
+        self._emit_geometry_changed()
 
     # ------------------------------------------------------------ 内部
     def _visible_parts(self) -> tuple[bool, bool, bool, bool]:
@@ -164,6 +659,7 @@ class DynamicIsland(QWidget):
             return fallback
         try:
             from . import balance as balance_mod
+
             tier = balance_mod.deepseek_pricing_tier()
         except Exception:
             return fallback
@@ -180,7 +676,7 @@ class DynamicIsland(QWidget):
     def _icon_text(self) -> str:
         return str(self._cfg.get("icon") or "🐳").strip()[:8] or "🐳"
 
-    def _update_size(self) -> None:
+    def _capsule_width(self) -> int:
         icon, name, info, status = self._visible_parts()
         fm = self.fontMetrics()
         # 左右边距各 16px，让状态灯到右边界的距离与图标到左边界的距离一致。
@@ -193,25 +689,97 @@ class DynamicIsland(QWidget):
             width += fm.horizontalAdvance(self._info_text()) + 8
         if status:
             width += 10
-        self.setFixedSize(max(120, width), _CAPSULE_HEIGHT)
+        return max(120, width + _CAPSULE_INSET * 2)
+
+    def _update_size(self) -> None:
+        self._set_free_geometry(QRect(self.pos(), self._rest_size()))
+        self._apply_fixed_size()
+
+    def _rest_size(self) -> QSize:
+        width = self._capsule_width()
+        if self._mode == "expanded":
+            return QSize(max(width, _CARD_WIDTH), _CAPSULE_HEIGHT + _CARD_HEIGHT)
+        return QSize(width, _CAPSULE_HEIGHT)
+
+    def _apply_fixed_size(self) -> None:
+        size = self._rest_size()
+        if self._mode == "docked" and not self._hover_peek:
+            edge = self.dock_edge
+            if edge in ("top", "bottom"):
+                size = QSize(size.width(), _STRIP_THICKNESS)
+            elif edge in ("left", "right"):
+                size = QSize(_STRIP_THICKNESS, _STRIP_SIDE)
+        self.setFixedSize(size)
+
+    def _clamp_rect(self, rect: QRect) -> QRect:
+        screen = self._current_screen()
+        if screen is None:
+            return rect
+        available = screen.availableGeometry()
+        x = max(available.left(), min(rect.x(), available.right() - rect.width() + 1))
+        y = max(available.top(), min(rect.y(), available.bottom() - rect.height() + 1))
+        return QRect(QPoint(x, y), rect.size())
+
+    def _target_rect(self) -> QRect:
+        """当前模式下的目标矩形（停靠细条 / 滑出预览 / 正常胶囊 / 展开卡片）。"""
+        size = self._rest_size()
+        edge = self.dock_edge
+        screen = self._current_screen()
+        if self._mode == "docked" and not self._hover_peek and screen is not None:
+            return strip_rect_for(
+                QRect(self.pos(), size), edge, screen.availableGeometry())
+        if edge != "none" and self._mode in ("docked", "expanded") \
+                and screen is not None:
+            # 从停靠边向内展开：顶/底锚定该边，左右以细条纵向中心展开
+            available = screen.availableGeometry()
+            rect = QRect(self.pos(), size)
+            if edge == "top":
+                rect.moveTop(available.top())
+            elif edge == "bottom":
+                rect.moveBottom(available.bottom())
+            elif edge == "left":
+                rect.moveLeft(available.left())
+                rect.moveTop(self.y() + self.height() // 2 - size.height() // 2)
+            elif edge == "right":
+                rect.moveRight(available.right())
+                rect.moveTop(self.y() + self.height() // 2 - size.height() // 2)
+            return self._clamp_rect(rect)
+        return self._clamp_rect(QRect(self.pos(), size))
+
+    def _current_screen(self):
+        screen = QGuiApplication.screenAt(self.pos()) or QGuiApplication.primaryScreen()
+        return screen
 
     def _apply_position(self) -> None:
         self._update_size()
+        screen = self._current_screen()
+        available = screen.availableGeometry() if screen is not None else None
         x = self._cfg.get("x")
         y = self._cfg.get("y")
-        screen = QGuiApplication.primaryScreen()
-        available = screen.availableGeometry() if screen is not None else None
         if isinstance(x, (int, float)) and isinstance(y, (int, float)):
             pos = QPoint(int(x), int(y))
         else:
-            pos = QPoint(available.right() - self.width() - _EDGE_MARGIN, available.top() + _EDGE_MARGIN) if available else QPoint(100, 100)
-        if available is not None:
-            pos.setX(max(available.left(), min(pos.x(), available.right() - self.width() + 1)))
-            pos.setY(max(available.top(), min(pos.y(), available.bottom() - self.height() + 1)))
+            pos = (
+                QPoint(available.right() - self.width() - _EDGE_MARGIN,
+                       available.top() + _EDGE_MARGIN)
+                if available else QPoint(100, 100)
+            )
         self.move(pos)
+        self._clamp_to_screen()
+        # 展开卡片态不被停靠劫持：卡片是用户当前的交互焦点，设置保存触发的
+        # 位置应用不能把 _mode 改成 docked（卡片会留在 16px 细条上收不起来）；
+        # 收起时 collapse_card 会按 dock_edge 自行决定是否停靠
+        if self.dock_edge != "none" and self._mode != "expanded":
+            self._mode = "docked"
+            self._hover_peek = False
+            target = self._target_rect()
+            self._set_free_geometry(target)
+            self._apply_fixed_size()
 
     def _clamp_to_screen(self) -> None:
-        screen = QGuiApplication.primaryScreen()
+        if self._mode == "docked" and not self._hover_peek:
+            return
+        screen = self._current_screen()
         if screen is None:
             return
         available = screen.availableGeometry()
@@ -219,6 +787,8 @@ class DynamicIsland(QWidget):
         y = max(available.top(), min(self.y(), available.bottom() - self.height() + 1))
         if (x, y) != (self.x(), self.y()):
             self.move(x, y)
+            # 位置校正也要通知碰撞体重提交，否则碰撞体留在旧位置
+            self._emit_geometry_changed()
 
     def _save_position(self) -> None:
         island = dict(self._cfg)
@@ -228,54 +798,226 @@ class DynamicIsland(QWidget):
         self.config.set("dynamic_island", island)
         self.config.save()
 
+    def _save_dock_edge(self, edge: str) -> None:
+        island = dict(self._cfg)
+        island["dock_edge"] = edge if edge in _DOCK_EDGES else "none"
+        self._cfg = island
+        self.config.set("dynamic_island", island)
+        self.config.save()
+
     # ------------------------------------------------------------ 绘制
     def _style_palette(self):
-        """返回 (背景, 主文字色, 次文字色)。背景可为 QColor 或 QLinearGradient。"""
+        """返回 (背景, 主文字色, 次文字色)。背景可为 QColor 或 QLinearGradient。
+
+        所有风格的 alpha 都乘上不透明度设置。
+        """
+        opacity = self._opacity()
         style = str(self._cfg.get("style") or "dark")
         if style == "light":
-            return QColor(255, 255, 255, 242), QColor(31, 35, 40), QColor(107, 114, 128)
+            return (QColor(255, 255, 255, round(242 * opacity)),
+                    QColor(31, 35, 40), QColor(107, 114, 128))
         if style == "glass":
             gradient = QLinearGradient(0, 0, 0, self.height())
-            gradient.setColorAt(0.0, QColor(255, 255, 255, 196))
-            gradient.setColorAt(0.5, QColor(230, 242, 255, 150))
-            gradient.setColorAt(1.0, QColor(255, 255, 255, 210))
+            gradient.setColorAt(0.0, QColor(255, 255, 255, round(196 * opacity)))
+            gradient.setColorAt(0.5, QColor(230, 242, 255, round(150 * opacity)))
+            gradient.setColorAt(1.0, QColor(255, 255, 255, round(210 * opacity)))
             return gradient, QColor(35, 45, 60), QColor(90, 105, 125)
-        return QColor(28, 30, 38, 235), QColor(235, 238, 245), QColor(160, 170, 190)
+        return (QColor(28, 30, 38, round(235 * opacity)),
+                QColor(235, 238, 245), QColor(160, 170, 190))
+
+    def _keyline_color(self) -> QColor:
+        """深色底上的 1px 分界描边（暗壁纸下把胶囊轮廓勾出来）。"""
+        style = str(self._cfg.get("style") or "dark")
+        if style in ("light", "glass"):
+            return QColor(0, 0, 0, 28)
+        return QColor(255, 255, 255, 52)
+
+    @staticmethod
+    def _readable_card_background(background):
+        """展开卡片底板：alpha 钳到下限 215。
+
+        胶囊透明度设置只该影响胶囊本体（不挡视线）；卡片是阅读界面，
+        跟着透明化会让余额/消息直接糊在壁纸上（实机反馈）。QColor 与
+        glass 的 QLinearGradient 两种背景分别钳制。
+        """
+        if isinstance(background, QLinearGradient):
+            clamped = QLinearGradient(background)
+            for pos, color in background.stops():
+                c = QColor(color)
+                c.setAlpha(max(c.alpha(), 215))
+                clamped.setColorAt(pos, c)
+            return clamped
+        c = QColor(background)
+        c.setAlpha(max(c.alpha(), 215))
+        return c
+
+    def _status_dot_color(self) -> QColor:
+        if self._agent_active:
+            return QColor(64, 150, 255)
+        if self._pet_visible:
+            return QColor(80, 220, 120)
+        return QColor(130, 140, 155)
 
     def paintEvent(self, event) -> None:  # noqa: N802
         painter = QPainter(self)
         painter.setRenderHint(QPainter.RenderHint.Antialiasing)
-        rect = QRectF(0, 0, self.width(), self.height())
-        radius = rect.height() / 2.0
 
-        # 柔和阴影：底层半透明圆角矩形
-        shadow = rect.translated(0, 2)
+        # 展开卡片时跳过一切整窗变换（kick 平移/呼吸/倾斜/缩放）：卡片底板
+        # 贴窗口边缘绘制，任何位移或 >1 缩放都会把它顶出窗口被硬切（截边
+        # 实机反馈；kick 来自展开后的余额刷新弹跳，是必然路径）
+        if self._mode == "expanded":
+            tilt, scale = 0.0, 1.0
+        else:
+            # 动效变换：整数位移（文字锐利）+ 呼吸微浮动
+            kick_x = round(self._kick_x)
+            kick_y = round(self._kick_y)
+            if time.monotonic() < self._breathe_until:
+                kick_y += round(1.5 * math.sin(time.monotonic() * 2.6))
+            if kick_x or kick_y:
+                painter.translate(kick_x, kick_y)
+            tilt = max(-_TILT_MAX_DEG, min(_TILT_MAX_DEG, self._tilt))
+            scale = max(_SCALE_MIN, min(_SCALE_MAX, self._scale))
+        if tilt or scale != 1.0:
+            cx = self.width() / 2.0
+            cy = min(self.height(), _CAPSULE_HEIGHT) / 2.0
+            painter.translate(cx, cy)
+            painter.rotate(tilt)
+            painter.scale(scale, scale)
+            painter.translate(-cx, -cy)
+
+        if self._mode == "docked" and not self._hover_peek:
+            self._paint_strip(painter)
+        else:
+            self._paint_capsule(painter)
+        painter.end()
+
+    def _squished_capsule_rect(self) -> tuple[QRectF, float]:
+        """果冻形变后的胶囊绘制矩形（内缩 _CAPSULE_INSET 留形变余量）。
+
+        只返回外形的几何——文字/图标不在这里面变换，保持锐利。
+        squish<1 时竖向压扁、横向鼓出（面积大致守恒），绕胶囊中心形变。
+        """
+        base = QRectF(_CAPSULE_INSET, _CAPSULE_INSET,
+                      self.width() - _CAPSULE_INSET * 2,
+                      _CAPSULE_HEIGHT - _CAPSULE_INSET * 2)
+        # 展开卡片态冻结形变（与整窗变换禁用同口径）：squish 鼓出会把
+        # 贴边底板两侧的胶囊圆角削掉（实测 342.8px > 340px 窗口宽）
+        squish = 1.0 if self._mode == "expanded" else \
+            max(_SQUISH_MIN, min(_SQUISH_MAX, self._squish))
+        if abs(squish - 1.0) < 0.002:
+            return base, base.height() / 2.0
+        sy = squish
+        sx = 1.0 + (1.0 - sy) * 0.3  # 竖压横鼓（权重打折，鼓出不超出内缩余量）
+        w, h = base.width() * sx, base.height() * sy
+        cx, cy = base.center().x(), base.center().y()
+        return QRectF(cx - w / 2.0, cy - h / 2.0, w, h), h / 2.0
+
+    def _paint_strip(self, painter: QPainter) -> None:
+        """停靠细条：圆角条 + 靠屏侧主题色亮线 + 状态点（竖条加图标）。"""
+        rect = QRectF(0, 0, self.width(), self.height())
+        radius = min(rect.width(), rect.height()) / 2.0
+        background, primary, _secondary = self._style_palette()
+        opacity = self._opacity()
+        if isinstance(background, QColor):
+            base = QColor(background)
+            base.setAlpha(min(255, round(210 * opacity)))
+        else:
+            base = QColor(255, 255, 255, round(210 * opacity))
         painter.setPen(Qt.PenStyle.NoPen)
-        painter.setBrush(QColor(0, 0, 0, 46))
-        painter.drawRoundedRect(shadow, radius, radius)
+        painter.setBrush(base)
+        painter.drawRoundedRect(rect, radius, radius)
+
+        # 靠屏一侧的 2px 亮线（深壁纸上也能一眼找到细条）
+        accent = QColor(self._accent_color())
+        accent.setAlpha(220)
+        painter.setBrush(accent)
+        edge = self.dock_edge
+        if edge == "top":
+            painter.drawRoundedRect(QRectF(6, 0, rect.width() - 12, 2), 1, 1)
+        elif edge == "bottom":
+            painter.drawRoundedRect(QRectF(6, rect.height() - 2, rect.width() - 12, 2), 1, 1)
+        elif edge == "left":
+            painter.drawRoundedRect(QRectF(0, 6, 2, rect.height() - 12), 1, 1)
+        elif edge == "right":
+            painter.drawRoundedRect(QRectF(rect.width() - 2, 6, 2, rect.height() - 12), 1, 1)
+
+        dot_size = 8
+        painter.setBrush(self._status_dot_color())
+        if edge in ("left", "right"):
+            # 竖条：上方角色图标（小字号防裁切）、下方状态点
+            painter.setPen(primary if isinstance(primary, QColor) else QColor(31, 35, 40))
+            icon_font = painter.font()
+            icon_font.setPixelSize(11)
+            painter.setFont(icon_font)
+            fm = painter.fontMetrics()
+            painter.drawText(
+                QRectF(0, 8, rect.width(), fm.height()),
+                Qt.AlignmentFlag.AlignCenter, self._icon_text())
+            painter.setPen(Qt.PenStyle.NoPen)
+            painter.setBrush(self._status_dot_color())
+            painter.drawEllipse(QRectF(
+                (rect.width() - dot_size) / 2, rect.height() - dot_size - 8,
+                dot_size, dot_size))
+        else:
+            painter.drawEllipse(QRectF(
+                (rect.width() - dot_size) / 2, (rect.height() - dot_size) / 2,
+                dot_size, dot_size))
+
+    def _paint_capsule(self, painter: QPainter) -> None:
+        # 展开时先画卡片底板（胶囊下方一整块，圆角连续；内容区遵守同心圆角）
+        if self._mode == "expanded":
+            panel = QRectF(0, 0, self.width(), self.height())
+            background, _p, _s = self._style_palette()
+            # 卡片底板走可读性钳制（不随胶囊透明度降下去）
+            background = self._readable_card_background(background)
+            painter.setPen(Qt.PenStyle.NoPen)
+            painter.setBrush(QColor(0, 0, 0, 40))
+            painter.drawRoundedRect(panel.translated(0, 2), 18, 18)
+            painter.setBrush(background)
+            painter.drawRoundedRect(panel, 18, 18)
+            painter.setPen(QPen(self._keyline_color(), 1))
+            painter.setBrush(Qt.BrushStyle.NoBrush)
+            painter.drawRoundedRect(panel.adjusted(0.5, 0.5, -0.5, -0.5), 17.5, 17.5)
+
+        # 胶囊外形：内缩 _CAPSULE_INSET + 果冻形变（只有外形参与 squish）
+        rect, radius = self._squished_capsule_rect()
+
+        # 柔和阴影：底层半透明圆角矩形（跟随形变）
+        if self._mode != "expanded":
+            shadow = rect.translated(0, 2)
+            painter.setPen(Qt.PenStyle.NoPen)
+            painter.setBrush(QColor(0, 0, 0, 46))
+            painter.drawRoundedRect(shadow, radius, radius)
 
         # 胶囊主体（白色 / 黑色 / 玻璃质感）
         background, primary_color, secondary_color = self._style_palette()
         painter.setBrush(background)
         painter.setPen(Qt.PenStyle.NoPen)
         painter.drawRoundedRect(rect, radius, radius)
-        if str(self._cfg.get("style") or "dark") == "glass":
+        style = str(self._cfg.get("style") or "dark")
+        if style == "glass":
             # 玻璃高光描边，强化“液化玻璃”边缘
             painter.setPen(QPen(QColor(255, 255, 255, 130), 1))
             painter.setBrush(Qt.BrushStyle.NoBrush)
             painter.drawRoundedRect(rect.adjusted(0.5, 0.5, -0.5, -0.5), radius - 0.5, radius - 0.5)
+        else:
+            # 深色底 key line：在暗壁纸上把轮廓勾出来
+            painter.setPen(QPen(self._keyline_color(), 1))
+            painter.setBrush(Qt.BrushStyle.NoBrush)
+            painter.drawRoundedRect(rect.adjusted(0.5, 0.5, -0.5, -0.5), radius - 0.5, radius - 0.5)
 
+        # 内容（图标/名称/信息/状态灯）：按未形变的静止位绘制，绝不参与形变
         icon, name, info, status = self._visible_parts()
-        x = 16.0
+        x = _CAPSULE_INSET + 13.0
         painter.setPen(Qt.PenStyle.NoPen)
         if icon:
-            painter.setBrush(QColor(64, 184, 255, 255))
-            painter.drawEllipse(QRectF(x, (self.height() - 26) / 2, 26, 26))
+            painter.setBrush(self._accent_color())
+            painter.drawEllipse(QRectF(x, (_CAPSULE_HEIGHT - 26) / 2, 26, 26))
             painter.setPen(QColor(255, 255, 255))
             fm = self.fontMetrics()
             icon_text = self._icon_text()
             painter.drawText(
-                QRectF(x, (self.height() - fm.height()) / 2 - 1, 26, fm.height()),
+                QRectF(x, (_CAPSULE_HEIGHT - fm.height()) / 2 - 1, 26, fm.height()),
                 Qt.AlignmentFlag.AlignCenter,
                 icon_text,
             )
@@ -286,7 +1028,7 @@ class DynamicIsland(QWidget):
         if name:
             text = self._character_name()
             painter.drawText(
-                QRectF(x, 0, self.fontMetrics().horizontalAdvance(text), self.height()),
+                QRectF(x, 0, self.fontMetrics().horizontalAdvance(text), _CAPSULE_HEIGHT),
                 Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignLeft,
                 text,
             )
@@ -296,7 +1038,7 @@ class DynamicIsland(QWidget):
             info_text = self._info_text()
             painter.setPen(self._info_color(secondary_color))
             painter.drawText(
-                QRectF(x, 0, self.fontMetrics().horizontalAdvance(info_text), self.height()),
+                QRectF(x, 0, self.fontMetrics().horizontalAdvance(info_text), _CAPSULE_HEIGHT),
                 Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignLeft,
                 info_text,
             )
@@ -304,13 +1046,53 @@ class DynamicIsland(QWidget):
 
         if status:
             dot_size = 10
-            dot_color = QColor(80, 220, 120) if self._pet_visible else QColor(130, 140, 155)
             painter.setPen(Qt.PenStyle.NoPen)
-            painter.setBrush(dot_color)
-            painter.drawEllipse(QRectF(x, (self.height() - dot_size) / 2, dot_size, dot_size))
+            painter.setBrush(self._status_dot_color())
+            painter.drawEllipse(QRectF(x, (_CAPSULE_HEIGHT - dot_size) / 2, dot_size, dot_size))
             x += dot_size + 12
 
-        painter.end()
+    # ------------------------------------------------------------ 显隐休眠
+    def hideEvent(self, event) -> None:  # noqa: N802
+        """隐藏即休眠：信息轮询/动效/停靠收回/卡片自动收起全部停表，
+        隐藏态零定时器空转。"""
+        super().hideEvent(event)
+        self._info_timer.stop()
+        self._tier_tick_timer.stop()
+        self._anim_timer.stop()
+        self._dock_back_timer.stop()
+        self._card_collapse_timer.stop()
+
+    def showEvent(self, event) -> None:  # noqa: N802
+        """重新显示：恢复信息轮询并立即刷新（沉睡期间的内容变化补上），
+        几何直接归位（隐藏可能打断了停靠/展开动画）。"""
+        super().showEvent(event)
+        self._finish_animations()
+        self._info_timer.start()
+        self._schedule_next_balance_tier_refresh()
+        self._refresh()
+
+    # ------------------------------------------------------------ 悬停
+    def enterEvent(self, event) -> None:  # noqa: N802
+        # 展开卡片时不悬停放大（整窗缩放会截掉贴边的卡片底板，见 paintEvent）
+        self._hover_scale_target = 1.0 if self._mode == "expanded" else 1.02
+        if self._mode == "docked" and not self._hover_peek:
+            self._dock_back_timer.stop()
+            self._hover_peek = True
+            self._animate_to(self._target_rect())
+        self._ensure_anim_timer()
+        super().enterEvent(event)
+
+    def leaveEvent(self, event) -> None:  # noqa: N802
+        self._hover_scale_target = 1.0
+        if self._mode == "docked" and self._hover_peek:
+            self._dock_back_timer.start()
+        self._ensure_anim_timer()
+        super().leaveEvent(event)
+
+    def _dock_back(self) -> None:
+        if self._mode == "docked" and self._hover_peek:
+            self._hover_peek = False
+            self._animate_to(self._target_rect())
 
     # ------------------------------------------------------------ 鼠标
     def mousePressEvent(self, event) -> None:  # noqa: N802
@@ -328,25 +1110,81 @@ class DynamicIsland(QWidget):
         global_pos = event.globalPosition().toPoint()
         if not self._dragging and (global_pos - self._press_global).manhattanLength() >= QApplication.startDragDistance():
             self._dragging = True
+            # 起拖先清几何插值状态（滑出/停靠/归位动画的目标）：否则动画
+            # 每 16ms 把窗口拽回目标位，与拖拽 move() 互抢（不跟手/60Hz
+            # 抖动，且期间碰撞结算被 _geo_to 守卫全程跳过）。注意不停动画
+            # 表：_on_anim_tick 只在 _geo_to 非 None 时插值几何，停表会把
+            # squish/kick 弹簧冻在中途
+            self._geo_from = None
+            self._geo_to = None
+            if self._mode == "expanded":
+                self.collapse_card(animate=False)  # 拖拽起手直接落位，不播收起动画
+            if self._mode == "docked":
+                # 拖出停靠：进入正常模式跟随光标
+                self._mode = "normal"
+                self._hover_peek = False
+                self._apply_fixed_size()
         if self._dragging and self._drag_offset is not None:
             self.move(global_pos - self._drag_offset)
+            self._emit_geometry_changed()
             event.accept()
 
     def mouseReleaseEvent(self, event) -> None:  # noqa: N802
         if event.button() != Qt.MouseButton.LeftButton:
             return
+        screen = self._current_screen()
+        available = screen.availableGeometry() if screen is not None else None
         if not self._dragging:
-            self.clicked.emit()
+            if self._mode == "docked" and not self._hover_peek:
+                # 细条单击 = 滑出预览（不停留展开卡片，保持轻量）
+                self._hover_peek = True
+                self._animate_to(self._target_rect())
+                self._dock_back_timer.start()
+            elif self._click_action() == "toggle_pet":
+                self.clicked.emit()
+            else:
+                self.expand_card()
         else:
-            available = QGuiApplication.primaryScreen().availableGeometry() if QGuiApplication.primaryScreen() else None
+            # 先夹回屏幕再判定停靠：拖出屏外的落点按夹后位置算距离
             if available is not None:
                 x = max(available.left(), min(self.x(), available.right() - self.width() + 1))
                 y = max(available.top(), min(self.y(), available.bottom() - self.height() + 1))
-                if y <= available.top() + _SNAP_TOP_THRESHOLD:
-                    y = available.top()
                 self.move(x, y)
+            edge = "none"
+            if available is not None and self._edge_dock_enabled():
+                edge = dock_edge_for(self.geometry(), available)
+                rect = self.geometry()
+                logger.info(
+                    "灵动岛拖拽落点 (%d,%d)：距四边 top=%d bottom=%d left=%d right=%d"
+                    "（阈值 %d）→ dock=%s",
+                    rect.x(), rect.y(),
+                    abs(rect.top() - available.top()),
+                    abs(available.bottom() - rect.bottom()),
+                    abs(rect.left() - available.left()),
+                    abs(available.right() - rect.right()),
+                    _DOCK_THRESHOLD, edge)
+            self._save_dock_edge(edge)
             self._save_position()
+            if edge != "none":
+                self._mode = "docked"
+                self._hover_peek = False
+                self._animate_to(self._target_rect())
+            elif self._mode == "docked":
+                self._mode = "normal"
+                self._animate_to(self._target_rect())
         self._press_global = None
         self._drag_offset = None
         self._dragging = False
+        self._emit_geometry_changed()
         event.accept()
+
+    # ------------------------------------------------------------ 测试钩子
+    def _debug_state(self) -> dict:
+        """测试用快照：模式/停靠边/几何动画是否活跃。"""
+        return {
+            "mode": self._mode,
+            "dock_edge": self.dock_edge,
+            "hover_peek": self._hover_peek,
+            "animating": self._anim_timer.isActive(),
+            "card_visible": self._card_box.isVisible(),
+        }

--- a/pet/island_collision.py
+++ b/pet/island_collision.py
@@ -1,0 +1,507 @@
+# -*- coding: utf-8 -*-
+"""灵动岛碰撞（本进程直连版，stadium 几何）。
+
+为什么重写（IPC 版的实机教训）：岛作为 FLAG_STATIC 成员进碰撞世界后，
+保活/快照/预测抑制/客户端阈值任何一环被 GUI 卡顿饿死，表现就是
+"撞了没反应/直接穿过去"。本进程直连后：
+
+- 30Hz 本地检测：岛建模为体育场形（stadium = 中轴矩形 + 两端半圆），
+  法线取"胶囊轴线最近点"方向——宽胶囊从正上/正下方撞不再被斜着弹飞；
+- 桌宠圆链带上帧扫掠（TOI），高速甩不穿；彻底穿过的放回接触点再弹回；
+- 岛是无限质量墙但保留弹性（STATIC_RESTITUTION，撞岛像撞弹床）；
+- 拖岛扫鱼：岛速参与相对速度（岛=移动的拍子）；深度重叠时按相对运动
+  方向解围（岛从哪边来，鱼往哪边飞）；
+- 命中反应复用桌宠侧既有的真实撞击路径（进抛掷物理/音效/挤压动画），
+  与鱼撞鱼手感一致；
+- 低占用：CoarseTimer（不用精确定时器，避免拉高系统时钟分辨率），
+  每 tick 只做几次几何查询 + AABB 预筛，亚毫秒级。
+
+取舍：独立进程的桌宠实例不在本进程视野内，会穿过岛。常规使用（含单进程
+多开）全部覆盖；这个取舍换来的是零时序风险。
+"""
+from __future__ import annotations
+
+import logging
+import math
+import time
+
+from PySide6.QtCore import QObject, Qt, QTimer
+
+from . import collision
+from . import physics as physics_mod
+
+log = logging.getLogger(__name__)
+
+_TICK_MS = 33               # 30Hz 本地检测（空闲时几何未变整体跳过，近零开销）
+_APPROACH_MIN_SPEED = 20.0  # 相对接近速度低于此视为轻贴：只做分离不弹飞
+_HIT_COOLDOWN_S = 0.15      # 每只桌宠的命中冷却（防一帧多弹）
+_CAPSULE_HEIGHT = 44        # 胶囊视觉高度（与 dynamic_island._CAPSULE_HEIGHT 同步）
+_MAX_ISLAND_SPEED = 1500.0  # 岛速估计上限（px/s）：异常大的估计不进拍鱼结算
+
+
+def _segment_circle_entry(p0: tuple[float, float], p1: tuple[float, float],
+                          center: tuple[float, float], radius: float) -> float | None:
+    """线段进入圆的最早时刻 t∈[0,1]（TOI）；起点已在圆内返回 0，未进入 None。"""
+    dx, dy = p1[0] - p0[0], p1[1] - p0[1]
+    fx, fy = p0[0] - center[0], p0[1] - center[1]
+    c = fx * fx + fy * fy - radius * radius
+    if c <= 0.0:
+        return 0.0
+    a = dx * dx + dy * dy
+    if a <= 1e-9:
+        return None
+    b = 2.0 * (fx * dx + fy * dy)
+    disc = b * b - 4.0 * a * c
+    if disc < 0.0:
+        return None
+    t = (-b - math.sqrt(disc)) / (2.0 * a)
+    return t if 0.0 <= t <= 1.0 else None
+
+
+def _segment_rect_entry(p0: tuple[float, float], p1: tuple[float, float],
+                        left: float, top: float, right: float, bottom: float) -> float | None:
+    """线段进入轴对齐矩形的最早时刻 t∈[0,1]（slab 法）；起点在内返回 0。"""
+    if left <= p0[0] <= right and top <= p0[1] <= bottom:
+        return 0.0
+    dx, dy = p1[0] - p0[0], p1[1] - p0[1]
+    t_enter, t_exit = 0.0, 1.0
+    for p, d, lo, hi in ((p0[0], dx, left, right), (p0[1], dy, top, bottom)):
+        if abs(d) <= 1e-12:
+            if p < lo or p > hi:
+                return None
+            continue
+        t0, t1 = (lo - p) / d, (hi - p) / d
+        if t0 > t1:
+            t0, t1 = t1, t0
+        t_enter, t_exit = max(t_enter, t0), min(t_exit, t1)
+        if t_enter > t_exit:
+            return None
+    return t_enter
+
+
+class IslandCollisionBody(QObject):
+    """灵动岛的本进程碰撞体：30Hz 本地检测 + stadium 几何 + 岛速估计。"""
+
+    def __init__(self, island, config, pets_provider=None, parent=None):
+        super().__init__(parent if isinstance(parent, QObject) else None)
+        self._island = island
+        self._config = config
+        # 返回本进程全部桌宠窗口的回调（AppShell 注入）
+        self._pets_provider = pets_provider or (lambda: ())
+        self._running = False
+        # 岛自身的运动速度（拖岛扫鱼时岛是"移动的墙"）
+        self._last_center: tuple[float, float] | None = None
+        self._last_motion_ts = 0.0
+        self._last_size: tuple[int, int] | None = None
+        self._vx = 0.0
+        self._vy = 0.0
+        # 桌宠跟踪：上帧中心/时间（扫掠+实测速度）与命中冷却、挤压错峰
+        self._pet_prev: dict[int, tuple[float, float]] = {}
+        self._pet_prev_ts: dict[int, float] = {}
+        self._pet_cooldown: dict[int, float] = {}
+        self._pet_squash: dict[int, float] = {}
+        self._timer = QTimer(self)
+        self._timer.setInterval(_TICK_MS)
+        # 30Hz 碰撞探测不需要精确定时器：PreciseTimer 会拉高系统时钟分辨率、
+        # 抑制 CPU 深睡，常年挂机的桌宠付不起这个电池税（CoarseTimer 5% 容差足够）
+        self._timer.setTimerType(Qt.TimerType.CoarseTimer)
+        self._timer.timeout.connect(self._tick)
+
+    # ------------------------------------------------------------ 生命周期
+    def start(self) -> None:
+        if self._running:
+            return
+        self._running = True
+        self._timer.start()
+        log.info("灵动岛碰撞体已启动（本进程直连）")
+
+    def stop(self) -> None:
+        if not self._running:
+            return
+        self._running = False
+        self._timer.stop()
+        self._pet_prev.clear()
+        self._pet_prev_ts.clear()
+        self._pet_cooldown.clear()
+        self._pet_squash.clear()
+        self._last_center = None
+        self._last_motion_ts = 0.0
+        self._last_size = None
+        self._vx = self._vy = 0.0
+        log.info("灵动岛碰撞体已停止")
+
+    def set_own_pet_visible(self, visible: bool) -> None:
+        """本进程桌宠可见性回调（AppShell 接线保留）：本地版无挂起语义，
+        仅留日志便于排查。"""
+        log.debug("灵动岛碰撞体：本进程桌宠可见性=%s", bool(visible))
+
+    def submit(self) -> None:
+        """岛几何变化钩子（island.on_geometry_changed）：刷新岛速估计。"""
+        self._update_motion()
+
+    # ------------------------------------------------------------ 岛速估计
+    def _update_motion(self) -> None:
+        """从相邻两次采样的中心位移估计岛速；静止/异常间隔时清零。
+
+        采样间隔下限（0.01s）是"跳过"而不是"清零"：拖拽时几何回调可达
+        100Hz+（每次 mouseMove 都 submit），dt 常落在 0.01 以下——若按
+        旧逻辑清零并刷新采样点，拖拽全程岛速恒为 0，"拖岛拍鱼"就退化成
+        只推挤不弹飞（实机教训）。跳过采样等间隔累积够再估计即可。
+        """
+        # 岛的展开/停靠/归位动画是程序驱动的几何变化（60fps），不是拖拽；
+        # 期间不采样不估计（展开动画峰值速度约 2600px/s，会把旁边静止的
+        # 鱼"凭空拍飞"——审查实测）。动画结束后的首次采样重建基线。
+        if getattr(self._island, "_geo_to", None) is not None:
+            self._vx = self._vy = 0.0
+            self._last_center = None
+            return
+        rect = self._island.geometry()
+        size = (rect.width(), rect.height())
+        if self._last_size is not None and size != self._last_size:
+            # 窗口尺寸变化（展开/收起卡片、停靠切换、文本变长）会平移窗口
+            # 中心，但胶囊碰撞体本体未必动——size 变了只重置采样点不估计
+            self._vx = self._vy = 0.0
+            self._last_center = None
+            self._last_size = size
+            return
+        self._last_size = size
+        cx, cy = float(rect.center().x()), float(rect.center().y())
+        now = time.monotonic()
+        if self._last_center is not None:
+            dt = now - self._last_motion_ts
+            if dt < 0.01:
+                return  # 高频回调样本太密：保留上次速度，不刷新采样点
+            dx, dy = cx - self._last_center[0], cy - self._last_center[1]
+            jump = math.hypot(dx, dy)
+            # 瞬移跳变守卫（与桌宠侧 jump_guard 对称）：配置变更/换屏/夹回
+            # 屏幕造成的跳变不参与估计——位移超过"极速拖拽×间隔 + 窗口宽度"
+            # 即视为瞬移，速度清零并只重置采样点（上限钳制挡不住这种拍飞）
+            if jump > 3000.0 * dt + rect.width():
+                self._vx = self._vy = 0.0
+                self._last_center = (cx, cy)
+                self._last_motion_ts = now
+                return
+            if dt <= 0.5 and jump >= 1.0:
+                vx, vy = dx / dt, dy / dt
+                speed = math.hypot(vx, vy)
+                if speed > _MAX_ISLAND_SPEED:
+                    if getattr(self._island, "_dragging", False):
+                        # 拖拽中的快速甩动是合法拍鱼：钳到上限
+                        vx *= _MAX_ISLAND_SPEED / speed
+                        vy *= _MAX_ISLAND_SPEED / speed
+                    else:
+                        # 非拖拽的极速位移必是瞬移/尺寸变化残留（真实拖拽
+                        # 之外的岛移动没有合法的高速来源）：清零并重置采样点
+                        self._vx = self._vy = 0.0
+                        self._last_center = (cx, cy)
+                        self._last_motion_ts = now
+                        self._last_size = (rect.width(), rect.height())
+                        return
+                self._vx, self._vy = vx, vy
+            else:
+                self._vx = 0.0
+                self._vy = 0.0
+        self._last_center = (cx, cy)
+        self._last_motion_ts = now
+
+    # ------------------------------------------------------------ 几何
+    def _island_stadium(self) -> tuple[float, float, float, float, float]:
+        """岛的体育场形：(axis_x0, axis_x1, axis_y, radius, rect_height)。
+
+        展开卡片时只覆盖胶囊本体（卡片区域不设幽灵墙）。
+        """
+        rect = self._island.geometry()
+        height = min(rect.height(), _CAPSULE_HEIGHT)
+        radius = height / 2.0
+        axis_y = rect.y() + radius
+        return (rect.x() + radius, rect.x() + rect.width() - radius,
+                axis_y, radius, height)
+
+    @staticmethod
+    def _axis_closest(stadium, px: float, py: float) -> tuple[float, float]:
+        """胶囊轴线上离 (px, py) 最近的点。"""
+        ax0, ax1, ay, _radius, _h = stadium
+        return (min(max(px, ax0), ax1), ay)
+
+    def _stadium_entry(self, p0: tuple[float, float], p1: tuple[float, float],
+                       stadium, pet_radius: float) -> float | None:
+        """圆心从 p0 扫到 p1 进入体育场形（外扩 pet_radius）的最早 TOI。"""
+        ax0, ax1, ay, rr, _h = stadium
+        expanded = pet_radius + rr
+        candidates = [
+            _segment_circle_entry(p0, p1, (ax0, ay), expanded),
+            _segment_circle_entry(p0, p1, (ax1, ay), expanded),
+            _segment_rect_entry(p0, p1, ax0, ay - expanded, ax1, ay + expanded),
+        ]
+        hits = [t for t in candidates if t is not None]
+        return min(hits) if hits else None
+
+    def _normal(self, stadium, ref: tuple[float, float],
+                vrel: tuple[float, float]) -> tuple[float, float, bool]:
+        """法线选择：优先"轴线最近点 → 参考点"的表面法线；但它与相对运动
+        近垂直（岛侧向铲进桌宠体内，如拖岛横扫）时，按相对运动方向解围
+        （岛从哪边来，鱼往哪边飞）。返回 (nx, ny, 是否解围方向)。"""
+        _ax0, _ax1, _ay, rr, _h = stadium
+        closest = self._axis_closest(stadium, ref[0], ref[1])
+        nx, ny = ref[0] - closest[0], ref[1] - closest[1]
+        norm = math.hypot(nx, ny)
+        speed = math.hypot(*vrel)
+        if norm >= rr * 0.6 and norm > 1e-9:
+            axis_nx, axis_ny = nx / norm, ny / norm
+            if speed <= 1.0 or abs(vrel[0] * axis_nx + vrel[1] * axis_ny) >= speed * 0.3:
+                return axis_nx, axis_ny, False
+        if speed > 1.0:
+            return -vrel[0] / speed, -vrel[1] / speed, True
+        return 0.0, -1.0, False
+
+    # ------------------------------------------------------------ 主循环
+    def _tick(self) -> None:
+        if not self._running or not self._island.isVisible():
+            return
+        # 停靠细条态不结算：细条是 16×64 的竖条，与 stadium 的水平轴假设
+        # 不符（会产生向右 28px 的幻影墙）；贴屏边细条的碰撞价值低，悬停
+        # 滑出（peek）恢复胶囊形态后照常结算
+        if getattr(self._island, "_mode", "") == "docked" \
+                and not getattr(self._island, "_hover_peek", False):
+            self._last_center = None  # 恢复检测时重建采样基线
+            return
+        # 几何动画（展开/停靠/归位/滑出）进行中一律不结算：几何每 16ms
+        # 在变，stadium 与视觉形态不一致（滑出首帧仍是细条矩形）
+        if getattr(self._island, "_geo_to", None) is not None:
+            self._last_center = None
+            self._vx = self._vy = 0.0
+            return
+        self._update_motion()
+        stadium = self._island_stadium()
+        island_rect = self._island.geometry()
+        now = time.monotonic()
+        alive_keys: set[int] = set()
+        for win in self._pets_provider():
+            try:
+                self._check_pet(win, stadium, island_rect, now, alive_keys)
+            except RuntimeError:
+                continue  # 窗口已销毁
+            except Exception:  # noqa: BLE001 - 单只异常不拖垮检测循环
+                log.warning("灵动岛碰撞检测跳过异常桌宠", exc_info=True)
+        # 清理离场桌宠的跟踪状态
+        self._pet_prev = {k: v for k, v in self._pet_prev.items() if k in alive_keys}
+        self._pet_prev_ts = {k: v for k, v in self._pet_prev_ts.items() if k in alive_keys}
+        self._pet_cooldown = {k: v for k, v in self._pet_cooldown.items() if k in alive_keys}
+        self._pet_squash = {k: v for k, v in self._pet_squash.items() if k in alive_keys}
+
+    def _check_pet(self, win, stadium, island_rect, now: float, alive_keys: set[int]) -> None:
+        if win is None:
+            return
+        key = id(win)
+        alive_keys.add(key)
+        if not win.isVisible() or getattr(win, "_hidden_paused", False):
+            self._pet_prev.pop(key, None)
+            self._pet_cooldown.pop(key, None)
+            return
+        # 注意：不读桌宠的全局碰撞开关（collision_enabled 的语义是
+        # 「多开桌宠之间碰撞」，设置页文案同）；果冻墙是否生效只由灵动岛
+        # 自己的开关管（app.py _sync_island_collision 的启停）
+        # 拖拽中的桌宠不结算（用户在摆放它，松手后才有相对运动）
+        if getattr(win, "_physics_mode", "") == "drag" \
+                or getattr(win, "_interaction_state", "") == "DRAGGING":
+            self._pet_prev.pop(key, None)
+            self._pet_cooldown.pop(key, None)
+            return
+        rect = win.collision_content_rect()
+        center = (float(rect.center().x()), float(rect.center().y()))
+        prev = self._pet_prev.get(key)
+        prev_ts = self._pet_prev_ts.get(key)
+        self._pet_prev[key] = center
+        self._pet_prev_ts[key] = now
+
+        pet_radius = max(rect.width(), rect.height()) / 2.0
+        # 瞬移守卫：跳变超过"极速飞行 × 间隔 + 体型余量"（传送/缩放/切屏）
+        # 不扫掠，避免把瞬移轨迹当成高速路径产生幽灵命中；合法的高速甩出
+        # （4800px/s × 100ms 才 480px）必须放行——守卫跟着 dt 走
+        dt_guard = (now - prev_ts) if prev_ts is not None else 0.0
+        jump_guard = 5000.0 * max(dt_guard, 0.02) \
+            + island_rect.width() + max(rect.width(), rect.height())
+        if prev is None or prev_ts is None \
+                or math.hypot(center[0] - prev[0], center[1] - prev[1]) > jump_guard:
+            if self._overlaps_stadium(center, pet_radius, stadium):
+                self._separate_from_stadium(win, center, pet_radius, stadium,
+                                            island_rect, now, key)
+            return
+
+        # 实测速度（位移/真实间隔）比 _phys_vel 更可靠：漫游走路的桌宠
+        # _phys_vel 常为零或残留，扫掠接近判定要用真实位移
+        dt = now - prev_ts
+        if dt > 1e-3:
+            measured_vx = (center[0] - prev[0]) / dt
+            measured_vy = (center[1] - prev[1]) / dt
+            # 整型窗口坐标的量化噪声：±1px / 33ms ≈ 30px/s，低于此按静止计
+            if math.hypot(measured_vx, measured_vy) < 30.0:
+                measured_vx = measured_vy = 0.0
+        else:
+            measured_vx = measured_vy = 0.0
+
+        # AABB 预筛：扫掠路径包围盒（外扩桌宠半径）与岛不相交 → 必不撞
+        path_left = min(prev[0], center[0]) - pet_radius
+        path_right = max(prev[0], center[0]) + pet_radius
+        path_top = min(prev[1], center[1]) - pet_radius
+        path_bottom = max(prev[1], center[1]) + pet_radius
+        if path_right < island_rect.x() or path_left > island_rect.right() \
+                or path_bottom < island_rect.y() \
+                or path_top > island_rect.y() + island_rect.height():
+            return
+
+        toi = self._stadium_entry(prev, center, stadium, pet_radius)
+        if toi is None:
+            return
+        if now - self._pet_cooldown.get(key, 0.0) < _HIT_COOLDOWN_S:
+            return
+        entry = (prev[0] + (center[0] - prev[0]) * toi,
+                 prev[1] + (center[1] - prev[1]) * toi)
+        currently_overlapping = self._overlaps_stadium(center, pet_radius, stadium)
+        vrel = (measured_vx - self._vx, measured_vy - self._vy)
+        ref = center if currently_overlapping else entry
+        nx, ny, is_fallback = self._normal(stadium, ref, vrel)
+        vn = vrel[0] * nx + vrel[1] * ny
+        # 解围方向（与运动近垂直时取 -vrel）下 vn = -|vrel|：方向不可靠，
+        # 只放行真有速度的横扫/甩（100px/s），防量化噪声把静置鱼弹飞
+        approach_floor = 100.0 if is_fallback else _APPROACH_MIN_SPEED
+        if vn >= -approach_floor:
+            if currently_overlapping:
+                # 贴着重叠但不接近：只把桌宠推出岛体（防嵌入累积）
+                self._separate_from_stadium(win, center, pet_radius, stadium,
+                                            island_rect, now, key)
+            return
+        self._pet_cooldown[key] = now
+        dv = -(1.0 + collision.STATIC_RESTITUTION) * vn
+        dvx, dvy = dv * nx, dv * ny
+        self._apply_hit(win, dvx, dvy, now, key)
+        self._separate_from_stadium(win, center, pet_radius, stadium,
+                                    island_rect, now, key,
+                                    ref=None if currently_overlapping else entry)
+        dv_mag = math.hypot(dvx, dvy)
+        if dv_mag > 1e-6:
+            log.info("灵动岛被撞（本地结算）dv=%.0f dir=(%.2f, %.2f)",
+                     dv_mag, -dvx / dv_mag, -dvy / dv_mag)
+            self._island.bump(min(3.0, dv_mag / 400.0),
+                              -dvx / dv_mag, -dvy / dv_mag)
+
+    def _overlaps_stadium(self, center, pet_radius: float, stadium) -> bool:
+        closest = self._axis_closest(stadium, center[0], center[1])
+        return math.hypot(center[0] - closest[0], center[1] - closest[1]) \
+            <= pet_radius + stadium[3]
+
+    def _separate_from_stadium(self, win, center, pet_radius: float, stadium,
+                               island_rect, now: float, key: int,
+                               ref=None) -> None:
+        """把桌宠放到岛体表面（沿法线推出，含 TOI 放回——它本不该在岛体内）。
+
+        ref：法线参考点，默认当前中心；隧道放回时传进入点（放回来路一侧）。
+        """
+        # 边缘探头会话期间位置归探头控制器管（PEEKING 稳态无 timer，被顶偏
+        # 不会自动归位）——轻贴分离位移直接丢弃，与权威冲量路径同口径；
+        # 真撞路径（_apply_hit）会先 cancel 探头会话，走到这里 active 已为 False
+        probe = getattr(win, "_edge_probe", None)
+        if getattr(probe, "active", False):
+            return
+        ref = center if ref is None else ref
+        vrel = (0.0 - self._vx, 0.0 - self._vy)
+        nx, ny, _is_fallback = self._normal(stadium, ref, vrel)
+        closest = self._axis_closest(stadium, ref[0], ref[1])
+        gap = pet_radius + stadium[3] + 1.0
+        target_x = closest[0] + nx * gap
+        target_y = closest[1] + ny * gap
+        dx, dy = target_x - center[0], target_y - center[1]
+        if math.hypot(dx, dy) < 1.0:
+            return
+        self._move_win(win, dx, dy)
+        # 放回/推出后刷新跟踪中心，避免下一帧把这次修正当成高速扫掠
+        rect = win.collision_content_rect()
+        self._pet_prev[key] = (float(rect.center().x()), float(rect.center().y()))
+        self._pet_prev_ts[key] = now
+
+    def _move_win(self, win, dx: float, dy: float) -> None:
+        # 先取消桌宠的自主移动计划：否则 33ms 后移动插值会把分离位置
+        # 覆盖回去（表现为贴岛抖动/推不出去）；与权威冲量路径同口径
+        cancel_move = getattr(win, "_cancel_move", None)
+        if callable(cancel_move):
+            cancel_move()
+        cancel_gap = getattr(win, "_cancel_animation_gap", None)
+        if callable(cancel_gap):
+            cancel_gap()
+        clamp = getattr(win, "_collision_clamp_pos", None)
+        if callable(clamp):
+            nx_pos, ny_pos = clamp(win.x() + dx, win.y() + dy)
+            left, top = clamp(float("-inf"), float("-inf"))
+            right, bottom = clamp(float("inf"), float("inf"))
+            win.move(
+                min(max(int(round(nx_pos)), math.ceil(left)), math.floor(right)),
+                min(max(int(round(ny_pos)), math.ceil(top)), math.floor(bottom)),
+            )
+        else:
+            win.move(int(round(win.x() + dx)), int(round(win.y() + dy)))
+        phys_pos = getattr(win, "_phys_pos", None)
+        if isinstance(phys_pos, list) and len(phys_pos) >= 2:
+            phys_pos[:] = [float(win.x()), float(win.y())]
+
+    def _apply_hit(self, win, dvx: float, dvy: float, now: float, key: int) -> None:
+        """复用桌宠侧真实撞击反应：加冲量 → 限速 → 音效 → 进抛掷物理 → 挤压。
+
+        与 collision_client 权威冲量路径保持一致的手感，但不走 IPC。
+        """
+        cancel_move = getattr(win, "_cancel_move", None)
+        if callable(cancel_move):
+            cancel_move()
+        cancel_gap = getattr(win, "_cancel_animation_gap", None)
+        if callable(cancel_gap):
+            cancel_gap()
+        win._phys_vel[0] += dvx
+        win._phys_vel[1] += dvy
+        speed = math.hypot(*win._phys_vel)
+        cap = float(getattr(win, "_throw_speed_cap", 4800.0) or 4800.0)
+        if speed > cap:
+            clamped = physics_mod.soft_clamp_speed(speed, cap)
+            win._phys_vel[:] = [win._phys_vel[0] * clamped / speed,
+                                win._phys_vel[1] * clamped / speed]
+        egg = getattr(win, "_throw_egg", None)
+        if egg is not None and getattr(egg, "active", False):
+            egg.on_pet_contact(math.hypot(*win._phys_vel))
+        play_sound = getattr(win, "_play_collision_sound", None)
+        if callable(play_sound):
+            play_sound()
+        # 进入抛掷物理（与权威路径一致）：撞飞 → 抛物线 → 落地停稳
+        edge_probe = getattr(win, "_edge_probe", None)
+        if edge_probe is not None:
+            cancel = getattr(edge_probe, "cancel", None)
+            if callable(cancel):
+                cancel("island_hit", restore=False)
+        win._interaction_state = "THROWN"
+        # 与权威冲量路径（collision_client）补齐两个副作用：幽灵点击抑制
+        #（被撞飞的鱼落地不应触发点击动画）+ 落地后允许重新进入边缘探头
+        clear_dragged = getattr(win, "_clear_just_dragged", None)
+        if callable(clear_dragged):
+            win._just_dragged = True
+            if isinstance(win, QObject):
+                QTimer.singleShot(120, win, clear_dragged)
+            else:
+                QTimer.singleShot(120, clear_dragged)
+        # 探头重入 arm 的读侧是 CollisionClient（_submit_collision_state），
+        # 写到 win 上是死写——写到真正的读侧
+        client = getattr(win, "_collision_client", None)
+        if client is not None:
+            client._reentry_after_throw_armed = True
+        enter = getattr(win, "_enter_physics_mode", None)
+        if callable(enter):
+            enter("throw")
+        if isinstance(getattr(win, "_phys_pos", None), list):
+            win._phys_pos[:] = [float(win.x()), float(win.y())]
+        win._last_physics_tick_time = None
+        physics_timer = getattr(win, "_physics_timer", None)
+        if physics_timer is not None:
+            physics_timer.start()
+        # 挤压动画逐只错峰（岛级单闸门会吞掉同时撞上的其他鱼）
+        if not getattr(win, "_squash_active", False) \
+                and now - self._pet_squash.get(key, 0.0) >= 0.25:
+            self._pet_squash[key] = now
+            squash = getattr(win, "_start_squash", None)
+            if callable(squash):
+                squash()

--- a/pet/modern_settings_dialog.py
+++ b/pet/modern_settings_dialog.py
@@ -306,11 +306,47 @@ class ModernSettingsDialog(QDialog):
         ):
             self.island_style_select.addItem(label, value)
         self.island_style_select.setCurrentData(str(island_cfg.get("style") or "dark"))
+        self.island_opacity_spin = BrowserDoubleSpinBox(self)
+        self.island_opacity_spin.setRange(0.4, 1.0)
+        self.island_opacity_spin.setSingleStep(0.05)
+        self.island_opacity_spin.setDecimals(2)
+        try:
+            _island_opacity = float(island_cfg.get("opacity", 1.0))
+        except (TypeError, ValueError):
+            _island_opacity = 1.0
+        self.island_opacity_spin.setValue(max(0.4, min(1.0, _island_opacity)))
+        self.island_accent_select = ModernSelect(self, width=160)
+        for label, value in (
+            ("海洋蓝", "blue"),
+            ("草绿", "green"),
+            ("葡萄紫", "purple"),
+            ("樱花粉", "pink"),
+            ("落日橙", "orange"),
+        ):
+            self.island_accent_select.addItem(label, value)
+        self.island_accent_select.setCurrentData(str(island_cfg.get("accent") or "blue"))
         self.island_icon_select = ModernSelect(self, width=160)
         for emoji in ("🐳", "🐟", "🐙", "🦭", "🐧", "🐱", "🐶", "🌟", "⚡", "❤️"):
             self.island_icon_select.addItem(emoji, emoji)
         self.island_icon_select.setCurrentData(str(island_cfg.get("icon") or "🐳"))
         self.island_custom_text_edit = _line_edit(str(island_cfg.get("custom_text") or ""), width=220)
+        self.island_click_action_select = ModernSelect(self, width=160)
+        for label, value in (
+            ("展开快捷卡片", "expand"),
+            ("切换桌宠显隐", "toggle_pet"),
+        ):
+            self.island_click_action_select.addItem(label, value)
+        self.island_click_action_select.setCurrentData(
+            str(island_cfg.get("click_action") or "expand"))
+        self.island_event_effects_check = ToggleSwitch(self)
+        self.island_event_effects_check.setChecked(
+            bool(island_cfg.get("event_effects", True)))
+        self.island_edge_dock_check = ToggleSwitch(self)
+        self.island_edge_dock_check.setChecked(
+            bool(island_cfg.get("edge_dock", True)))
+        self.island_collision_check = ToggleSwitch(self)
+        self.island_collision_check.setChecked(
+            bool(island_cfg.get("collision_enabled", True)))
 
         if include_ai:
             # 延迟 import：no-chat 打包变体 excludes=['pet.chat']，顶层导入会在
@@ -372,9 +408,15 @@ class ModernSettingsDialog(QDialog):
             SettingRow("dynamic_island_info", "显示信息槽", "显示时间/余额/自定义短文本等信息。", self.island_info_check),
             SettingRow("dynamic_island_status", "显示状态灯", "显示右侧状态圆点。", self.island_status_check),
             SettingRow("dynamic_island_info_mode", "信息槽内容", "选择信息槽显示的内容；自定义文本在下方填写。", self.island_info_mode_select),
-            SettingRow("dynamic_island_style", "背景风格", "黑色 / 白色 / 苹果式玻璃质感。", self.island_style_select),
+            SettingRow("dynamic_island_style", "背景风格", "黑色 / 白色 / 苹果式玻璃质感；配合下方不透明度可调出半透明质感（纯自绘，低占用）。", self.island_style_select),
+            SettingRow("dynamic_island_opacity", "背景不透明度", "越低越透（0.4~1.0）；配合深色底在低占用下做出半透明质感。", self.island_opacity_spin),
+            SettingRow("dynamic_island_accent", "主题色", "图标底圈、事件闪光、停靠描边共用的点缀色。", self.island_accent_select),
             SettingRow("dynamic_island_icon_value", "图标", "选择灵动岛左侧显示的预制 emoji 图标。", self.island_icon_select),
             SettingRow("dynamic_island_custom_text", "自定义短文本", "信息槽选择“自定义短文本”时显示的内容。", self.island_custom_text_edit, stacked=True),
+            SettingRow("dynamic_island_click_action", "单击行为", "单击胶囊：展开快捷卡片（余额/最近消息/快捷按钮）或直接切换桌宠显隐。", self.island_click_action_select),
+            SettingRow("dynamic_island_event_effects", "事件动效", "AI 回复到达、余额刷新、峰谷切换时果冻弹跳提示；dsh 工作时状态灯变蓝。静止时零额外开销。", self.island_event_effects_check),
+            SettingRow("dynamic_island_edge_dock", "靠边半隐藏", "拖到屏幕任意边缘（上下左右）收成细条，鼠标靠近自动滑出；顶部被占时可停靠侧边。", self.island_edge_dock_check),
+            SettingRow("dynamic_island_collision", "果冻墙（参与碰撞）", "岛注册为静态碰撞体：肥鱼被甩到岛上会弹开，岛原地果冻摆动。岛的位置不会被撞动。", self.island_collision_check),
         ], island_content))
         island_layout.addStretch(1)
         self._add_page("灵动岛", "island", self._page_shell("灵动岛", island_content))
@@ -1643,7 +1685,15 @@ class ModernSettingsDialog(QDialog):
             "custom_text": self.island_custom_text_edit.text().strip(),
             "show_status": self.island_status_check.isChecked(),
             "style": str(self.island_style_select.currentData() or "dark"),
+            "opacity": float(self.island_opacity_spin.value()),
+            "accent": str(self.island_accent_select.currentData() or "blue"),
             "icon": str(self.island_icon_select.currentData() or "🐳"),
+            "click_action": str(self.island_click_action_select.currentData() or "expand"),
+            "event_effects": self.island_event_effects_check.isChecked(),
+            "edge_dock": self.island_edge_dock_check.isChecked(),
+            "collision_enabled": self.island_collision_check.isChecked(),
+            # 拖拽落点写入的停靠边与位置：设置页不回写，原样保留。
+            "dock_edge": existing_island.get("dock_edge", "none"),
             "x": existing_island.get("x"),
             "y": existing_island.get("y"),
         })

--- a/pet/settings_pet_controls.py
+++ b/pet/settings_pet_controls.py
@@ -532,8 +532,11 @@ def _update_island_controls(host, enabled: bool) -> None:
     host._set_setting_rows_visible((
         "dynamic_island_icon", "dynamic_island_name", "dynamic_island_info",
         "dynamic_island_status", "dynamic_island_info_mode",
-        "dynamic_island_style", "dynamic_island_icon_value",
-        "dynamic_island_custom_text",
+        "dynamic_island_style", "dynamic_island_opacity", "dynamic_island_accent",
+        "dynamic_island_icon_value",
+        "dynamic_island_custom_text", "dynamic_island_click_action",
+        "dynamic_island_event_effects", "dynamic_island_edge_dock",
+        "dynamic_island_collision",
     ), enabled, dependency="island_enabled")
     _update_island_icon_controls(host, host.island_icon_check.isChecked())
     _update_island_info_controls(host, host.island_info_check.isChecked())

--- a/tests/test_collision_ipc.py
+++ b/tests/test_collision_ipc.py
@@ -883,6 +883,68 @@ def test_coordinator_suppresses_repeated_position_only_contact():
     assert len(received) == first_count
 
 
+def test_static_member_gets_freshness_grace():
+    """FLAG_STATIC 成员（灵动岛）新鲜度宽限 3s：GUI 卡顿不该让岛掉出碰撞世界。"""
+    flags = collision.FLAG_VISIBLE | collision.FLAG_COLLISION_ENABLED
+    island = {"runtime_id": "island", "seq": 1, "x": 0.0, "y": 0.0,
+              "radius_x": 100.0, "radius_y": 22.0, "circles": [[0.0, 0.0, 22.0]],
+              "vx": 0.0, "vy": 0.0, "flags": flags | collision.FLAG_STATIC}
+    pet = {"runtime_id": "a", "seq": 1, "x": 300.0, "y": 0.0,
+           "radius_x": 30.0, "radius_y": 30.0, "circles": [[300.0, 0.0, 30.0]],
+           "vx": 0.0, "vy": 0.0, "flags": flags}
+    worker = _coordinator_with_members(island, pet)
+    # 双方状态都 2s 没更新（模拟 GUI 卡顿）：静态岛仍在，普通成员过期
+    worker.members["island"]["last_seen"] = 1.0 - 2.0
+    worker.members["a"]["last_seen"] = 1.0 - 2.0
+    fresh_ids = {m["runtime_id"] for m in worker._fresh_member_values(1.0)}
+    assert "island" in fresh_ids
+    assert "a" not in fresh_ids
+    # 超过 3s 宽限（进程真死了）→ 岛也移出
+    worker.members["island"]["last_seen"] = 1.0 - 3.5
+    fresh_ids = {m["runtime_id"] for m in worker._fresh_member_values(1.0)}
+    assert "island" not in fresh_ids
+
+
+def test_new_member_seeds_previous_frame_for_swept():
+    """FLAG_STATIC 新成员（岛）首帧用当前帧垫底：swept 退化为静态检测；
+    普通桌宠成员保持旧语义（首帧无 previous，不垫底）。"""
+    worker = _CollisionWorker("unused-" + uuid.uuid4().hex, "coordinator", "", {
+        "collision_enabled": True, "collision_restitution": .82,
+        "collision_friction": .08, "collision_mass_scale": 1.0,
+        "collision_impulse_cap": 9000.0,
+    })
+    worker.server = object()
+    worker.epoch = "epoch-a"
+    worker._now = staticmethod(lambda: 1.0)
+    socket = FakeSocket()
+    worker.peers[socket] = ""
+    worker._handle_message(socket, {"type": "hello", "runtime_id": "a"})
+    flags = collision.FLAG_VISIBLE | collision.FLAG_COLLISION_ENABLED
+    state = {
+        "type": "state", "seq": 5, "x": 0.0, "y": 0.0,
+        "radius_x": 30.0, "radius_y": 30.0, "circles": [[0.0, 0.0, 30.0]],
+        "vx": 0.0, "vy": 0.0,
+    }
+    # 普通桌宠成员：首帧不垫底（旧行为不变）
+    worker._handle_message(socket, {**state, "flags": flags})
+    assert "a" in worker.members
+    assert "a" not in worker.previous_members
+    # FLAG_STATIC 成员（岛）：首帧垫底，swept 退化为静态检测
+    worker._handle_message(socket, {"type": "hello", "runtime_id": "island"})
+    worker._handle_message(socket, {
+        **state, "runtime_id": "island", "flags": flags | collision.FLAG_STATIC,
+    })
+    assert "island" in worker.members
+    assert worker.previous_members["island"]["seq"] == 5
+    # 第二帧起 previous 正常滚动
+    worker._handle_message(socket, {
+        **state, "runtime_id": "island", "seq": 6, "x": 10.0,
+        "circles": [[10.0, 0.0, 30.0]], "flags": flags | collision.FLAG_STATIC,
+    })
+    assert worker.previous_members["island"]["seq"] == 5
+    assert worker.members["island"]["seq"] == 6
+
+
 def test_client_watchdog_stays_alive_while_snapshots_arrive(monkeypatch):
     worker = _CollisionWorker("unused-" + uuid.uuid4().hex, "client", "", {})
     worker.epoch = "epoch-a"

--- a/tests/test_desktop_pet_features.py
+++ b/tests/test_desktop_pet_features.py
@@ -1567,8 +1567,11 @@ def test_modern_settings_toggle_dependencies_hide_complete_setting_groups(tmp_pa
         row(key) for key in (
             "dynamic_island_icon", "dynamic_island_name", "dynamic_island_info",
             "dynamic_island_status", "dynamic_island_info_mode",
-            "dynamic_island_style", "dynamic_island_icon_value",
-            "dynamic_island_custom_text",
+            "dynamic_island_style", "dynamic_island_opacity",
+            "dynamic_island_accent", "dynamic_island_icon_value",
+            "dynamic_island_custom_text", "dynamic_island_click_action",
+            "dynamic_island_event_effects", "dynamic_island_edge_dock",
+            "dynamic_island_collision",
         )
     ]
     dialog.island_enabled_check.setChecked(False)

--- a/tests/test_dynamic_island_revamp.py
+++ b/tests/test_dynamic_island_revamp.py
@@ -1,0 +1,472 @@
+# -*- coding: utf-8 -*-
+"""灵动岛重生：四边停靠/滑出、展开卡片、事件动效、配置清洗。"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from PySide6.QtCore import QEvent, QPoint, QPointF, QRect, Qt
+from PySide6.QtGui import QGuiApplication, QMouseEvent
+from PySide6.QtWidgets import QApplication
+
+from pet.config import Config
+from pet.dynamic_island import (
+    DynamicIsland,
+    _STRIP_THICKNESS,
+    dock_edge_for,
+    spring_step,
+    strip_rect_for,
+)
+
+
+def _qapp() -> QApplication:
+    return QApplication.instance() or QApplication([])
+
+
+def _island(tmp_path: Path, **overrides) -> DynamicIsland:
+    cfg = Config(base=tmp_path)
+    data = {
+        "enabled": True, "show_icon": True, "show_name": True,
+        "show_info": True, "info_mode": "time", "custom_text": "",
+        "show_status": True, "style": "dark", "x": 400, "y": 300,
+    }
+    data.update(overrides)
+    cfg.set("dynamic_island", data)
+    return DynamicIsland(cfg)
+
+
+def _avail() -> QRect:
+    screen = QGuiApplication.primaryScreen()
+    return screen.availableGeometry() if screen is not None else QRect(0, 0, 1920, 1040)
+
+
+def _mouse(kind: QEvent.Type, widget, global_pos: QPoint,
+           button=Qt.MouseButton.LeftButton,
+           buttons=Qt.MouseButton.LeftButton) -> QMouseEvent:
+    local = widget.mapFromGlobal(global_pos)
+    return QMouseEvent(kind, QPointF(local), QPointF(global_pos),
+                       button, buttons, Qt.KeyboardModifier.NoModifier)
+
+
+def _drag_to(widget, target_global: QPoint) -> None:
+    """完整拖一次：按下 → 移动（超过拖拽阈值）→ 在 target 松手。"""
+    start = widget.geometry().center()
+    widget.mousePressEvent(_mouse(QEvent.Type.MouseButtonPress, widget, start))
+    mid = QPoint((start.x() + target_global.x()) // 2,
+                 (start.y() + target_global.y()) // 2)
+    widget.mouseMoveEvent(_mouse(QEvent.Type.MouseMove, widget, mid))
+    widget.mouseMoveEvent(_mouse(QEvent.Type.MouseMove, widget, target_global))
+    widget.mouseReleaseEvent(
+        _mouse(QEvent.Type.MouseButtonRelease, widget, target_global,
+               buttons=Qt.MouseButton.NoButton))
+
+
+def _click(widget) -> None:
+    center = widget.geometry().center()
+    widget.mousePressEvent(_mouse(QEvent.Type.MouseButtonPress, widget, center))
+    widget.mouseReleaseEvent(
+        _mouse(QEvent.Type.MouseButtonRelease, widget, center,
+               buttons=Qt.MouseButton.NoButton))
+
+
+# ------------------------------------------------------------ 纯函数
+def test_spring_step_converges_and_overshoots():
+    value, velocity = 1.0, 6.0  # 事件冲量
+    peak = value
+    for _ in range(600):
+        value, velocity = spring_step(value, velocity, 1.0, 1 / 60)
+        peak = max(peak, value)
+    assert peak > 1.05  # 有过冲才有果冻感
+    assert abs(value - 1.0) < 0.01
+    assert abs(velocity) < 0.05
+
+
+def test_dock_edge_for_four_edges_and_none():
+    available = QRect(0, 0, 1920, 1040)
+    capsule = QRect(900, 300, 200, 44)
+    assert dock_edge_for(capsule, available) == "none"
+    assert dock_edge_for(QRect(900, 2, 200, 44), available) == "top"
+    assert dock_edge_for(QRect(900, 1035 - 44, 200, 44), available) == "bottom"
+    assert dock_edge_for(QRect(3, 500, 200, 44), available) == "left"
+    assert dock_edge_for(QRect(1917 - 200, 500, 200, 44), available) == "right"
+
+
+def test_strip_rect_shapes():
+    available = QRect(0, 0, 1920, 1040)
+    capsule = QRect(900, 2, 200, 44)
+    top = strip_rect_for(capsule, "top", available)
+    assert top.y() == 0 and top.height() == _STRIP_THICKNESS and top.width() == 200
+    bottom = strip_rect_for(capsule, "bottom", available)
+    assert bottom.bottom() == available.bottom() and bottom.height() == _STRIP_THICKNESS
+    left = strip_rect_for(capsule, "left", available)
+    assert left.x() == 0 and left.width() == _STRIP_THICKNESS
+    right = strip_rect_for(capsule, "right", available)
+    assert right.right() == available.right() and right.width() == _STRIP_THICKNESS
+    assert strip_rect_for(capsule, "none", available) == capsule
+
+
+# ------------------------------------------------------------ 停靠与滑出
+def test_drag_to_edge_docks_and_hover_peeks(tmp_path):
+    _qapp()
+    island = _island(tmp_path)
+    try:
+        island.show()
+        available = _avail()
+        # 拖到顶边 → 停靠成细条
+        _drag_to(island, QPoint(island.x(), available.top()))
+        island._finish_animations()
+        assert island._debug_state()["mode"] == "docked"
+        assert island._debug_state()["dock_edge"] == "top"
+        assert island.height() == _STRIP_THICKNESS
+        assert island.y() == available.top()
+        # 配置已持久化
+        assert island.config.get("dynamic_island")["dock_edge"] == "top"
+
+        # 鼠标靠近 → 滑出完整胶囊
+        island.enterEvent(None)
+        island._finish_animations()
+        assert island.height() == 44
+        # 鼠标离开 → 延迟后收回细条
+        island.leaveEvent(None)
+        island._dock_back()  # 直接驱动定时器回调
+        island._finish_animations()
+        assert island.height() == _STRIP_THICKNESS
+
+        # 拖离顶边（屏幕可用区正中心，不赌分辨率）→ 回到正常模式
+        _drag_to(island, available.center())
+        island._finish_animations()
+        assert island._debug_state()["mode"] == "normal"
+        assert island._debug_state()["dock_edge"] == "none"
+        assert island.height() == 44
+    finally:
+        island.hide()
+        island.deleteLater()
+
+
+def test_edge_dock_disabled_never_docks(tmp_path):
+    _qapp()
+    island = _island(tmp_path, edge_dock=False)
+    try:
+        island.show()
+        available = _avail()
+        _drag_to(island, QPoint(island.x(), available.top()))
+        island._finish_animations()
+        assert island._debug_state()["mode"] == "normal"
+        assert island._debug_state()["dock_edge"] == "none"
+    finally:
+        island.hide()
+        island.deleteLater()
+
+
+# ------------------------------------------------------------ 展开卡片
+def test_click_expands_card_and_buttons_emit(tmp_path):
+    app = _qapp()
+    island = _island(tmp_path)
+    try:
+        island.show()
+        island.set_balance_info("高峰 → 23:00", "余额 ¥12.34")
+        island.set_last_message("我吃了三碗饭")
+        got = {"toggle": 0, "chat": 0, "settings": 0}
+        island.toggle_pet_requested.connect(lambda: got.__setitem__("toggle", 1))
+        island.open_chat_requested.connect(lambda: got.__setitem__("chat", 1))
+        island.open_settings_requested.connect(lambda: got.__setitem__("settings", 1))
+
+        _click(island)
+        island._finish_animations()
+        app.processEvents()
+        state = island._debug_state()
+        assert state["mode"] == "expanded"
+        assert state["card_visible"] is True
+        assert island._card_balance_label.text() == "余额 ¥12.34"
+        assert island._card_message_label.text() == "我吃了三碗饭"
+
+        island._card_toggle_btn.click()
+        island._card_chat_btn.click()
+        island._card_settings_btn.click()
+        assert got == {"toggle": 1, "chat": 1, "settings": 1}
+        # 任一按钮动作后卡片收起
+        assert island._debug_state()["mode"] == "normal"
+
+        # 再点一次胶囊 → 展开；再点 → 收起
+        _click(island)
+        island._finish_animations()
+        assert island._debug_state()["mode"] == "expanded"
+        _click(island)
+        island._finish_animations()
+        assert island._debug_state()["mode"] == "normal"
+    finally:
+        island.hide()
+        island.deleteLater()
+        app.processEvents()
+
+
+def test_click_toggle_pet_legacy_action(tmp_path):
+    _qapp()
+    island = _island(tmp_path, click_action="toggle_pet")
+    try:
+        island.show()
+        clicks = []
+        island.clicked.connect(lambda: clicks.append(1))
+        _click(island)
+        assert clicks == [1]
+        assert island._debug_state()["mode"] == "normal"  # 不展开卡片
+    finally:
+        island.hide()
+        island.deleteLater()
+
+
+# ------------------------------------------------------------ 事件动效
+def test_notify_event_starts_animation_only_when_enabled(tmp_path):
+    _qapp()
+    island = _island(tmp_path)
+    try:
+        island.show()
+        assert island._debug_state()["animating"] is False
+        island.notify_event("reply")
+        assert island._debug_state()["animating"] is True
+        island._finish_animations()
+        assert island._debug_state()["animating"] is False
+
+        island._cfg = dict(island._cfg, event_effects=False)
+        island.notify_event("reply")
+        assert island._debug_state()["animating"] is False
+    finally:
+        island.hide()
+        island.deleteLater()
+
+
+def test_bump_and_agent_active(tmp_path):
+    _qapp()
+    island = _island(tmp_path)
+    try:
+        island.show()
+        island.bump(2.0, 1.0, 0.0)  # 果冻墙受击：表面压扁回弹 + 定向踢动
+        assert island._debug_state()["animating"] is True
+        assert island._tilt_v != 0.0
+        assert island._kick_vx > 0.0  # 踢动方向跟随撞击方向
+        assert island._squish_v < 0.0  # 表面被压扁（弹簧回摆出果冻抖动）
+        island._finish_animations()
+        assert island._tilt == 0.0
+        assert island._kick_x == 0.0 and island._kick_y == 0.0
+        assert island._squish == 1.0
+
+        island.set_agent_active(True)  # dsh 开工：蓝灯 + 弹一下
+        assert island._agent_active is True
+        assert island._status_dot_color().blue() > 200
+        island.set_agent_active(False)
+        assert island._status_dot_color().green() > 200  # 回到可见绿灯
+    finally:
+        island.hide()
+        island.deleteLater()
+
+
+def test_event_bounce_is_positional_with_squish(tmp_path):
+    """事件动效 = 整数位移下压回弹 + 表面轻压 + 微缩放（不再有大幅挤压变形）。"""
+    _qapp()
+    island = _island(tmp_path)
+    try:
+        island.show()
+        island.notify_event("reply")
+        assert island._kick_y > 0.0  # 下压
+        assert island._squish_v < 0.0  # 表面轻压（史莱姆形变）
+        assert abs(island._scale_v) < 0.5  # 缩放只做辅助（旧版 5.0 会糊文字）
+        island._finish_animations()
+        assert island._debug_state()["animating"] is False
+    finally:
+        island.hide()
+        island.deleteLater()
+
+
+def test_expand_card_emits_signal(tmp_path):
+    """卡片展开发出 card_expanded（AppShell 借此静默刷新余额）。"""
+    _qapp()
+    island = _island(tmp_path)
+    try:
+        island.show()
+        hits = []
+        island.card_expanded.connect(lambda: hits.append(1))
+        island.expand_card()
+        island._finish_animations()
+        assert hits == [1]
+        island.collapse_card()
+        assert hits == [1]  # 收起不发
+    finally:
+        island.hide()
+        island.deleteLater()
+
+
+def test_appearance_opacity_and_accent(tmp_path):
+    """不透明度与主题色进入调色板；非法值回退默认。"""
+    _qapp()
+    island = _island(tmp_path, opacity=0.5, accent="pink")
+    try:
+        bg, _primary, _secondary = island._style_palette()
+        assert bg.alpha() == round(235 * 0.5)
+        assert island._accent_color().name() == "#ff7ab8"
+        island._cfg = dict(island._cfg, opacity="bogus", accent="not-a-color")
+        assert island._opacity() == 1.0
+        assert island._accent_color().name() == "#40b8ff"
+    finally:
+        island.hide()
+        island.deleteLater()
+
+
+# ------------------------------------------------------------ 配置清洗
+def test_config_cleans_new_island_keys(tmp_path):
+    cfg = Config(base=tmp_path)
+    cfg.set("dynamic_island", {
+        "click_action": "bogus", "event_effects": 0, "edge_dock": 1,
+        "dock_edge": "celling", "enabled": True,
+    })
+    cleaned = cfg.get("dynamic_island")
+    assert cleaned["click_action"] == "expand"  # 非法值回默认
+    assert cleaned["event_effects"] is False
+    assert cleaned["edge_dock"] is True
+    assert cleaned["dock_edge"] == "none"  # 非法边回 none
+
+    cfg.set("dynamic_island", {
+        "click_action": "toggle_pet", "dock_edge": "left", "enabled": True,
+    })
+    cleaned = cfg.get("dynamic_island")
+    assert cleaned["click_action"] == "toggle_pet"
+    assert cleaned["dock_edge"] == "left"
+
+    # 外观新键：opacity 钳位、accent 白名单（acrylic 已下线，非法风格回默认）
+    cfg.set("dynamic_island", {
+        "style": "glass", "opacity": 0.55, "accent": "purple", "enabled": True,
+    })
+    cleaned = cfg.get("dynamic_island")
+    assert cleaned["style"] == "glass"
+    assert cleaned["opacity"] == 0.55
+    assert cleaned["accent"] == "purple"
+    cfg.set("dynamic_island", {
+        "style": "acrylic", "opacity": 9.9, "accent": "gold", "enabled": True,
+    })
+    cleaned = cfg.get("dynamic_island")
+    assert cleaned["style"] == "dark"     # 已下线的风格回默认
+    assert cleaned["opacity"] == 1.0      # 超界钳到 1.0
+    assert cleaned["accent"] == "blue"    # 非法色回默认
+
+
+def test_expanded_mode_disables_window_transform(tmp_path):
+    """展开卡片态禁用整窗变换（截边回归）：悬停不放大、单击展开后目标归零、
+    kick 平移参与不到 paint（展开态 paintEvent 冒烟不炸）。"""
+    _qapp()
+    island = _island(tmp_path)
+    try:
+        island.show()
+        # 悬停（收起态）会抬放大目标
+        island.enterEvent(None)
+        assert island._hover_scale_target == 1.02
+        # 单击展开：目标必须拉回 1.0（否则展开后仍按 1.02 缩放，贴边底板被截）
+        island.expand_card()
+        assert island._mode == "expanded"
+        assert island._hover_scale_target == 1.0
+        # 展开态再次悬停：不再抬目标
+        island.enterEvent(None)
+        assert island._hover_scale_target == 1.0
+        # 展开态 + 待播放的 kick：paintEvent 跳过整窗平移（冒烟不炸）
+        island._bounce(4.0)
+        island.repaint()
+        island.update()
+        QApplication.processEvents()
+        # 收起后悬停放大恢复
+        island.collapse_card()
+        island.enterEvent(None)
+        assert island._hover_scale_target == 1.02
+    finally:
+        island.hide()
+        island.deleteLater()
+
+
+def test_expanded_mode_freezes_squish(tmp_path):
+    """展开卡片态冻结史莱姆形变：squish 打到下限也不鼓出窗口（截边回归）。"""
+    _qapp()
+    island = _island(tmp_path)
+    try:
+        island.show()
+        island.expand_card()
+        island._squish = 0.85  # 形变下限（bump 最大冲击）
+        rect, _radius = island._squished_capsule_rect()
+        assert rect.width() <= island.width() - 2 * 6 + 0.01  # 不超内缩边界
+        assert rect.width() <= island.width()
+        # 收起态形变恢复（对照）
+        island.collapse_card()
+        island._squish = 0.85
+        rect2, _ = island._squished_capsule_rect()
+        assert rect2.width() > rect.width()
+    finally:
+        island.hide()
+        island.deleteLater()
+
+
+def test_edge_dock_off_resets_docked_island(tmp_path):
+    """关闭「靠边半隐藏」时已停靠的岛复位回正常形态（不再卡 16px 细条）。"""
+    _qapp()
+    island = _island(tmp_path, edge_dock=True, dock_edge="left")
+    try:
+        island.show()
+        island._apply_position()
+        assert island._mode == "docked"
+        assert island.dock_edge == "left"
+        # 设置里关掉开关（dock_edge 键仍保留），刷新配置
+        data = dict(island._cfg)
+        data["edge_dock"] = False
+        island.config.set("dynamic_island", data)
+        island.refresh_from_config()
+        assert island._mode == "normal"
+        assert island.dock_edge == "none"  # 读取处被总开关拦截
+        assert not island._hover_peek
+        # 开关再开：存储的边恢复
+        data["edge_dock"] = True
+        island.config.set("dynamic_island", data)
+        island.refresh_from_config()
+        assert island.dock_edge == "left"
+    finally:
+        island.hide()
+        island.deleteLater()
+
+
+def test_drag_start_clears_geometry_animation(tmp_path):
+    """拖拽起手清掉进行中的几何动画目标（滑出动画不再和拖拽抢窗口）。"""
+    _qapp()
+    island = _island(tmp_path)
+    try:
+        island.show()
+        island._animate_to(QRect(100, 100, 260, 44))  # 模拟进行中的几何动画
+        assert island._geo_to is not None
+        # 模拟按下并拖动超过阈值
+        press = QPoint(island.x() + 10, island.y() + 10)
+        island.mousePressEvent(QMouseEvent(
+            QEvent.Type.MouseButtonPress, QPointF(10, 10),
+            QPointF(press), Qt.MouseButton.LeftButton,
+            Qt.MouseButton.LeftButton, Qt.KeyboardModifier.NoModifier))
+        island.mouseMoveEvent(QMouseEvent(
+            QEvent.Type.MouseMove, QPointF(60, 10),
+            QPointF(press + QPoint(50, 0)), Qt.MouseButton.LeftButton,
+            Qt.MouseButton.LeftButton, Qt.KeyboardModifier.NoModifier))
+        assert island._dragging
+        assert island._geo_to is None
+        assert island._geo_from is None
+    finally:
+        island.hide()
+        island.deleteLater()
+
+
+def test_apply_position_does_not_hijack_expanded_card(tmp_path):
+    """展开卡片态不被停靠劫持（设置保存触发 _apply_position 时 mode 保持
+    expanded、卡片不收起）；收起后按 dock_edge 正常停靠。"""
+    _qapp()
+    island = _island(tmp_path, edge_dock=True, dock_edge="left")
+    try:
+        island.show()
+        island.expand_card()
+        assert island._mode == "expanded"
+        island._apply_position()  # 保存设置的触发路径
+        assert island._mode == "expanded"  # 不被劫持成 docked
+        assert island._card_box.isVisible()
+        # 收起后按 dock_edge 正常停靠（collapse_card 的分支）
+        island.collapse_card()
+        assert island._mode == "docked"
+    finally:
+        island.hide()
+        island.deleteLater()

--- a/tests/test_island_collision.py
+++ b/tests/test_island_collision.py
@@ -1,0 +1,461 @@
+# -*- coding: utf-8 -*-
+"""果冻墙（灵动岛本进程直连碰撞）：FLAG_STATIC 弹性规则 + 本地检测/结算。"""
+from __future__ import annotations
+
+import math
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+from PySide6.QtCore import QRect
+from PySide6.QtWidgets import QApplication
+
+from pet import collision
+from pet.collision_ipc import _KNOWN_FLAGS_MASK
+from pet.config import Config
+from pet.dynamic_island import DynamicIsland
+from pet.island_collision import IslandCollisionBody, _segment_circle_entry
+
+
+def _qapp() -> QApplication:
+    return QApplication.instance() or QApplication([])
+
+
+def _pet(runtime_id="pet", x=100.0, y=100.0, vx=-600.0, flags=0) -> collision.MemberState:
+    return collision.MemberState(
+        runtime_id=runtime_id, x=x, y=y, radius_x=50.0, radius_y=50.0,
+        vx=vx, vy=0.0, flags=collision.FLAG_VISIBLE | collision.FLAG_COLLISION_ENABLED | flags,
+    )
+
+
+def _island_state(flags=collision.FLAG_STATIC) -> collision.MemberState:
+    return collision.MemberState(
+        runtime_id="island", x=200.0, y=100.0, radius_x=100.0, radius_y=22.0,
+        vx=0.0, vy=0.0, is_infinite_mass=True,
+        flags=collision.FLAG_VISIBLE | collision.FLAG_COLLISION_ENABLED | flags,
+    )
+
+
+# ------------------------------------------------------------ 弹性规则（通用求解器）
+def test_static_wall_boosts_restitution_pet_bounces_off_faster():
+    """FLAG_STATIC 静态岛加速弹开（e=1.3）：撞岛比撞墙弹得更快，像撞弹床。"""
+    pet = _pet(vx=600.0)  # 桌宠在岛左侧，向右（+x）撞岛
+    island = _island_state()
+    # nx=-1：法线从 A(岛) 指向 B(桌宠)，接近速度 vn = 600*(-1) < 0
+    jn, dvx_a, _dvy_a, dvx_b, _dvy_b = collision.solve_collision_impulse(
+        island, pet, -1.0, 0.0,
+        restitution=0.82, friction=0.08, impulse_cap=9000.0)
+    assert jn > 0
+    assert dvx_a == 0.0  # 岛无限质量，不动
+    # e=1.3 加速反弹：桌宠末速 = 600 * (-1.3) = -780（比入射更快地弹回）
+    assert pet.vx + dvx_b < -600.0
+
+
+def test_static_wall_low_speed_contact_stays_dead():
+    """低速贴上岛不抖动：接近速度低于阈值仍 e=0（只挡不弹）。"""
+    pet = _pet(vx=50.0)  # 低于 IMPULSE_MIN_APPROACH_SPEED(80)
+    island = _island_state()
+    _jn, _dva, _dva2, dvx_b, _dvb = collision.solve_collision_impulse(
+        island, pet, -1.0, 0.0,
+        restitution=0.82, friction=0.08, impulse_cap=9000.0)
+    # e=0：仅消除接近速度，不反转、不加速
+    assert abs(pet.vx + dvx_b) < 1e-6
+
+
+def test_static_flag_in_known_mask():
+    assert _KNOWN_FLAGS_MASK & collision.FLAG_STATIC == collision.FLAG_STATIC
+
+
+def test_segment_circle_entry_swept():
+    """扫掠 TOI：线段进入圆返回最早时刻；未进入返回 None。"""
+    assert _segment_circle_entry((0.0, 0.0), (100.0, 0.0), (50.0, 0.0), 10.0) == 0.4
+    assert _segment_circle_entry((0.0, 0.0), (100.0, 0.0), (50.0, 8.0), 10.0) is not None
+    assert _segment_circle_entry((0.0, 0.0), (100.0, 0.0), (50.0, 30.0), 10.0) is None
+    assert _segment_circle_entry((5.0, 5.0), (5.0, 5.0), (5.0, 5.0), 3.0) == 0.0  # 起点在内
+
+
+# ------------------------------------------------------------ 本地碰撞体
+class FakePhysicsTimer:
+    def __init__(self):
+        self.started = False
+
+    def start(self):
+        self.started = True
+
+
+class FakeWin:
+    """最小桌宠窗口桩：本地结算触及的全部属性/方法。"""
+
+    def __init__(self, x: float, y: float, vx: float = 0.0, vy: float = 0.0,
+                 size: int = 120, visible: bool = True):
+        self._x, self._y = x, y
+        self._size = size
+        self._visible = visible
+        self._phys_vel = [vx, vy]
+        self._phys_pos = [x, y]
+        self._interaction_state = "IDLE"
+        self._physics_mode = ""
+        self._physics_timer = FakePhysicsTimer()
+        self._throw_speed_cap = 4800.0
+        self._throw_egg = None
+        self._edge_probe = None
+        self._squash_active = False
+        self._hidden_paused = False
+        self._last_physics_tick_time = None
+        self.cfg = SimpleNamespace(get=lambda k, d=None: d)
+        self.sounds = 0
+        self.squashes = 0
+        self.entered_modes = []
+
+    def isVisible(self):
+        return self._visible
+
+    def collision_content_rect(self) -> QRect:
+        return QRect(int(self._x), int(self._y), self._size, self._size)
+
+    def x(self):
+        return int(self._x)
+
+    def y(self):
+        return int(self._y)
+
+    def move(self, x, y):
+        self._x, self._y = float(x), float(y)
+
+    def _collision_clamp_pos(self, x, y):
+        x = 0.0 if x == float("-inf") else (2560.0 if x == float("inf") else x)
+        y = 0.0 if y == float("-inf") else (1440.0 if y == float("inf") else y)
+        return x, y
+
+    def _cancel_move(self):
+        pass
+
+    def _cancel_animation_gap(self):
+        pass
+
+    def _play_collision_sound(self):
+        self.sounds += 1
+
+    def _enter_physics_mode(self, mode):
+        self._physics_mode = mode
+        self.entered_modes.append(mode)
+
+    def _start_squash(self):
+        self.squashes += 1
+
+
+def _make_body(tmp_path: Path, pets=()):
+    cfg = Config(base=tmp_path)
+    cfg.set("dynamic_island", {"enabled": True, "x": 400, "y": 300})
+    island = DynamicIsland(cfg)
+    body = IslandCollisionBody(island, cfg, pets_provider=lambda: list(pets))
+    return island, body
+
+
+def test_body_start_stop_lifecycle(tmp_path):
+    _qapp()
+    island, body = _make_body(tmp_path)
+    try:
+        island.show()
+        body.start()
+        assert body._running and body._timer.isActive()
+        body.stop()
+        assert not body._running and not body._timer.isActive()
+    finally:
+        island.hide()
+        island.deleteLater()
+
+
+def test_fast_pet_bounces_off_island(tmp_path):
+    """高速撞岛：本地结算 e=1.3 弹回 + 进抛掷物理 + 音效 + 岛播 bump。"""
+    _qapp()
+    # 岛在 (400,300)（体育场轴 [422,634], y=322, r=22）；肥鱼贴岛左缘向右撞
+    win = FakeWin(x=300.0, y=260.0, vx=600.0)
+    island, body = _make_body(tmp_path, pets=[win])
+    try:
+        island.show()
+        bumps = []
+        island.bump = lambda *args: bumps.append(args)
+        body._running = True
+        now = time.monotonic()
+        # 注入上帧：50ms 前在 (330,320) → 实测速度 600px/s 向右
+        body._pet_prev[id(win)] = (330.0, 320.0)
+        body._pet_prev_ts[id(win)] = now - 0.05
+        body._tick()
+        assert win._phys_vel[0] < 0.0  # 被弹回左侧
+        # e=1.3 加速：末速率 = 600*1.3
+        assert abs(win._phys_vel[0]) > 600.0
+        assert win._interaction_state == "THROWN"
+        assert "throw" in win.entered_modes
+        assert win.sounds == 1
+        assert len(bumps) == 1
+        _strength, dir_x, _dir_y = bumps[0]
+        assert dir_x > 0.0  # 岛被向右顶
+    finally:
+        island.hide()
+        island.deleteLater()
+
+
+def test_swept_hit_catches_tunneling_pet(tmp_path):
+    """上一帧还在岛左侧远处、这一帧已在岛右侧：扫掠仍判定命中（防隧道），
+    且被放回来路一侧。"""
+    _qapp()
+    win = FakeWin(x=700.0, y=260.0, vx=4800.0)  # 岛在 400,300；这帧已穿过
+    island, body = _make_body(tmp_path, pets=[win])
+    try:
+        island.show()
+        body._running = True
+        now = time.monotonic()
+        # 100ms 前在岛左侧 (260,320)：合法高速甩出（4800px/s）不被瞬移守卫误杀
+        body._pet_prev[id(win)] = (260.0, 320.0)
+        body._pet_prev_ts[id(win)] = now - 0.1
+        body._tick()
+        assert win._interaction_state == "THROWN"  # 被拦下结算
+        assert win._phys_vel[0] < 0.0  # 弹回来路
+        # TOI 放回：位于岛体左侧（来路一侧），不在右侧
+        assert win.collision_content_rect().center().x() < 400
+    finally:
+        island.hide()
+        island.deleteLater()
+
+
+def test_slow_contact_separates_without_bounce(tmp_path):
+    """低速贴上（相对接近 <20px/s）：只推出不弹飞、不进抛掷、不响。"""
+    _qapp()
+    win = FakeWin(x=340.0, y=285.0, vx=5.0)  # 与岛左缘轻贴
+    island, body = _make_body(tmp_path, pets=[win])
+    try:
+        island.show()
+        body._running = True
+        bumps = []
+        island.bump = lambda *args: bumps.append(args)
+        now = time.monotonic()
+        # 上帧同位（50ms 无位移）→ 实测速度 0
+        rect = win.collision_content_rect()
+        body._pet_prev[id(win)] = (float(rect.center().x()), float(rect.center().y()))
+        body._pet_prev_ts[id(win)] = now - 0.05
+        old_x = win._x
+        body._tick()
+        assert win._interaction_state == "IDLE"  # 不弹飞
+        assert win.sounds == 0
+        assert bumps == []
+        assert win._x != old_x  # 但被推出重叠区
+    finally:
+        island.hide()
+        island.deleteLater()
+
+
+def test_dragged_pet_and_hidden_pet_skipped(tmp_path):
+    """拖拽中的桌宠（用户在摆放）与隐藏的桌宠不参与结算。"""
+    _qapp()
+    dragged = FakeWin(x=340.0, y=285.0, vx=600.0)
+    dragged._physics_mode = "drag"
+    hidden = FakeWin(x=340.0, y=285.0, vx=600.0, visible=False)
+    island, body = _make_body(tmp_path, pets=[dragged, hidden])
+    try:
+        island.show()
+        body._running = True
+        body._tick()
+        assert dragged._interaction_state == "IDLE"
+        assert hidden._interaction_state == "IDLE"
+    finally:
+        island.hide()
+        island.deleteLater()
+
+
+def test_hit_cooldown_per_pet(tmp_path):
+    """0.15s 命中冷却：同一只桌宠连着两次接近只结算一次。"""
+    _qapp()
+    win = FakeWin(x=300.0, y=260.0, vx=600.0)
+    island, body = _make_body(tmp_path, pets=[win])
+    try:
+        island.show()
+        body._running = True
+        now = time.monotonic()
+        body._pet_prev[id(win)] = (330.0, 320.0)
+        body._pet_prev_ts[id(win)] = now - 0.05
+        body._tick()
+        first_v = win._phys_vel[0]
+        # 冷却内再来一次接近（重新注入接近轨迹）
+        body._pet_prev[id(win)] = (330.0, 320.0)
+        body._pet_prev_ts[id(win)] = time.monotonic() - 0.05
+        win._x, win._y = 300.0, 260.0
+        body._tick()
+        assert win._phys_vel[0] == first_v
+    finally:
+        island.hide()
+        island.deleteLater()
+
+
+def test_dragging_island_slaps_stationary_pet(tmp_path):
+    """拖着岛扫鱼：岛速参与相对速度，静止的鱼被拍飞（深度重叠按相对运动解围）。"""
+    _qapp()
+    win = FakeWin(x=560.0, y=285.0, vx=0.0)  # 静止在岛右端上方
+    island, body = _make_body(tmp_path, pets=[win])
+    try:
+        island.show()
+        body._running = True
+        # 模拟岛正被向右拖（速度 800px/s）；鱼静止（实测位移 0）
+        body._vx, body._vy = 800.0, 0.0
+        now = time.monotonic()
+        rect = win.collision_content_rect()
+        body._pet_prev[id(win)] = (float(rect.center().x()), float(rect.center().y()))
+        body._pet_prev_ts[id(win)] = now - 0.05
+        body._check_pet(win, body._island_stadium(), island.geometry(), now, set())
+        assert win._phys_vel[0] > 0.0  # 向右飞出去
+        assert win._interaction_state == "THROWN"
+    finally:
+        island.hide()
+        island.deleteLater()
+
+
+def test_island_velocity_estimate_zero_when_still(tmp_path):
+    """岛不动时速度估计为 0（静止噪声不拍鱼）。"""
+    _qapp()
+    island, body = _make_body(tmp_path)
+    try:
+        island.show()
+        body._update_motion()
+        body._update_motion()
+        assert body._vx == 0.0 and body._vy == 0.0
+    finally:
+        island.hide()
+        island.deleteLater()
+
+
+def test_island_velocity_survives_high_freq_submit(tmp_path):
+    """拖拽中高频几何回调（dt<0.01）不再把岛速清零（实机回归）。
+
+    旧逻辑在 dt<0.01 时清零并刷新采样点：拖拽的 mouseMove 频率远超
+    30Hz，岛速被反复清零，"拖岛拍鱼"退化成只推挤不弹飞。
+    """
+    _qapp()
+    island, body = _make_body(tmp_path)
+    try:
+        island.show()
+        rect = island.geometry()
+        now = time.monotonic()
+        # 上一次有效采样：50ms 前、中心靠左 40px → 拖拽速度约 800px/s
+        body._last_center = (float(rect.center().x()) - 40.0,
+                             float(rect.center().y()))
+        body._last_motion_ts = now - 0.05
+        body._update_motion()
+        assert math.isclose(body._vx, 800.0, rel_tol=0.05)
+        sampled_ts = body._last_motion_ts
+        # 紧跟一波高频回调（间隔远小于 10ms）：速度保留、采样点不刷新
+        for _ in range(5):
+            body._update_motion()
+        assert math.isclose(body._vx, 800.0, rel_tol=0.05)
+        assert body._last_motion_ts == sampled_ts
+    finally:
+        island.hide()
+        island.deleteLater()
+
+
+def test_docked_strip_skips_collision(tmp_path):
+    """停靠细条态不结算碰撞：16×64 竖条与 stadium 水平轴假设不符（幻影墙），
+    且贴屏边细条碰撞价值低；悬停滑出恢复胶囊后照常结算。"""
+    _qapp()
+    win = FakeWin(x=60.0, y=478.0, vx=-600.0)
+    island, body = _make_body(tmp_path, pets=[win])
+    try:
+        island.show()
+        island._mode = "docked"
+        island._hover_peek = False
+        body._running = True
+        body._tick()
+        assert win._interaction_state == "IDLE"  # 细条态不结算
+        # 悬停滑出（几何动画进行中）同样不结算
+        island._hover_peek = True
+        island._geo_to = QRect(16, 440, 260, 44)
+        body._tick()
+        assert win._interaction_state == "IDLE"
+    finally:
+        island.hide()
+        island.deleteLater()
+
+
+def test_island_teleport_does_not_launch_pet(tmp_path):
+    """岛瞬移（配置变更/换屏/夹回屏幕）不产生拍鱼速度（跳变守卫）。"""
+    _qapp()
+    island, body = _make_body(tmp_path)
+    try:
+        island.show()
+        body._update_motion()          # 建立采样基线
+        body._last_motion_ts -= 0.1    # 模拟 100ms 间隔
+        island.move(island.x() + 800, island.y())  # 瞬移 800px
+        body._update_motion()
+        assert body._vx == 0.0 and body._vy == 0.0
+        # 守卫只重置采样点：下一次正常拖拽估计不受影响
+        body._last_motion_ts -= 0.1
+        island.move(island.x() + 30, island.y())   # 30px/100ms = 300px/s
+        body._update_motion()
+        assert math.isclose(body._vx, 300.0, rel_tol=0.2)
+    finally:
+        island.hide()
+        island.deleteLater()
+
+
+def test_separation_cancels_pet_move_plan(tmp_path):
+    """岛推出桌宠前取消其自主移动计划（否则 33ms 后移动插值覆盖分离位置）。"""
+    _qapp()
+    win = FakeWin(x=560.0, y=285.0, vx=0.0)  # 静止贴在岛右端
+    island, body = _make_body(tmp_path, pets=[win])
+    cancels = {"move": 0, "gap": 0}
+    win._cancel_move = lambda: cancels.__setitem__("move", cancels["move"] + 1)
+    win._cancel_animation_gap = lambda: cancels.__setitem__("gap", cancels["gap"] + 1)
+    try:
+        island.show()
+        body._running = True
+        now = time.monotonic()
+        rect = win.collision_content_rect()
+        body._pet_prev[id(win)] = (float(rect.center().x()), float(rect.center().y()))
+        body._pet_prev_ts[id(win)] = now - 0.05
+        body._check_pet(win, body._island_stadium(), island.geometry(), now, set())
+        assert cancels["move"] >= 1 and cancels["gap"] >= 1
+    finally:
+        island.hide()
+        island.deleteLater()
+
+
+def test_island_hit_ignores_pet_global_collision_switch(tmp_path):
+    """桌宠全局碰撞开关（多开桌宠之间碰撞）不否决果冻墙——岛只由自己的开关管。"""
+    _qapp()
+    win = FakeWin(x=560.0, y=285.0, vx=-600.0)
+    win.cfg = SimpleNamespace(
+        get=lambda k, d=None: False if k == "collision_enabled" else d)
+    island, body = _make_body(tmp_path, pets=[win])
+    try:
+        island.show()
+        body._running = True
+        now = time.monotonic()
+        rect = win.collision_content_rect()
+        body._pet_prev[id(win)] = (float(rect.center().x()) + 40.0,
+                                   float(rect.center().y()))
+        body._pet_prev_ts[id(win)] = now - 0.05
+        body._check_pet(win, body._island_stadium(), island.geometry(), now, set())
+        assert win._interaction_state == "THROWN"
+    finally:
+        island.hide()
+        island.deleteLater()
+
+
+def test_island_resize_does_not_inject_phantom_speed(tmp_path):
+    """窗口尺寸变化（展开/收起卡片等）只重置采样点——窗口中心平移不是岛速。"""
+    _qapp()
+    island, body = _make_body(tmp_path)
+    try:
+        island.show()
+        body._update_motion()           # 建立基线（含尺寸）
+        body._last_motion_ts -= 0.05
+        # 岛处于 setFixedSize 状态，先解锁再 resize（否则 resize 是 no-op，
+        # 测试空转——判别力：删掉 size 守卫后，中心平移 +40px/50ms=800px/s
+        # 会让 _vx 非零，断言判红）
+        island.setMinimumSize(0, 0)
+        island.setMaximumSize(16777215, 16777215)
+        island.resize(island.width() + 80, island.height())  # 纯 resize
+        body._update_motion()
+        assert body._vx == 0.0 and body._vy == 0.0
+    finally:
+        island.hide()
+        island.deleteLater()

--- a/tests/test_island_shell_wiring.py
+++ b/tests/test_island_shell_wiring.py
@@ -1,0 +1,166 @@
+# -*- coding: utf-8 -*-
+"""灵动岛 AppShell 接线测试：碰撞体生命周期/挂起、no-chat 变体守卫。
+
+审查补票（P0-1/P0-2/P1-6）：碰撞体重开必须换新 session；pet.chat 被排除的
+打包变体不能崩；碰撞体随桌宠可见性挂起。
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from PySide6.QtWidgets import QApplication
+
+from pet.app import AppShell
+from pet.chat.service import ChatService
+from pet.collision_ipc import _stop_live_sessions_for_tests
+from pet.config import Config
+
+
+def _qapp() -> QApplication:
+    return QApplication.instance() or QApplication([])
+
+
+def _make_shell(tmp_path: Path, **island_cfg) -> AppShell:
+    """最小 AppShell 桩：__new__ 绕过完整初始化，只接灵动岛链路。"""
+    cfg = Config(base=tmp_path)
+    cfg.set("dynamic_island", {
+        "enabled": True, "x": 400, "y": 300,
+        **island_cfg,
+    })
+    shell = AppShell.__new__(AppShell)
+    shell.config = cfg
+    shell.island = None
+    shell.island_collision = None
+    shell.instance = None
+    shell._instances = []
+    return shell
+
+
+def _teardown_shell(shell) -> None:
+    try:
+        body = getattr(shell, "island_collision", None)
+        if body is not None:
+            body.stop()
+    finally:
+        island = getattr(shell, "island", None)
+        if island is not None:
+            island.hide()
+            island.deleteLater()
+        ChatService.unregister_global_finished(shell._on_global_chat_finished)
+        _stop_live_sessions_for_tests()
+        QApplication.processEvents()
+
+
+def test_shell_creates_island_and_local_collision_body(tmp_path):
+    """接线全景：岛创建、本进程碰撞体启动、几何/可见性回调接好。"""
+    app = _qapp()
+    shell = _make_shell(tmp_path)
+    try:
+        shell._sync_dynamic_island()
+        island = shell.island
+        body = shell.island_collision
+        assert island is not None and island.isVisible()
+        assert body is not None and body._running is True
+        assert body._timer.isActive()
+        # 几何变化钩子与可见性回调都指向碰撞体
+        assert island.on_geometry_changed == body.submit
+        assert island.on_pet_visibility_changed == body.set_own_pet_visible
+        # pets_provider 返回本进程全部桌宠窗口（无窗时为空）
+        assert body._pets_provider() == []
+    finally:
+        _teardown_shell(shell)
+        app.processEvents()
+
+
+def test_collision_body_restart_after_disable(tmp_path):
+    """关→开果冻墙：本地碰撞体停表/重开都干净（无 IPC session 语义）。"""
+    app = _qapp()
+    shell = _make_shell(tmp_path)
+    try:
+        shell._sync_dynamic_island()
+        body = shell.island_collision
+        # 关掉碰撞（设置里关果冻墙）
+        cfg = dict(shell.config.get("dynamic_island"))
+        cfg["collision_enabled"] = False
+        shell._sync_island_collision(cfg)
+        assert body._running is False and not body._timer.isActive()
+        # 再打开 → 重新运行
+        cfg["collision_enabled"] = True
+        shell._sync_island_collision(cfg)
+        assert body._running is True and body._timer.isActive()
+    finally:
+        _teardown_shell(shell)
+        app.processEvents()
+
+
+def test_island_survives_no_chat_packaging_variant(tmp_path, monkeypatch):
+    """P0-2 回归：pet.chat 被排除的打包变体里创建灵动岛不得抛异常。"""
+    app = _qapp()
+    monkeypatch.setitem(sys.modules, "pet.chat.service", None)  # 模拟变体排除
+    shell = _make_shell(tmp_path)
+    try:
+        shell._sync_dynamic_island()  # 不应抛 ModuleNotFoundError
+        assert shell.island is not None
+        # 未注册全局订阅（无 chat 可订）
+        assert shell._on_global_chat_finished not in ChatService._global_finished_listeners
+    finally:
+        _teardown_shell(shell)
+        app.processEvents()
+
+
+def test_quiet_balance_refresh_paths(tmp_path, monkeypatch):
+    """卡片展开静默刷新：无 Key 明示 / 缓存命中直接用 / 后台查询只更新岛。"""
+    import hashlib
+    import time as _time
+    from types import SimpleNamespace
+
+    app = _qapp()
+    shell = _make_shell(tmp_path)
+    shell._balance_busy = False
+    shell._balance_cache = None
+    shell._balance_cache_path = Path(shell.config.dir) / "balance_cache.json"
+    try:
+        shell._sync_dynamic_island()
+        island = shell.island
+
+        provider = SimpleNamespace(id="p", base_url="http://x", api_key="", verify_ssl=True)
+        monkeypatch.setattr(shell.config, "chat_settings",
+                            lambda: SimpleNamespace(active_config=provider))
+        monkeypatch.setattr(shell.config, "resolve_api_key", lambda _p: "")
+
+        # 1) 未配置 API Key → 明确提示，不再停留 "余额 --"
+        island.expand_card()  # card_expanded → _quiet_balance_refresh
+        assert island._balance_text.startswith("未配置 API Key")
+
+        # 2) 有 Key + 新鲜内存缓存 → 直接命中，不起后台查询
+        provider.api_key = "sk-test"
+        monkeypatch.setattr(shell.config, "resolve_api_key", lambda _p: "sk-test")
+        digest = hashlib.sha256(b"sk-test").hexdigest()[:12]
+        provider_key = "|".join(["p", "http://x", digest])
+        shell._balance_cache = (_time.monotonic(), {"text": "余额 ¥9.9", "info": {}}, provider_key)
+        shell._quiet_balance_refresh()
+        assert island._balance_text == "余额 ¥9.9"
+
+        # 3) 无缓存 → 后台查询：结果回来只更新岛卡片（不冒泡/不播动画）
+        island._finish_animations()  # 展开动画落定（动画表停），隔离基线
+        assert not island._anim_timer.isActive()
+        shell._balance_cache = None
+        shell._quiet_balance_last = None
+
+        def fake_worker(bridge, base_url, api_key, verify_ssl, provider_key='', **_kw):
+            bridge.done.emit(True, {"text": "余额 ¥8.8", "info": {}})
+
+        monkeypatch.setattr(shell, "_balance_worker", fake_worker)
+        shell._quiet_balance_refresh()
+        for _ in range(50):
+            QApplication.processEvents()
+            _time.sleep(0.02)
+            if island._balance_text == "余额 ¥8.8":
+                break
+        assert island._balance_text == "余额 ¥8.8"
+        assert not island._anim_timer.isActive()  # 静默路径不播动画
+    finally:
+        shell._balance_busy = False
+        _teardown_shell(shell)
+        app.processEvents()


### PR DESCRIPTION
## 摘要

重做灵动岛：胶囊 UI 全面升级（事件动效 / 四边停靠半隐藏 / 单击展开快捷卡片 / 外观可调 / 史莱姆形变），碰撞从碰撞 IPC 改为本进程直连检测（果冻墙）。

## 改动

**灵动岛 UI（pet/dynamic_island.py）**
- 事件动效：AI 回复 / 余额刷新 / 峰谷切换时位移弹跳 + 呼吸浮动
- 四边停靠半隐藏：贴屏边收成 16px 细条 + 主题色亮线，悬停临时滑出
- 单击展开快捷卡片：余额 / 峰谷提示 / 最近消息 + 显隐桌宠 / 聊天 / 设置快捷按钮
- 外观设置：不透明度（0.4~1.0）与主题色（五色）进调色板；展开卡片底板可读性钳制（不随胶囊透明度降低）
- 史莱姆形变：squish 只作用于胶囊外形，文字/图标保持锐利；展开态禁用整窗变换（防贴边底板被截）

**果冻墙碰撞（pet/island_collision.py，新文件）**
- 岛建模为体育场形（stadium）无限质量弹性墙（STATIC_RESTITUTION=1.3，撞岛像撞弹床）
- 30Hz CoarseTimer 本地检测 + 圆链扫掠 TOI 防高速穿透 + 实测速度（位移/dt）
- 拖岛拍鱼：岛速参与相对速度，岛是"移动的拍子"；命中复用桌宠真实撞击路径（抛掷物理 / 音效 / 挤压逐只错峰）
- 防御层：瞬移跳变守卫、岛速上限（区分拖拽/非拖拽，保留甩岛拍鱼手感）、窗口尺寸变化不产幻影速度、岛几何动画期间不结算、停靠细条态跳过、边缘探头姿态保持

**为什么直连不走碰撞 IPC**：岛作为静态成员进碰撞世界时，保活/快照/预测抑制/客户端阈值任一环节被 GUI 卡顿饿死，表现就是撞了没反应或直接穿过去（实机教训）。本进程直连换零时序风险。代价：独立进程实例的桌宠不在检测视野内；单进程多开（experimental_single_process_spawn）场景全覆盖。FLAG_STATIC 的 IPC 链路保留在代码里并显式标注为后续预留。

**配套修正**
- 本地命中路径与权威冲量路径副作用对齐（幽灵点击抑制、探头重入 arm 写到 CollisionClient）
- 进程级聊天订阅退出注销 + 岛回调补 isValid 守卫
- 静默余额刷新（卡片展开触发）：独立忙标志 + None 语义节流 + 不播动画
- 配置清洗：岛布尔键统一走 _bool_or_default（兼容 int 0/1 与字符串）
- 删除已无调用方的 switch_character(force=) 参数

## 验证

- 全量 pytest：1993 passed / 8 skipped（QT_QPA_PLATFORM=offscreen）；ruff 干净
- 新增回归测试覆盖：拖岛拍鱼 / 隧道拦截 / 细条态跳过 / 瞬移守卫 / resize 幻影速度 / 分离取消移动计划 / 展开态冻结 squish / 岛开关独立于全局碰撞开关 / 静默刷新不播动画 / 配置清洗边界
- 实机验证：撞岛弹开、拖岛拍鱼、四边停靠滑出、展开卡片可读性（含低透明度设置下）、单进程多开多只桌宠撞岛