### PR TITLE
fix: 碰撞卡顿三连修——落地预热离线程 / 飞行期首帧 pin / 岛内容层缓存

### DIFF
--- a/pet/dynamic_island.py
+++ b/pet/dynamic_island.py
@@ -20,7 +20,7 @@ from PySide6.QtCore import (
     QPoint, QRect, QRectF, QSize, Qt, QTimer, Signal,
 )
 from PySide6.QtGui import (
-    QColor, QGuiApplication, QLinearGradient, QPainter, QPen,
+    QColor, QGuiApplication, QLinearGradient, QPainter, QPen, QPixmap,
 )
 from PySide6.QtWidgets import (
     QApplication, QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget,
@@ -185,6 +185,9 @@ class DynamicIsland(QWidget):
         self._scale_v = 0.0
         self._breathe_until = 0.0
         self._hover_scale_target = 1.0
+        # 内容层位图缓存（paintEvent 的文字绘制是实测大头，见 _content_cache）
+        self._content_pixmap: QPixmap | None = None
+        self._content_cache_key: tuple | None = None
         self._geo_from: QRect | None = None
         self._geo_to: QRect | None = None
         self._geo_t = 0.0
@@ -963,6 +966,84 @@ class DynamicIsland(QWidget):
                 (rect.width() - dot_size) / 2, (rect.height() - dot_size) / 2,
                 dot_size, dot_size))
 
+    def _content_cache(self) -> QPixmap:
+        """内容层（图标/名称/信息/状态灯）的缓存位图。
+
+        为什么缓存（拖岛扫鱼实测定案）：paintEvent 均值 6.2ms，大头是 CJK
+        文字的 shaping/回退字体解析；而内容只在刷新（时间跳变/余额刷新/
+        配置变更）时变化，拖拽/弹簧期间逐帧重画纯属浪费。缓存后每帧一次
+        blit（亚毫秒）。blit 走同一 painter 的整窗变换（kick 为整数平移，
+        文字锐利口径不变）；squish 只调制胶囊外形、本来就不碰内容层。
+        key 覆盖所有影响像素的输入（可见项/文本/颜色/字体/DPR/宽度），
+        任一变化自动重建，无需显式失效钩子。
+        """
+        icon, name, info, status = self._visible_parts()
+        _background, primary_color, secondary_color = self._style_palette()
+        info_color = self._info_color(secondary_color)
+        dpr = self.devicePixelRatioF()
+        key = (
+            icon, name, info, status,
+            self._icon_text() if icon else "",
+            self._character_name() if name else "",
+            self._info_text() if info else "",
+            self._accent_color().name() if icon else "",
+            primary_color.name() if name else "",
+            info_color.name() if info else "",
+            self._status_dot_color().name() if status else "",
+            self.font().toString(), dpr, self.width(),
+        )
+        if self._content_pixmap is not None and self._content_cache_key == key:
+            return self._content_pixmap
+        pm = QPixmap(max(1, round(self.width() * dpr)),
+                     max(1, round(_CAPSULE_HEIGHT * dpr)))
+        pm.setDevicePixelRatio(dpr)
+        pm.fill(Qt.GlobalColor.transparent)
+        painter = QPainter(pm)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        painter.setFont(self.font())
+        x = _CAPSULE_INSET + 13.0
+        painter.setPen(Qt.PenStyle.NoPen)
+        if icon:
+            painter.setBrush(self._accent_color())
+            painter.drawEllipse(QRectF(x, (_CAPSULE_HEIGHT - 26) / 2, 26, 26))
+            painter.setPen(QColor(255, 255, 255))
+            fm = self.fontMetrics()
+            painter.drawText(
+                QRectF(x, (_CAPSULE_HEIGHT - fm.height()) / 2 - 1, 26, fm.height()),
+                Qt.AlignmentFlag.AlignCenter,
+                self._icon_text(),
+            )
+            painter.setPen(Qt.PenStyle.NoPen)
+            x += 26 + 8
+        painter.setPen(primary_color)
+        if name:
+            text = self._character_name()
+            painter.drawText(
+                QRectF(x, 0, self.fontMetrics().horizontalAdvance(text), _CAPSULE_HEIGHT),
+                Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignLeft,
+                text,
+            )
+            x += self.fontMetrics().horizontalAdvance(text) + 8
+        if info:
+            info_text = self._info_text()
+            painter.setPen(info_color)
+            painter.drawText(
+                QRectF(x, 0, self.fontMetrics().horizontalAdvance(info_text), _CAPSULE_HEIGHT),
+                Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignLeft,
+                info_text,
+            )
+            x += self.fontMetrics().horizontalAdvance(info_text) + 8
+        if status:
+            dot_size = 10
+            painter.setPen(Qt.PenStyle.NoPen)
+            painter.setBrush(self._status_dot_color())
+            painter.drawEllipse(QRectF(x, (_CAPSULE_HEIGHT - dot_size) / 2, dot_size, dot_size))
+            x += dot_size + 12
+        painter.end()
+        self._content_pixmap = pm
+        self._content_cache_key = key
+        return pm
+
     def _paint_capsule(self, painter: QPainter) -> None:
         # 展开时先画卡片底板（胶囊下方一整块，圆角连续；内容区遵守同心圆角）
         if self._mode == "expanded":
@@ -989,8 +1070,9 @@ class DynamicIsland(QWidget):
             painter.setBrush(QColor(0, 0, 0, 46))
             painter.drawRoundedRect(shadow, radius, radius)
 
-        # 胶囊主体（白色 / 黑色 / 玻璃质感）
-        background, primary_color, secondary_color = self._style_palette()
+        # 胶囊主体（白色 / 黑色 / 玻璃质感）；内容层已下沉到 _content_cache，
+        # 主/次文字色在这里不再使用
+        background, _primary_color, _secondary_color = self._style_palette()
         painter.setBrush(background)
         painter.setPen(Qt.PenStyle.NoPen)
         painter.drawRoundedRect(rect, radius, radius)
@@ -1006,50 +1088,10 @@ class DynamicIsland(QWidget):
             painter.setBrush(Qt.BrushStyle.NoBrush)
             painter.drawRoundedRect(rect.adjusted(0.5, 0.5, -0.5, -0.5), radius - 0.5, radius - 0.5)
 
-        # 内容（图标/名称/信息/状态灯）：按未形变的静止位绘制，绝不参与形变
-        icon, name, info, status = self._visible_parts()
-        x = _CAPSULE_INSET + 13.0
-        painter.setPen(Qt.PenStyle.NoPen)
-        if icon:
-            painter.setBrush(self._accent_color())
-            painter.drawEllipse(QRectF(x, (_CAPSULE_HEIGHT - 26) / 2, 26, 26))
-            painter.setPen(QColor(255, 255, 255))
-            fm = self.fontMetrics()
-            icon_text = self._icon_text()
-            painter.drawText(
-                QRectF(x, (_CAPSULE_HEIGHT - fm.height()) / 2 - 1, 26, fm.height()),
-                Qt.AlignmentFlag.AlignCenter,
-                icon_text,
-            )
-            painter.setPen(Qt.PenStyle.NoPen)
-            x += 26 + 8
-
-        painter.setPen(primary_color)
-        if name:
-            text = self._character_name()
-            painter.drawText(
-                QRectF(x, 0, self.fontMetrics().horizontalAdvance(text), _CAPSULE_HEIGHT),
-                Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignLeft,
-                text,
-            )
-            x += self.fontMetrics().horizontalAdvance(text) + 8
-
-        if info:
-            info_text = self._info_text()
-            painter.setPen(self._info_color(secondary_color))
-            painter.drawText(
-                QRectF(x, 0, self.fontMetrics().horizontalAdvance(info_text), _CAPSULE_HEIGHT),
-                Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignLeft,
-                info_text,
-            )
-            x += self.fontMetrics().horizontalAdvance(info_text) + 8
-
-        if status:
-            dot_size = 10
-            painter.setPen(Qt.PenStyle.NoPen)
-            painter.setBrush(self._status_dot_color())
-            painter.drawEllipse(QRectF(x, (_CAPSULE_HEIGHT - dot_size) / 2, dot_size, dot_size))
-            x += dot_size + 12
+        # 内容层（图标/名称/信息/状态灯）：缓存位图 blit——文字逐帧重画是
+        # 实测大头（见 _content_cache）；内容绝不参与形变，口径与原"按未
+        # 形变静止位绘制"一致
+        painter.drawPixmap(0, 0, self._content_cache())
 
     # ------------------------------------------------------------ 显隐休眠
     def hideEvent(self, event) -> None:  # noqa: N802

--- a/pet/webm_clip.py
+++ b/pet/webm_clip.py
@@ -483,6 +483,19 @@ def _clip_first_frame_bytes(clip) -> int:
     return 0 if img is None else img.width() * img.height() * 4
 
 
+def _ffr_is_pinned(clip) -> bool:
+    """clip 首帧是否受「绝不逐出」保护（登记选型与清空前复查共用）。
+
+    两类 pin 生命周期不同，必须都认且不可混用同一标志：
+    - _ffr_pinned：library 标记的高频交互核常驻（click/turn/drag，永不来摘）；
+    - _ffr_landing_pinned：弹射飞行期的落地首帧保护（window 起飞打、落地/
+      飞行中断摘）。idle 池可与高频交互常驻集重叠，混用会让落地摘 pin 顺手
+      摘掉常驻保护，点击/拖拽首帧重新暴露在预热浪涌的逐出路径下。
+    """
+    return bool(getattr(clip, '_ffr_pinned', False)
+                or getattr(clip, '_ffr_landing_pinned', False))
+
+
 def _ffr_touch(clip, added_bytes: int = 0) -> list:
     """登记/置顶 clip 并记账；返回待逐出 (clip, token) 列表（调用方锁外处理）。
 
@@ -509,10 +522,9 @@ def _ffr_touch(clip, added_bytes: int = 0) -> list:
         clip._ffr_evict_token = None  # 新登记/置顶 = 取消悬挂中的逐出
         while _first_frame_bytes > _first_frame_budget_bytes and len(_first_frame_reg) > 1:
             # 从 LRU 头部找首个可逐出项：死引用/已清缓存顺手清账摘出；
-            # _ffr_pinned（瞬时交互核：click/turn/drag，由 MovieLibrary 标记，
-            # 批10-A3 起 idle/move 改由预测式预热覆盖）跳过不逐——否则预热
-            # 浪涌会把交互首帧挤出去，用户点击/拖拽时被迫 GUI 同步解码
-            # （实测：42 段低优先级 ≈38MB > 预算，交互首帧被逐出后
+            # _ffr_is_pinned（常驻交互核 + 飞行期落地 pin，见其文档）跳过不逐
+            # ——否则预热浪涌会把交互首帧挤出去，用户点击/拖拽时被迫 GUI
+            # 同步解码（实测：42 段低优先级 ≈38MB > 预算，交互首帧被逐出后
             # 看门狗抓到 117~160ms 切换卡顿）。
             victim = None
             removed_dead = False
@@ -523,7 +535,7 @@ def _ffr_touch(clip, added_bytes: int = 0) -> list:
                     _first_frame_reg.pop(i)
                     removed_dead = True
                     break
-                if getattr(c, '_ffr_pinned', False):
+                if _ffr_is_pinned(c):
                     continue
                 victim = (c, i)
                 break
@@ -573,6 +585,10 @@ def _ffr_evict(victims) -> None:
             with victim._first_frame_lock:
                 if victim._ffr_evict_token != token:
                     continue  # 摘表后被重新登记/置顶：本次逐出决定已过期
+                if _ffr_is_pinned(victim):
+                    continue  # 选型后被 pin（如起飞保护落地首帧）：逐出决定已
+                    # 过期——"绝不逐出"语义下，登记处选型与这里清空之间有
+                    # 窗口期，必须按 _ffr_is_pinned 复查（常驻 + 飞行期 pin）
                 victim._first_image = None
                 victim._ffr_evict_token = None
         except Exception:

--- a/pet/window.py
+++ b/pet/window.py
@@ -4097,6 +4097,7 @@ class PetWindow(QWidget, WindowFeatureGateMixin):
         was_throw = self._physics_mode == 'throw'
         self._physics_timer.stop()
         self._physics_mode = None
+        self._unpin_landing_idles()  # 飞行结束：摘掉起飞首帧保护（pin 只在飞行期存在）
         if getattr(self, '_interaction_state', IDLE) == THROWN:
             self._interaction_state = IDLE
         self._phys_vel[:] = [0.0, 0.0]
@@ -4118,6 +4119,9 @@ class PetWindow(QWidget, WindowFeatureGateMixin):
         if mode == 'throw':
             self._throw_slow_switched = False  # 每次弹射只允许一次降速过渡
             self._warm_landing_idles()
+        else:
+            # 飞行被拖拽打断（空中抓住）：起飞预热/首帧 pin 的落地语义已不存在
+            self._unpin_landing_idles()
 
     def _first_frame_warm(self, name) -> bool:
         """目标动画首帧是否已在缓存（播过留 LRU / pinned / 预热完成）。
@@ -4161,9 +4165,56 @@ class PetWindow(QWidget, WindowFeatureGateMixin):
 
         预测式预热覆盖不到这里：弹射是事件触发（拖拽打断早已把预测代次
         作废），且交互让路闸门在拖拽/弹射期间会挡住 warm_predicted——
-        故直接调 clip 级 warm_first_frame（幂等、后台线程、可被取消），
-        绕过闸门。idle 池极小（通常 1-3 个），代价可忽略；不暖的话落地
-        切换可能命中冷首帧，GUI 线程同步拉 ffmpeg 解码（实测 ~100ms）。
+        故直接调 clip 级 warm_first_frame（幂等、可被取消），绕过闸门。
+        idle 池极小（通常 1-3 个），代价可忽略；不暖的话落地切换可能命中
+        冷首帧，GUI 线程同步拉 ffmpeg 解码（实测 ~100ms）。
+
+        线程安全：warm_first_frame 只在调用线程跑解码（QImage 级，无 GUI
+        对象访问），与前台 _decode_first_frame_sync 经 _first_frame_lock
+        原子互斥（N4），与 library 预热调度器从后台线程调用它的语义完全
+        一致。clip 解析在 GUI 线程完成（MovieLibrary.movie 不保证线程安全），
+        后台线程只持有 clip 引用。
+        实机教训：本方法曾在 GUI 线程同步执行预热——碰撞风暴下每次撞飞进
+        throw 都同步拉起 ffmpeg（~100ms/只），多鱼互撞时连续 200ms+ 级
+        卡顿（GUI 看门狗实测）；挪到 daemon 线程后起飞路径零阻塞。
+        """
+        lib = getattr(self, 'lib', None)
+        movie = getattr(lib, 'movie', None)
+        if not callable(movie):
+            return
+        clips = []
+        for name in self.idles or ():
+            try:
+                clips.append(movie(name))
+            except Exception:
+                pass
+        if not clips:
+            return
+        # 飞行期间禁止逐出（GUI 线程打标记，warm 在后台完成）：多鱼同进程
+        # 的预热浪涌会在 8MB 预算内把刚暖好的落地首帧挤掉（实测定案：8MB
+        # + 后台预热下风暴期仍有 105~399ms 落地冷解码卡顿）。pin 只覆盖
+        # 起飞→落地窗口（idle 池极小，~1MB/窗），落地/飞行中断即摘除
+        #（_stop_physics / 进拖拽），常驻内存零增长——不碰 8MB 预算本体。
+        for clip in clips:  # 独立标志：绝不与 library 常驻 _ffr_pinned 混用
+            clip._ffr_landing_pinned = True
+
+        def _warm() -> None:
+            for clip in clips:
+                try:
+                    warm = getattr(clip, 'warm_first_frame', None)
+                    if callable(warm):
+                        warm()
+                except Exception:
+                    pass  # 预热失败不致命：落地切换退化为现状（按需同步解码）
+
+        threading.Thread(
+            target=_warm, daemon=True, name='pet-warm-landing-idles').start()
+
+    def _unpin_landing_idles(self) -> None:
+        """摘掉起飞时给 idle 首帧打的飞行期 pin（见 _warm_landing_idles）。
+
+        落地（_stop_physics）/ 飞行被拖拽打断（_enter_physics_mode('drag')）
+        时调用；只摘 _ffr_landing_pinned，library 常驻 _ffr_pinned 绝不动。
         """
         lib = getattr(self, 'lib', None)
         movie = getattr(lib, 'movie', None)
@@ -4171,11 +4222,9 @@ class PetWindow(QWidget, WindowFeatureGateMixin):
             return
         for name in self.idles or ():
             try:
-                warm = getattr(movie(name), 'warm_first_frame', None)
-                if callable(warm):
-                    warm()
+                movie(name)._ffr_landing_pinned = False
             except Exception:
-                pass  # 预热失败不致命：落地切换退化为现状（按需同步解码）
+                pass
 
     def _on_physics_tick(self) -> None:
         if perfstats.ENABLED:

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -72,7 +72,14 @@ PET_DIR = Path(__file__).resolve().parents[1] / "pet"
 # 两处都是 3 行内联守卫，拆出去会切断 _pause_activity 与 _closing 共享状态流
 # （更关键的是顺序语义：match_shutdown 必须**先**暂停再置 _closing，见
 # pet/window_optional_services.py）；拆分待办不变，预算仍只随实测校准。
-WINDOW_PY_LINE_BUDGET = 4429
+# 2026-09-13 再上调到 4478：肥鱼互撞卡顿修复批（window.py 净 +49，实测 4478）——
+# _warm_landing_idles 从 GUI 线程同步 ffmpeg 首帧解码改为 daemon 线程预热
+# （实测定案：碰撞风暴下每次撞飞堵 GUI ~100ms，看门狗连续抓 200ms+ 卡顿），
+# 起飞/落地 pin-unpin 保护落地首帧不在飞行窗口被预热浪涌逐出（8MB 预算不动，
+# 常驻内存零增长），增量行数几乎全是线程安全性/实机教训注释；这些守卫与
+# _enter_physics_mode/_stop_physics 共享窗口状态流，拆控制器反而切断调用链，
+# 按约定只校准预算。
+WINDOW_PY_LINE_BUDGET = 4478
 
 # modern_settings_dialog.py 行数预算：按结构线拆分后实测 1857 行（拆分前 4811 行）。
 # 主对话框 ModernSettingsDialog + 对话框装配/配置写回 + 为 pet/ 与 tests/ 保留的

--- a/tests/test_island_content_cache.py
+++ b/tests/test_island_content_cache.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+"""灵动岛内容层缓存（_content_cache）回归测试。
+
+背景（拖岛扫鱼实测定案）：paintEvent 均值 6.2ms，大头是 CJK 文字
+shaping/回退字体解析；内容层只在刷新时变化，拖拽/弹簧期间逐帧重画
+是纯浪费。缓存后每帧一次 blit。本文件锁定：缓存命中/失效语义 +
+缓存路径下内容确实画出来（不是透明空图）。
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from PySide6.QtGui import QImage, QPainter
+from PySide6.QtWidgets import QApplication
+
+from pet.config import Config
+from pet.dynamic_island import DynamicIsland
+
+
+def _qapp() -> QApplication:
+    return QApplication.instance() or QApplication([])
+
+
+def _island(tmp_path: Path, **overrides) -> DynamicIsland:
+    cfg = Config(base=tmp_path)
+    data = {
+        "enabled": True, "show_icon": True, "show_name": True,
+        "show_info": True, "info_mode": "custom", "custom_text": "测试文本",
+        "show_status": True, "style": "dark", "x": 400, "y": 300,
+    }
+    data.update(overrides)
+    cfg.set("dynamic_island", data)
+    return DynamicIsland(cfg)
+
+
+def test_content_cache_hit_and_auto_invalidate(tmp_path):
+    _qapp()
+    island = _island(tmp_path)
+    island.show()
+    first = island._content_cache()
+    assert not first.isNull()
+    assert island._content_cache() is first, "同 key 必须命中缓存（同一位图对象）"
+
+    # 内容变化（走生产路径：改配置 + refresh_from_config）→ 自动重建
+    data = dict(island._cfg)
+    data["custom_text"] = "变了"
+    island.config.set("dynamic_island", data)
+    island.refresh_from_config()
+    second = island._content_cache()
+    assert second is not first, "内容变化后必须重建缓存"
+
+    # 可见项变化也必须重建
+    data = dict(island._cfg)
+    data["show_status"] = False
+    island.config.set("dynamic_island", data)
+    island.refresh_from_config()
+    assert island._content_cache() is not second
+    island.deleteLater()
+
+
+def test_content_cache_renders_nontransparent_content(tmp_path):
+    """缓存位图里必须有实际内容（图标圆/文字/状态点的非透明像素）。"""
+    _qapp()
+    island = _island(tmp_path)
+    island.show()
+    img = island._content_cache().toImage().convertToFormat(
+        QImage.Format.Format_ARGB32)
+    opaque = 0
+    for y in range(0, img.height(), 2):
+        for x in range(0, img.width(), 2):
+            if img.pixelColor(x, y).alpha() > 0:
+                opaque += 1
+    assert opaque > 50, "内容层几乎是空的——缓存路径把内容画丢了"
+    island.deleteLater()
+
+
+def test_paint_uses_cache_without_error(tmp_path):
+    """paintEvent 冒烟：正常/形变/展开三态走缓存路径都不炸且有内容。"""
+    _qapp()
+    island = _island(tmp_path)
+    island.show()
+    island._squish = 0.85  # 果冻形变中
+    grab = island.grab()
+    assert not grab.isNull()
+    island._squish = 1.0
+    island._mode = "expanded"
+    island.refresh_from_config()
+    grab2 = island.grab()
+    assert not grab2.isNull()
+    island.deleteLater()
+
+
+def test_content_cache_key_covers_colors_and_style(tmp_path, monkeypatch):
+    """key 必须覆盖所有影响像素的颜色输入；每一步只让一个 key 项在动。
+
+    突变判别：删掉对应 key 项，该步会拿到陈旧位图（同一对象）→ 判红。
+    """
+    _qapp()
+    # 关掉信息槽：风格变化时次文字色项为空，只有主文字色项在动
+    island = _island(tmp_path, show_info=False)
+    island.show()
+    width = island.width()
+    dark = island._content_cache()
+
+    data = dict(island._cfg)
+    data["style"] = "light"
+    island.config.set("dynamic_island", data)
+    island.refresh_from_config()
+    light = island._content_cache()
+    assert island.width() == width, "前提：这些改动不改胶囊宽度（排除宽度项顶包）"
+    assert light is not dark, "风格（主文字色）变化必须重建缓存"
+
+    data = dict(island._cfg)
+    data["accent"] = "pink"
+    island.config.set("dynamic_island", data)
+    island.refresh_from_config()
+    accent = island._content_cache()
+    assert island.width() == width, "前提：主题色不改胶囊宽度"
+    assert accent is not light, "主题色变化必须重建缓存"
+
+    island.set_pet_visible(False)  # 状态灯 绿 → 灰
+    assert island.width() == width, "前提：可见性不改胶囊宽度"
+    assert island._content_cache() is not accent, "状态灯颜色变化必须重建缓存"
+    island.deleteLater()
+
+    # 信息色项：自定义峰谷标签同名 + 固定切换时间 → 文案两侧相同，
+    # 只有 _info_color 在动（隔离出 info_color.name() 这一项）
+    from pet import balance as balance_mod
+
+    island2 = _island(tmp_path, info_mode="balance_tier")
+    # 峰谷标签/颜色开关读的是顶层 config（不是 dynamic_island 子字典）
+    island2.config.set("balance_tier_labels_mode", "custom")
+    island2.config.set("balance_tier_label_peak", "峰")
+    island2.config.set("balance_tier_label_idle", "峰")
+    island2.show()
+    monkeypatch.setattr(balance_mod, "next_pricing_switch",
+                        lambda *a, **k: ("idle", None))
+    monkeypatch.setattr(balance_mod, "format_switch_time",
+                        lambda *a, **k: "12:00")
+    monkeypatch.setattr(balance_mod, "deepseek_pricing_tier",
+                        lambda *a, **k: "peak")
+    peak = island2._content_cache()
+    text_peak = island2._info_text()
+    monkeypatch.setattr(balance_mod, "deepseek_pricing_tier",
+                        lambda *a, **k: "idle")
+    assert island2._info_text() == text_peak, "前提：文案不随档位变化"
+    assert island2._content_cache() is not peak, "峰谷信息色变化必须重建缓存"
+    island2.deleteLater()

--- a/tests/test_warm_landing_idles.py
+++ b/tests/test_warm_landing_idles.py
@@ -1,0 +1,207 @@
+# -*- coding: utf-8 -*-
+"""_warm_landing_idles 回归测试：起飞预热绝不在 GUI 线程同步解码。
+
+实机教训（肥鱼互撞超级卡）：该方法曾在 GUI 线程同步执行
+clip.warm_first_frame() —— 碰撞风暴下每次撞飞进 throw 都同步拉起
+ffmpeg（~100ms/只），多鱼互撞时 GUI 看门狗连续抓 200ms+ 卡顿。
+修复后预热在 daemon 线程执行；这些测试锁定该语义（改回同步即判红）。
+"""
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+from pet.window import PetWindow
+
+
+class _FakeClip:
+    def __init__(self, name, sink, block_event=None, raises=False):
+        self.name = name
+        self._sink = sink
+        self._block_event = block_event
+        self._raises = raises
+
+    def warm_first_frame(self):
+        if self._block_event is not None:
+            self._block_event.wait(timeout=2.0)
+        self._sink.append((self.name, threading.get_ident()))
+        if self._raises:
+            raise RuntimeError("boom")
+
+
+def _stub_win(clips):
+    return SimpleNamespace(
+        lib=SimpleNamespace(movie=lambda name: clips[name]),
+        idles=list(clips.keys()),
+    )
+
+
+def test_warm_landing_idles_runs_off_calling_thread():
+    sink: list = []
+    clips = {n: _FakeClip(n, sink) for n in ("idle_a", "idle_b")}
+    main_ident = threading.get_ident()
+
+    PetWindow._warm_landing_idles(_stub_win(clips))
+
+    import time
+    deadline = time.monotonic() + 2.0
+    while len(sink) < 2 and time.monotonic() < deadline:
+        time.sleep(0.005)
+
+    assert len(sink) == 2, "所有 idle 首帧都应被预热"
+    assert all(ident != main_ident for _name, ident in sink), \
+        "warm_first_frame 绝不允许在 GUI（调用）线程同步执行"
+
+
+def test_warm_landing_idles_returns_immediately_when_decode_blocks():
+    block = threading.Event()  # 永不 set：模拟 ffmpeg 解码卡住
+    sink: list = []
+    clips = {n: _FakeClip(n, sink, block_event=block) for n in ("idle_a",)}
+
+    import time
+    t0 = time.monotonic()
+    PetWindow._warm_landing_idles(_stub_win(clips))
+    elapsed = time.monotonic() - t0
+
+    assert elapsed < 0.2, f"起飞预热阻塞了调用线程 {elapsed * 1000:.0f}ms"
+    assert sink == [], "阻塞中的预热不应已完成（在后台线程挂着）"
+
+
+def test_warm_landing_idles_tolerates_clip_errors():
+    sink: list = []
+    clips = {
+        "bad": _FakeClip("bad", sink, raises=True),
+        "good": _FakeClip("good", sink),
+    }
+    # 不应抛出席卷 GUI 线程；good 仍应被预热
+    PetWindow._warm_landing_idles(_stub_win(clips))
+
+    import time
+    deadline = time.monotonic() + 2.0
+    while not any(n == "good" for n, _ in sink) and time.monotonic() < deadline:
+        time.sleep(0.005)
+    assert any(n == "good" for n, _ in sink)
+
+
+def test_warm_landing_idles_no_idles_noop():
+    win = SimpleNamespace(lib=SimpleNamespace(
+        movie=lambda name: (_ for _ in ()).throw(AssertionError("不应解析 clip"))),
+        idles=[])
+    PetWindow._warm_landing_idles(win)  # 不抛异常即通过
+
+
+# ------------------------------------------------------------ 飞行期 pin 保护
+# 实测定案：多鱼同进程 8MB 预算下，起飞暖好的落地首帧会在飞行窗口内被预热
+# 浪涌逐出（风暴期仍有 105~399ms 落地冷解码卡顿）。pin 只活起飞→落地窗口。
+# 两类 pin 必须分标志：library 常驻（clicks/turns/drag 的 _ffr_pinned）永不
+# 来摘，而 idle 池可与它在同一 clip 上重叠（catalog 允许同一文件多分类）。
+
+def _clip_with_pin(name, sink=None):
+    clip = _FakeClip(name, sink if sink is not None else [])
+    clip._ffr_pinned = False
+    clip._ffr_landing_pinned = False
+    return clip
+
+
+def test_takeoff_pins_landing_idles_and_landing_unpins():
+    clips = {n: _clip_with_pin(n) for n in ("idle_a", "idle_b")}
+    win = _stub_win(clips)
+
+    PetWindow._warm_landing_idles(win)
+    assert all(c._ffr_landing_pinned for c in clips.values()), \
+        "起飞必须把落地 idle 首帧打进飞行期 pin（防飞行途中被逐出）"
+    assert not any(c._ffr_pinned for c in clips.values()), \
+        "飞行期 pin 不得复用 library 常驻标志 _ffr_pinned"
+
+    PetWindow._unpin_landing_idles(win)
+    assert not any(c._ffr_landing_pinned for c in clips.values()), \
+        "落地/打断后必须摘掉飞行期 pin（常驻内存零增长）"
+
+
+def test_landing_unpin_keeps_library_resident_pin():
+    """落地摘 pin 只摘飞行期那一类：与 idle 池重叠的 library 常驻保护不动。
+
+    突变判别：把 _unpin_landing_idles 改回无脑置 _ffr_pinned = False，
+    resident 会丢失常驻保护 → 断言红（正是本轮修复前的缺陷）。
+    """
+    resident = _clip_with_pin("both")
+    resident._ffr_pinned = True  # library 高频交互核常驻（clicks/turns/drag）
+    win = _stub_win({"both": resident})
+
+    PetWindow._warm_landing_idles(win)
+    PetWindow._unpin_landing_idles(win)
+
+    assert resident._ffr_pinned is True, \
+        "library 常驻保护绝不能被落地摘 pin 顺手摘掉（点击/拖拽首帧会重新冷解码）"
+    assert resident._ffr_landing_pinned is False, "飞行期 pin 仍须摘除"
+
+
+def test_unpin_landing_idles_tolerates_broken_lib():
+    # 库已销毁/解析失败：摘 pin 绝不抛出席卷调用方
+    win = SimpleNamespace(
+        lib=SimpleNamespace(movie=lambda name: (_ for _ in ()).throw(RuntimeError())),
+        idles=["x"])
+    PetWindow._unpin_landing_idles(win)
+    win2 = SimpleNamespace(lib=None, idles=["x"])
+    PetWindow._unpin_landing_idles(win2)
+
+
+def test_ffr_evict_respects_late_pin():
+    """_ffr_evict 复查 pin：选型后才打上的 clip 不得清空（两类标志都查）。
+
+    窗口期：_ffr_touch 选型（跳过 pinned）与 _ffr_evict 清空分两处，
+    常驻/飞行期 pin 可能落在两者之间——不复查的话"绝不逐出"语义形同虚设。
+    """
+    import threading
+    from pet import webm_clip
+
+    class _Victim:
+        def __init__(self, **flags):
+            self._first_frame_lock = threading.Lock()
+            self._ffr_evict_token = 7
+            self._first_image = object()
+            for key, value in flags.items():
+                setattr(self, key, value)
+
+    for flag in ("_ffr_pinned", "_ffr_landing_pinned"):
+        pinned_victim = _Victim(**{flag: True})
+        plain_victim = _Victim()
+        webm_clip._ffr_evict([(pinned_victim, 7), (plain_victim, 7)])
+        assert pinned_victim._first_image is not None, \
+            f"被 {flag} 保护的首帧绝不可逐出"
+        assert plain_victim._first_image is None, "未 pin 的照常逐出（防回归放水）"
+
+
+def test_landing_pin_skips_lru_selection(monkeypatch):
+    """飞行期 pin 与常驻 pin 同权参与逐出选型：LRU 从头跳过它，逐出下一个。
+
+    突变判别：_ffr_touch 的选型失去落地标志 → 被 pin 的 a 被选中/摘表，
+    victims 变成 [a] 且账面错位 → 断言红。
+    """
+    from pet import webm_clip
+
+    class _Img:
+        def width(self):
+            return 5
+
+        def height(self):
+            return 5
+
+    class _Clip:
+        def __init__(self):
+            self._first_frame_lock = threading.Lock()
+            self._first_image = _Img()
+            self._ffr_evict_token = None
+
+    monkeypatch.setattr(webm_clip, "_first_frame_reg", [])
+    monkeypatch.setattr(webm_clip, "_first_frame_bytes", 0)
+    monkeypatch.setattr(webm_clip, "_first_frame_budget_bytes", 250)
+
+    a, b, c = _Clip(), _Clip(), _Clip()
+    a._ffr_landing_pinned = True
+    webm_clip._ffr_touch(a, 100)
+    webm_clip._ffr_touch(b, 100)
+    victims = webm_clip._ffr_touch(c, 100)  # 300 > 250 → a 被跳过，逐出 b
+    assert [v for v, _t in victims] == [b]
+    assert a._first_image is not None, "被飞行期 pin 的首帧不得进逐出选型"
+    assert webm_clip._first_frame_bytes == 200


### PR DESCRIPTION
## 摘要

修复单进程多鱼互撞 / 拖灵动岛扫过桌宠时的 GUI 连续卡顿（看门狗实测 200ms+ 连发）。跟在 #113 之后（含其全部改动）。

## 根因与修复

- **落地首帧预热曾在 GUI 线程同步执行**（pet/window.py `_warm_landing_idles`）：每次被撞飞进抛掷物理都同步拉起 ffmpeg 解码（实测 ~100ms/次），多鱼互撞时密集触发。改为 daemon 线程执行预热，clip 解析留在 GUI 线程（`warm_first_frame` 本身即为后台调用设计，与前台同步解码经 `_first_frame_lock` 原子互斥）。
- **飞行期首帧 pin 保护**（pet/window.py + pet/webm_clip.py）：多鱼同进程时预热浪涌会在 8MB 首帧预算内把刚暖好的落地首帧逐出（8MB 下风暴期仍有 105~399ms 落地冷解码）。起飞→落地窗口内给 idle 落地首帧打 `_ffr_landing_pinned`——**独立标志**，不复用 library 常驻 `_ffr_pinned`（idle 池与交互常驻集在素材回退路径下可重叠，混用会在落地摘 pin 时误摘常驻保护）；落地/拖拽打断即摘除，常驻内存零增长，8MB 预算不变。`_ffr_evict` 清空前按 `_ffr_is_pinned` 复查，修掉选型→清空窗口期竞态。
- **灵动岛内容层绘制缓存**（pet/dynamic_island.py）：图标/名称/信息/状态灯缓存为位图，内容不变时每帧一次 blit（paintEvent 实测均值 6.2ms → 2.3ms）；缓存 key 覆盖可见项/文本/颜色/字体/DPR/宽度，任一变化自动重建。

## 实测（同机同场景：对撞风暴 + 拖岛扫鱼）

| 指标 | 修复前 | 修复后 |
|---|---|---|
| 风暴期 100ms+ 卡顿 | 38 次 | 0 次 |
| 撞飞进抛掷 | 101ms/次 | 0.3ms/次 |
| 动画切换 | ~50ms | 10.8ms |
| 岛 paintEvent | 6.2ms | 2.3ms |

## 验证

- 全量 pytest：**2007 passed / 8 skipped / 0 failed**（QT_QPA_PLATFORM=offscreen）；ruff 干净
- 新增回归测试 13 个：预热离线程语义 / pin 生命周期（起飞打、落地摘、常驻不被误摘）/ 逐出选型与清空复查竞态 / 缓存命中失效与三态渲染冒烟；10 条运行期突变体全部如期判红
- 实机验证：多鱼互撞、拖岛扫鱼、撞岛弹开均无卡顿
